### PR TITLE
Document usage polling architecture and benchmark workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ pio run -e lilygo_t_display_s3
 ## Docs
 - Operator runbook: `docs/operator-runbook.md`
 - Hardware contract: `docs/hardware-contract.md`
+- Usage polling architecture + benchmarks: `docs/usage-polling-architecture.md`
 - Open roadmap: `TODO.md`
 - Protocol: `protocol/PROTOCOL.md`
 

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -4,6 +4,7 @@ Single source of truth for install, runtime checks, recovery, and smoke testing.
 
 Hardware identity and board/env contract reference:
 - `docs/hardware-contract.md`
+- `docs/usage-polling-architecture.md` (usage command latency, polling architecture, tuning/bench workflow)
 
 ## Scope
 - macOS runtime (`launchctl` + LaunchAgent)

--- a/docs/usage-polling-architecture.md
+++ b/docs/usage-polling-architecture.md
@@ -1,0 +1,168 @@
+# Usage Polling Architecture and Benchmarks
+
+This document is the single reference for how `codexbar-display` fetches usage data, why stale values can appear, and how to benchmark/tune polling behavior.
+
+## Scope
+
+- Companion runtime (`companion/internal/daemon`)
+- CodexBar fetch layer (`companion/internal/codexbar`)
+- macOS LaunchAgent runtime behavior
+- Benchmark workflow for latency and allocation budgets
+
+## Upstream CodexBar CLI Reference
+
+Primary upstream docs:
+
+- CLI reference: <https://github.com/steipete/CodexBar/blob/main/docs/cli.md>
+- Refresh loop: <https://github.com/steipete/CodexBar/blob/main/docs/refresh-loop.md>
+- Status polling: <https://github.com/steipete/CodexBar/blob/main/docs/status.md>
+
+Upstream commands we rely on in this repo:
+
+- Aggregated usage: `codexbar usage --json --web-timeout 8`
+- Provider-scoped usage: `codexbar usage --json --provider <provider> --web-timeout <n>`
+- Codex CLI-priority path: `codexbar usage --json --provider codex --source cli`
+- Debug/structured logging flags:
+  - `--json-output`
+  - `--json-only`
+  - `--log-level <trace|debug|...>`
+
+## Current Polling Architecture (This Repo)
+
+### 1) Daemon cadence
+
+- Default render interval: `60s`
+- Runtime loop is in `companion/internal/daemon/daemon.go`
+- Collector runs in background and provides provider snapshots to render cycles
+
+### 2) Provider collector behavior
+
+Collector knobs (env vars):
+
+- `CODEXBAR_DISPLAY_COLLECTOR_INTERVAL_SECS`
+  - bounded to `30s..60s`
+- `CODEXBAR_DISPLAY_PROVIDER_TIMEOUT_SECS`
+  - bounded to `2s..4s` (default `4s`)
+- `CODEXBAR_DISPLAY_PROVIDER_MAX_PARALLEL`
+  - bounded to `1..4` (default `3`)
+- `CODEXBAR_DISPLAY_PROVIDER_ORDER`
+  - comma-separated provider order override
+
+Per-provider fetch path:
+
+1. For `codex`: try CLI-priority provider call first (`--provider codex --source cli`)
+2. Otherwise call provider-scoped usage (`--provider <key> --web-timeout <n>`)
+3. `CODEXBAR_DISPLAY_PROVIDER_WEB_TIMEOUT_SECS` controls provider web timeout (`2..8`, default `3`)
+
+### 3) Selection path
+
+Provider selection order in `ProviderSelector`:
+
+1. Local activity signal (`local-activity`)
+2. Usage delta (`usage-delta`)
+3. Sticky current provider (`sticky-current`)
+4. CodexBar provider order (`codexbar-order`)
+
+### 4) Fallback/staleness behavior
+
+When provider fetches fail:
+
+- Collector keeps previously successful provider snapshots
+- Render cycle can continue sending stale values via:
+  - snapshot reuse
+  - last-good fallback frame
+
+Related env vars:
+
+- `CODEXBAR_DISPLAY_LAST_GOOD_MAX_AGE`
+- `CODEXBAR_DISPLAY_PROVIDER_LAST_GOOD_MAX_AGE`
+
+Important practical implication:
+
+- If real command latency is above collector timeout, `collector succeeded=0` can persist while stale values remain visible on device.
+
+## Benchmark Workflow
+
+Use both host-command latency measurements and daemon micro-benchmarks.
+
+### A) Command latency benchmarks (real machine behavior)
+
+Run:
+
+```bash
+./scripts/bench-codexbar-usage-latency.sh 5
+```
+
+This script measures:
+
+- `codexbar usage --provider codex --source cli --json`
+- `codexbar usage --provider codex --json --web-timeout 8`
+- `codexbar usage --json --web-timeout 8`
+
+### B) Daemon micro-benchmarks (code-level budget)
+
+Run:
+
+```bash
+cd companion
+go test ./internal/daemon -run '^$' -bench 'BenchmarkRunCycleWithDeps|BenchmarkMarshalFrameWithinLimit' -benchmem -count=1
+```
+
+Optional budget gate:
+
+```bash
+./scripts/check-companion-bench-budget.sh
+```
+
+### C) Runtime observability checks
+
+```bash
+~/Library/Application\ Support/codexbar-display/bin/codexbar-display health
+tail -n 200 /tmp/codexbar-display-daemon.out.log
+```
+
+Look for:
+
+- `collector complete ... succeeded=<n> timeout=<x>s`
+- `sent frame -> ... reason=<...>`
+- large gaps between `sent frame ->` events
+
+## Sample Measurements (2026-03-04, MacBook Pro M3)
+
+Host command latency (under local load):
+
+| Command | Observed real time |
+|---|---|
+| `codexbar usage --provider codex --source cli --json` | `1.92s` |
+| `codexbar usage --provider codex --json --web-timeout 8` | `54.61s` |
+| `codexbar usage --json --web-timeout 8` | `99.51s` |
+
+Additional spot-check (same day): `codexbar usage --provider codex --source cli --json` also measured `5.98s` and `5.42s`.
+
+Daemon benchmark:
+
+| Benchmark | Result |
+|---|---|
+| `BenchmarkRunCycleWithDeps` | `45867 ns/op`, `4351 B/op`, `71 allocs/op` |
+| `BenchmarkMarshalFrameWithinLimit` | `1911 ns/op`, `224 B/op`, `2 allocs/op` |
+
+Interpretation:
+
+- If collector timeout is `3s` or `4s`, even moderate provider latency (`~5s`) will fail consistently.
+- Long-tail spikes (`50s+`) make stale fallback behavior inevitable with current timeout caps.
+- Persistent provider timeouts lead to stale snapshot rendering.
+
+## Tuning Checklist
+
+1. Measure `p50/p95` command latency on target hardware (idle and loaded).
+2. Set collector/provider timeouts to exceed `p95` with margin.
+3. Validate `collector succeeded` is non-zero during normal operation.
+4. Validate `last sent frame` freshness in `health`.
+5. Re-run daemon micro-benchmarks after changes.
+
+## Known Constraints (Current Main Branch)
+
+- `CODEXBAR_DISPLAY_PROVIDER_TIMEOUT_SECS` max is currently hard-clamped to `4s`.
+- `CODEXBAR_DISPLAY_PROVIDER_WEB_TIMEOUT_SECS` max is currently hard-clamped to `8s`.
+
+If measured `p95` exceeds these caps on real machines, reliability requires code changes (not only config changes).

--- a/scripts/bench-codexbar-usage-latency.sh
+++ b/scripts/bench-codexbar-usage-latency.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runs="${1:-5}"
+if ! [[ "$runs" =~ ^[0-9]+$ ]] || [ "$runs" -le 0 ]; then
+  echo "usage: $0 <runs>" >&2
+  exit 1
+fi
+
+if ! command -v codexbar >/dev/null 2>&1; then
+  echo "error: codexbar binary not found in PATH" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+measure_case() {
+  local label="$1"
+  shift
+  local -a cmd=("$@")
+
+  local case_file="$tmp_dir/${label// /_}.times"
+  : >"$case_file"
+
+  echo "== $label =="
+  echo "cmd: ${cmd[*]}"
+
+  local success=0
+  local failed=0
+
+  for i in $(seq 1 "$runs"); do
+    local time_file="$tmp_dir/${label// /_}.${i}.time"
+    set +e
+    /usr/bin/time -p "${cmd[@]}" >/dev/null 2>"$time_file"
+    local status=$?
+    set -e
+
+    local real
+    real="$(awk '/^real /{print $2}' "$time_file")"
+    if [ -n "$real" ]; then
+      echo "$real" >>"$case_file"
+    fi
+
+    if [ "$status" -eq 0 ]; then
+      success=$((success + 1))
+    else
+      failed=$((failed + 1))
+    fi
+
+    printf "run %02d status=%d real=%ss\n" "$i" "$status" "${real:-n/a}"
+  done
+
+  if [ ! -s "$case_file" ]; then
+    echo "summary: no timing samples captured"
+    echo
+    return
+  fi
+
+  local summary
+  summary="$(sort -n "$case_file" | awk '
+    {vals[NR]=$1; sum+=$1}
+    END {
+      n=NR
+      p50_idx=int((n+1)/2)
+      p95_idx=int((n*95+99)/100)
+      if (p95_idx < 1) p95_idx=1
+      if (p95_idx > n) p95_idx=n
+      printf("summary: n=%d mean=%.3fs p50=%.3fs p95=%.3fs min=%.3fs max=%.3fs",
+        n, sum/n, vals[p50_idx], vals[p95_idx], vals[1], vals[n])
+    }')"
+
+  echo "$summary success=$success failed=$failed"
+  echo
+}
+
+measure_case "provider_codex_cli" codexbar usage --provider codex --source cli --json
+measure_case "provider_codex_auto" codexbar usage --provider codex --json --web-timeout 8
+measure_case "all_providers_auto" codexbar usage --json --web-timeout 8


### PR DESCRIPTION
## Summary
Adds a dedicated usage polling architecture document and a repeatable command-latency benchmark script so we can tune polling behavior from shared evidence instead of ad-hoc debugging.

## What is included
- New document: `docs/usage-polling-architecture.md`
  - Upstream CodexBar CLI references (`docs/cli.md`, `docs/refresh-loop.md`, `docs/status.md`)
  - Current companion polling architecture (collector cadence/timeouts/selection/fallback)
  - Runtime observability commands for diagnosing stale usage
  - Benchmark workflow (command latency + daemon microbench)
  - Sample real-world measurements from this machine under load
  - Explicit constraints called out (`provider timeout` clamp, `provider web timeout` clamp)
- New script: `scripts/bench-codexbar-usage-latency.sh`
  - Runs repeated latency samples for key `codexbar usage` commands
  - Prints per-run status + summary stats (`mean`, `p50`, `p95`, `min`, `max`)
- Discoverability links:
  - README docs section
  - Operator runbook header references

## Validation
- Executed `./scripts/bench-codexbar-usage-latency.sh 1` successfully
- Verified generated sample timings and daemon benchmark commands in the new doc

Closes #25
