### PR TITLE
Fix daemon stalls after USB replug with cycle/write timeouts

### DIFF
--- a/companion/internal/daemon/daemon.go
+++ b/companion/internal/daemon/daemon.go
@@ -29,11 +29,13 @@ type Options struct {
 
 const (
 	defaultInterval         = 60 * time.Second
+	defaultCycleTimeout     = 20 * time.Second
 	startupFastPollWindow   = 2 * time.Minute
 	startupFastPollInterval = 30 * time.Second
 	lastGoodPersistInterval = 1 * time.Minute
 	themeEnvVar             = "CODEXBAR_DISPLAY_THEME"
 	coldStartTimeoutEnvVar  = "CODEXBAR_DISPLAY_COLDSTART_TIMEOUT_SECS"
+	cycleTimeoutEnvVar      = "CODEXBAR_DISPLAY_CYCLE_TIMEOUT_SECS"
 	collectorIntervalEnvVar = "CODEXBAR_DISPLAY_COLLECTOR_INTERVAL_SECS"
 	collectorTimeoutEnvVar  = "CODEXBAR_DISPLAY_PROVIDER_TIMEOUT_SECS"
 	collectorParallelEnvVar = "CODEXBAR_DISPLAY_PROVIDER_MAX_PARALLEL"
@@ -49,6 +51,7 @@ const (
 	runtimeErrorUnknown        runtimeErrorKind = runtimeErrorKind(errcode.Unknown)
 	runtimeErrorSerialResolve  runtimeErrorKind = runtimeErrorKind(errcode.RuntimeSerialResolve)
 	runtimeErrorSerialWrite    runtimeErrorKind = runtimeErrorKind(errcode.RuntimeSerialWrite)
+	runtimeErrorCycleTimeout   runtimeErrorKind = runtimeErrorKind(errcode.RuntimeCycleTimeout)
 	runtimeErrorFrameEncode    runtimeErrorKind = runtimeErrorKind(errcode.RuntimeFrameEncode)
 	runtimeErrorFrameTooLarge  runtimeErrorKind = runtimeErrorKind(errcode.RuntimeFrameTooLarge)
 	runtimeErrorCodexbarBinary runtimeErrorKind = runtimeErrorKind(errcode.RuntimeCodexbarBinary)
@@ -576,6 +579,7 @@ func startProviderCollector(ctx context.Context, opts Options, deps runtimeDeps,
 
 func runDaemonLoop(ctx context.Context, opts Options, deps runtimeDeps, runCycle func(context.Context) error) error {
 	backoff := newRetryBackoff(opts.Interval)
+	cycleTimeout := cycleRunTimeout()
 	var lastCycleStart time.Time
 	var startedAt time.Time
 
@@ -593,7 +597,7 @@ func runDaemonLoop(ctx context.Context, opts Options, deps runtimeDeps, runCycle
 		}
 		lastCycleStart = cycleStart
 
-		err := runCycle(ctx)
+		err := runCycleWithTimeout(ctx, cycleTimeout, runCycle)
 		if opts.Once {
 			return err
 		}
@@ -601,6 +605,14 @@ func runDaemonLoop(ctx context.Context, opts Options, deps runtimeDeps, runCycle
 		waitFor := opts.Interval
 		if err != nil {
 			runtimeErr := asRuntimeError(err)
+			if runtimeErr.Kind == runtimeErrorCycleTimeout {
+				deps.logf("fatal cycle timeout: code=%s op=%s timeout=%s action=exit-for-launchd-restart\n",
+					runtimeErr.ErrorCode(),
+					runtimeErr.Op,
+					cycleTimeout,
+				)
+				return runtimeErr
+			}
 			waitFor = backoff.Next()
 			deps.logf("cycle error: code=%s op=%s retry=%s recovery=%q err=%v\n",
 				runtimeErr.ErrorCode(),
@@ -620,6 +632,44 @@ func runDaemonLoop(ctx context.Context, opts Options, deps runtimeDeps, runCycle
 			return ctx.Err()
 		case <-deps.after(waitFor):
 		}
+	}
+}
+
+func runCycleWithTimeout(parent context.Context, timeout time.Duration, runCycle func(context.Context) error) error {
+	if timeout <= 0 {
+		return runCycle(parent)
+	}
+
+	cycleCtx, cancel := context.WithCancel(parent)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runCycle(cycleCtx)
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		cancel()
+		return &RuntimeError{
+			Kind: runtimeErrorCycleTimeout,
+			Op:   "run-cycle-timeout",
+			Err:  fmt.Errorf("cycle exceeded timeout %s", timeout),
+			Hint: errcode.DefaultRecovery(errcode.RuntimeCycleTimeout),
+		}
+	case <-parent.Done():
+		cancel()
+		select {
+		case err := <-done:
+			return err
+		default:
+		}
+		return parent.Err()
 	}
 }
 
@@ -1065,6 +1115,22 @@ func collectorInterval(renderInterval time.Duration) time.Duration {
 		return max
 	}
 	return renderInterval
+}
+
+func cycleRunTimeout() time.Duration {
+	const (
+		min = 5 * time.Second
+		max = 120 * time.Second
+	)
+
+	override := parseSecondsEnv(cycleTimeoutEnvVar, int(defaultCycleTimeout.Seconds()))
+	if override < min {
+		return min
+	}
+	if override > max {
+		return max
+	}
+	return override
 }
 
 func collectorProviderTimeout() time.Duration {

--- a/companion/internal/daemon/daemon_test.go
+++ b/companion/internal/daemon/daemon_test.go
@@ -1122,6 +1122,39 @@ func TestDetectSleepWakeGap(t *testing.T) {
 	}
 }
 
+func TestRunCycleWithTimeoutReturnsRuntimeCycleTimeout(t *testing.T) {
+	prepareFastTestEnv(t)
+
+	block := make(chan struct{})
+	err := runCycleWithTimeout(context.Background(), 10*time.Millisecond, func(context.Context) error {
+		<-block
+		return nil
+	})
+	close(block)
+
+	if err == nil {
+		t.Fatalf("expected timeout error")
+	}
+	runtimeErr := asRuntimeError(err)
+	if runtimeErr.Kind != runtimeErrorCycleTimeout {
+		t.Fatalf("expected runtime cycle timeout, got %s", runtimeErr.Kind)
+	}
+}
+
+func TestCycleRunTimeoutHonorsBounds(t *testing.T) {
+	prepareFastTestEnv(t)
+
+	t.Setenv(cycleTimeoutEnvVar, "999")
+	if got := cycleRunTimeout(); got != 120*time.Second {
+		t.Fatalf("expected max clamp, got %s", got)
+	}
+
+	t.Setenv(cycleTimeoutEnvVar, "1")
+	if got := cycleRunTimeout(); got != 5*time.Second {
+		t.Fatalf("expected min clamp, got %s", got)
+	}
+}
+
 func decodeFrameLine(t *testing.T, line []byte) protocol.Frame {
 	t.Helper()
 

--- a/companion/internal/errcode/errcode.go
+++ b/companion/internal/errcode/errcode.go
@@ -21,6 +21,7 @@ const (
 
 	RuntimeSerialResolve  Code = "runtime/serial-resolve"
 	RuntimeSerialWrite    Code = "runtime/serial-write"
+	RuntimeCycleTimeout   Code = "runtime/cycle-timeout"
 	RuntimeFrameEncode    Code = "runtime/frame-encode"
 	RuntimeFrameTooLarge  Code = "runtime/frame-too-large"
 	RuntimeCodexbarBinary Code = "runtime/codexbar-binary"
@@ -114,6 +115,8 @@ func DefaultRecovery(code Code) string {
 		return "Reconnect the board or pass `--port` to `codexbar-display daemon`."
 	case RuntimeSerialWrite:
 		return "Check cable/device power; daemon will retry automatically."
+	case RuntimeCycleTimeout:
+		return "Daemon cycle timed out; restart daemon (LaunchAgent KeepAlive will auto-restart) and run `codexbar-display doctor` to verify USB serial health."
 	case RuntimeFrameEncode, RuntimeFrameTooLarge:
 		return "Inspect payload size and optional fields; reduce frame footprint."
 	case RuntimeCodexbarBinary:

--- a/companion/internal/usb/usb.go
+++ b/companion/internal/usb/usb.go
@@ -24,6 +24,7 @@ const (
 	serialBaudRate       = 115200
 	closeTimeout         = 200 * time.Millisecond
 	reopenSettleDuration = 1200 * time.Millisecond
+	writeTimeout         = 2 * time.Second
 	helloReadWindow      = 300 * time.Millisecond
 	helloReadStepTimeout = 80 * time.Millisecond
 	helloReadBufferBytes = 1024
@@ -221,6 +222,7 @@ type SenderConfig struct {
 	Sleep          func(time.Duration)
 	SettleDuration time.Duration
 	HelloWindow    time.Duration
+	WriteTimeout   time.Duration
 }
 
 type Sender struct {
@@ -230,6 +232,7 @@ type Sender struct {
 	sleep          func(time.Duration)
 	settleDuration time.Duration
 	helloWindow    time.Duration
+	writeTimeout   time.Duration
 
 	port          SerialPort
 	path          string
@@ -260,12 +263,17 @@ func NewSenderWithConfig(cfg SenderConfig) *Sender {
 	if window <= 0 {
 		window = helloReadWindow
 	}
+	writeLimit := cfg.WriteTimeout
+	if writeLimit <= 0 {
+		writeLimit = writeTimeout
+	}
 
 	return &Sender{
 		opener:         opener,
 		sleep:          sleep,
 		settleDuration: settle,
 		helloWindow:    window,
+		writeTimeout:   writeLimit,
 	}
 }
 
@@ -286,7 +294,7 @@ func (s *Sender) Send(path string, line []byte) error {
 		_ = s.port.ResetInputBuffer()
 	}
 
-	if _, err := s.port.Write(line); err != nil {
+	if err := writeWithTimeout(s.port, line, s.writeTimeout); err != nil {
 		s.closeCurrentLocked()
 		return wrapTransportError(
 			errcode.TransportSerialWrite,
@@ -297,6 +305,32 @@ func (s *Sender) Send(path string, line []byte) error {
 		)
 	}
 	return nil
+}
+
+func writeWithTimeout(port SerialPort, payload []byte, timeout time.Duration) error {
+	if port == nil {
+		return errors.New("serial port is nil")
+	}
+	if timeout <= 0 {
+		_, err := port.Write(payload)
+		return err
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := port.Write(payload)
+		done <- err
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		return errors.New("serial write timeout")
+	}
 }
 
 func (s *Sender) ReadHello(path string) (protocol.DeviceHello, error) {

--- a/companion/internal/usb/usb_test.go
+++ b/companion/internal/usb/usb_test.go
@@ -144,6 +144,54 @@ func TestSenderReconnectsAfterWriteFailure(t *testing.T) {
 	}
 }
 
+func TestSenderReconnectsAfterWriteTimeout(t *testing.T) {
+	first := newMockSerialPort()
+	first.writeDelay = 40 * time.Millisecond
+	second := newMockSerialPort()
+
+	openSeq := []SerialPort{first, second}
+	opener := &mockOpener{
+		openFn: func(path string, _ *serial.Mode) (SerialPort, error) {
+			if len(openSeq) == 0 {
+				return nil, errors.New("unexpected open")
+			}
+			next := openSeq[0]
+			openSeq = openSeq[1:]
+			return next, nil
+		},
+	}
+	sender := NewSenderWithConfig(SenderConfig{
+		Opener:         opener,
+		Sleep:          func(time.Duration) {},
+		SettleDuration: time.Millisecond,
+		HelloWindow:    10 * time.Millisecond,
+		WriteTimeout:   5 * time.Millisecond,
+	})
+	defer sender.Close()
+
+	started := time.Now()
+	err := sender.Send("/dev/mock", []byte("{\"v\":1}\n"))
+	if err == nil {
+		t.Fatalf("expected first send timeout error")
+	}
+	if elapsed := time.Since(started); elapsed >= 30*time.Millisecond {
+		t.Fatalf("expected write timeout before delay elapsed, got %s", elapsed)
+	}
+	if got := errcode.Of(err); got != errcode.TransportSerialWrite {
+		t.Fatalf("expected serial write code, got %s", got)
+	}
+	if first.closeCalls == 0 {
+		t.Fatalf("expected first port to be closed after write timeout")
+	}
+
+	if err := sender.Send("/dev/mock", []byte("{\"v\":1}\n")); err != nil {
+		t.Fatalf("expected reconnect send success, got %v", err)
+	}
+	if got := opener.openCount("/dev/mock"); got != 2 {
+		t.Fatalf("expected reopen after timeout, got %d opens", got)
+	}
+}
+
 func TestDeviceHelloUnavailableReturnsProtocolCode(t *testing.T) {
 	port := newMockSerialPort()
 	opener := &mockOpener{
@@ -204,6 +252,7 @@ type mockSerialPort struct {
 	readQueue  [][]byte
 	writeCalls int
 	writeErr   error
+	writeDelay time.Duration
 	closeCalls int
 }
 
@@ -225,10 +274,15 @@ func (m *mockSerialPort) Read(p []byte) (int, error) {
 
 func (m *mockSerialPort) Write(p []byte) (int, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.writeCalls++
-	if m.writeErr != nil {
-		return 0, m.writeErr
+	writeDelay := m.writeDelay
+	writeErr := m.writeErr
+	m.mu.Unlock()
+	if writeDelay > 0 {
+		time.Sleep(writeDelay)
+	}
+	if writeErr != nil {
+		return 0, writeErr
 	}
 	return len(p), nil
 }

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -324,7 +324,7 @@ Use this taxonomy for incident triage:
 |---|---|---|
 | `transport/*` | `transport/serial-open`, `transport/no-usb-serial-ports`, `transport/serial-write` | Reconnect board/cable, check `ls /dev/cu.usb*`, release busy port via `lsof <port>` |
 | `protocol/*` | `protocol/device-hello-unavailable` | Reconnect device to force boot hello; runtime falls back when hello is missing |
-| `runtime/*` | `runtime/serial-resolve`, `runtime/codexbar-parse`, `runtime/frame-too-large` | Run `codexbar-display doctor`, verify CodexBar output, inspect daemon logs |
+| `runtime/*` | `runtime/serial-resolve`, `runtime/cycle-timeout`, `runtime/codexbar-parse`, `runtime/frame-too-large` | Run `codexbar-display doctor`, verify CodexBar output, inspect daemon logs |
 | `setup/*` | `setup/flash-firmware`, `setup/unsupported-hardware`, `setup/launchagent-verify` | Rerun setup with matching `--firmware-env`, verify PlatformIO + launchctl state |
 | `upgrade/*` | `upgrade/port-busy`, `upgrade/version-guard`, `upgrade/flash-firmware` | Free serial port, use compatible versions, rerun `codexbar-display upgrade` |
 | `rollback/*` | `rollback/missing-known-good`, `rollback/companion-restore`, `rollback/firmware-restore` | Provide explicit rollback image/manifest or restore captured known-good state |


### PR DESCRIPTION
## Summary
This PR fixes a runtime hang where the LaunchAgent daemon can stop sending frames after USB unplug/replug, leaving the device stuck on splashscreen.

### What changed
- Added a hard runtime cycle timeout (`CODEXBAR_DISPLAY_CYCLE_TIMEOUT_SECS`, default 20s, clamped 5s..120s).
- Added new error code: `runtime/cycle-timeout` with recovery hint.
- When a cycle times out, daemon logs a fatal timeout and exits so LaunchAgent `KeepAlive` can restart a clean process.
- Added serial write timeout in USB sender (default 2s, configurable in `SenderConfig` for tests).
- On serial write timeout/error, sender closes stale port handle and reconnects on next send.
- Updated operator runbook error-code map to include `runtime/cycle-timeout`.

## Why this addresses the issue
Observed production behavior had collector logs still running while no new `sent frame -> ...` lines appeared after replug, indicating the render cycle got stuck. These guardrails prevent indefinite hangs in either serial write or other cycle operations and force deterministic recovery.

## Tests
- `cd companion && go test ./internal/usb ./internal/daemon`
- `cd companion && go test ./...`

Closes #23
