### PR TITLE
CI: add go vet gate for companion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           go-version-file: companion/go.mod
 
+      - name: Run go vet
+        working-directory: companion
+        run: go vet ./...
+
       - name: Run Go tests
         working-directory: companion
         run: go test ./...


### PR DESCRIPTION
## Summary
- add a dedicated `go vet ./...` step to the `companion-tests` CI job
- keep existing `go test` and `staticcheck` gates unchanged

## Validation
- `go vet ./...` (companion) ✅
- `go test ./...` (companion) ✅
- `staticcheck ./...` (companion) ✅

## Runtime impact
Local run (macOS) shows `go vet ./...` adds about **0.42s** wall time, which is within acceptable CI overhead for defect prevention.

Closes #13
