### PR TITLE
[codex] Add release firmware upgrade path

### DIFF
--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -79,7 +79,7 @@ func printUsage() {
 	fmt.Println("  codexbar-display health")
 	fmt.Println("  codexbar-display service <start|stop|status>")
 	fmt.Println("  codexbar-display version [--short] [--json]")
-	fmt.Println("  codexbar-display upgrade [--port /dev/cu.usbserial-10] [--firmware-env env] [--target-firmware-version x.y.z] [--skip-version-guard]")
+	fmt.Println("  codexbar-display upgrade [--port /dev/cu.usbserial-10] [--firmware-env env] [--target-firmware-version x.y.z] [--repo owner/name] [--skip-version-guard]")
 	fmt.Println("  codexbar-display rollback [--port /dev/cu.usbserial-10] [--skip-companion] [--skip-firmware] [--image path/to/backup.bin] [--manifest path/to/backup.manifest] [--backup-dir <dir>] [--script-path <path>] [--skip-verify]")
 	fmt.Println("  codexbar-display restore-known-good [--port /dev/cu.usbserial-10] [--image path/to/backup.bin] [--backup-dir <dir>] [--script-path <path>] [--manifest <path>] [--skip-verify]")
 	fmt.Println("  codexbar-display theme-validate --spec path/to/theme-spec.json [--port /dev/cu.usbserial-10] [--allow-unknown-capabilities]")

--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,20 +29,24 @@ const (
 	releaseStateSchemaVersion = 1
 	releaseStateFileName      = "release-state.json"
 	protocolVersionV1         = 1
+	defaultReleaseRepo        = "DreamyTalesPAN/CodexBar-Display"
+	githubAPIBaseURL          = "https://api.github.com"
+	githubDownloadBaseURL     = "https://github.com"
 )
 
 var (
-	upgradeStopLaunchAgentFn           = stopLaunchAgentBestEffort
-	upgradeRestartLaunchAgentFn        = restartLaunchAgent
-	rollbackRestartLaunchAgentFn       = restartLaunchAgent
-	resolveSerialPortFn                = usb.ResolvePort
-	readDeviceHelloFn                  = usb.ReadDeviceHello
-	ensureSerialPortNotBusyFn          = ensureSerialPortNotBusy
-	setupRunFn                         = setup.Run
-	loadReleaseStateFn                 = loadReleaseState
-	saveReleaseStateFn                 = saveReleaseState
-	snapshotInstalledCompanionBinaryFn = snapshotInstalledCompanionBinary
-	runRestoreKnownGoodCommandFn       = runRestoreKnownGood
+	upgradeStopLaunchAgentFn                           = stopLaunchAgentBestEffort
+	upgradeRestartLaunchAgentFn                        = restartLaunchAgent
+	rollbackRestartLaunchAgentFn                       = restartLaunchAgent
+	resolveSerialPortFn                                = usb.ResolvePort
+	readDeviceHelloFn                                  = usb.ReadDeviceHello
+	ensureSerialPortNotBusyFn                          = ensureSerialPortNotBusy
+	loadReleaseStateFn                                 = loadReleaseState
+	saveReleaseStateFn                                 = saveReleaseState
+	snapshotInstalledCompanionBinaryFn                 = snapshotInstalledCompanionBinary
+	runRestoreKnownGoodCommandFn                       = runRestoreKnownGood
+	releaseHTTPClient                  releaseHTTPDoer = &http.Client{Timeout: 5 * time.Minute}
+	flashReleaseFirmwareImageFn                        = flashReleaseFirmwareImage
 )
 
 const launchAgentLabel = "com.codexbar-display.daemon.plist"
@@ -165,11 +173,13 @@ func runUpgrade(args []string) (retErr error) {
 	fs := flag.NewFlagSet("upgrade", flag.ContinueOnError)
 	port := fs.String("port", "", "serial port (auto-detect when empty)")
 	firmwareEnv := fs.String("firmware-env", setup.DefaultFirmwareEnvironment(), "PlatformIO environment to flash")
-	targetFirmwareVersion := fs.String("target-firmware-version", "", "target firmware semver for version guard (default from compatibility matrix)")
+	targetFirmwareVersion := fs.String("target-firmware-version", "", "target firmware semver/release version (default: latest GitHub release)")
+	repo := fs.String("repo", defaultReleaseRepo, "GitHub repository for release firmware assets")
 	skipVersionGuard := fs.Bool("skip-version-guard", false, "skip companion/firmware compatibility guard")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	ctx := context.Background()
 
 	selectedEnv := strings.TrimSpace(*firmwareEnv)
 	if selectedEnv == "" {
@@ -216,20 +226,33 @@ func runUpgrade(args []string) (retErr error) {
 		}
 	}
 
+	releaseRepo, err := normalizeReleaseRepo(*repo)
+	if err != nil {
+		return &commandError{
+			Op:   "resolve-release-repo",
+			Code: errcode.UpgradeFlashFirmware,
+			Err:  err,
+			Hint: "pass --repo owner/name",
+		}
+	}
+
 	targetVersion := strings.TrimSpace(*targetFirmwareVersion)
+	releaseTag := ""
 	if targetVersion == "" {
-		mapped, ok := versioning.FirmwareVersionForEnvironment(selectedEnv)
-		if !ok {
+		latestTag, latestVersion, err := fetchLatestReleaseVersion(ctx, releaseRepo)
+		if err != nil {
 			return &commandError{
 				Op:   "resolve-target-firmware-version",
-				Code: errcode.UpgradeVersionGuard,
-				Err: fmt.Errorf(
-					"no compatibility matrix entry for firmware env %q; pass --target-firmware-version",
-					selectedEnv,
-				),
+				Code: errcode.UpgradeFlashFirmware,
+				Err:  err,
+				Hint: "check network access or pass --target-firmware-version for a known release",
 			}
 		}
-		targetVersion = mapped
+		targetVersion = latestVersion
+		releaseTag = latestTag
+	} else {
+		targetVersion = normalizeReleaseVersion(targetVersion)
+		releaseTag = "v" + targetVersion
 	}
 
 	companionVersion := buildinfo.NormalizedVersion()
@@ -302,19 +325,42 @@ func runUpgrade(args []string) (retErr error) {
 		}
 	}
 
-	fmt.Printf("upgrade: port=%s firmware_env=%s target_firmware=%s\n", resolvedPort, selectedEnv, targetVersion)
-	if err := setupRunFn(context.Background(), setup.Options{
-		Port:        resolvedPort,
-		AssumeYes:   true,
-		SkipFlash:   false,
-		FirmwareEnv: selectedEnv,
-	}); err != nil {
+	fmt.Printf("upgrade: port=%s firmware_env=%s target_firmware=%s release=%s repo=%s\n", resolvedPort, selectedEnv, targetVersion, releaseTag, releaseRepo)
+	imagePath, manifestPath, artifact, err := downloadReleaseFirmware(ctx, home, releaseRepo, releaseTag, targetVersion, selectedEnv)
+	if err != nil {
 		return &commandError{
-			Op:   "flash-and-install",
+			Op:   "download-release-firmware",
 			Code: errcode.UpgradeFlashFirmware,
 			Err:  err,
+			Hint: "verify the GitHub release contains firmware artifacts and checksums, then retry upgrade",
 		}
 	}
+	fmt.Printf("release firmware: %s manifest=%s sha256=%s\n", imagePath, manifestPath, artifact.SHA256)
+	if helloErr == nil {
+		detectedBoard := strings.TrimSpace(strings.ToLower(hello.Board))
+		expectedBoard := strings.TrimSpace(strings.ToLower(artifact.Board))
+		if detectedBoard != "" && expectedBoard != "" && detectedBoard != expectedBoard {
+			return &commandError{
+				Op:   "hardware-guard",
+				Code: errcode.UpgradeVersionGuard,
+				Err: fmt.Errorf(
+					"device board %q is incompatible with release firmware board %q",
+					detectedBoard,
+					expectedBoard,
+				),
+				Hint: "choose a matching --firmware-env for the connected VibeTV hardware",
+			}
+		}
+	}
+	if err := flashReleaseFirmwareImageFn(ctx, resolvedPort, artifact, imagePath); err != nil {
+		return &commandError{
+			Op:   "flash-release-firmware",
+			Code: errcode.UpgradeFlashFirmware,
+			Err:  err,
+			Hint: fmt.Sprintf("ensure no process holds %s, install PlatformIO CLI if missing, then rerun upgrade", resolvedPort),
+		}
+	}
+	fmt.Println("firmware flash: ok")
 
 	postHello, postHelloErr := readDeviceHelloFn(resolvedPort)
 	if postHelloErr == nil {
@@ -363,6 +409,293 @@ func runUpgrade(args []string) (retErr error) {
 
 	fmt.Println("upgrade complete")
 	fmt.Println("rollback path ready: `codexbar-display rollback`")
+	return nil
+}
+
+type releaseHTTPDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type releaseFirmwareManifest struct {
+	SchemaVersion   int                       `json:"schemaVersion"`
+	Release         string                    `json:"release"`
+	ProtocolVersion int                       `json:"protocolVersion"`
+	Artifacts       []releaseFirmwareArtifact `json:"artifacts"`
+}
+
+type releaseFirmwareArtifact struct {
+	FirmwareEnv     string `json:"firmwareEnv"`
+	Board           string `json:"board"`
+	FirmwareVersion string `json:"firmwareVersion"`
+	Asset           string `json:"asset"`
+	SHA256          string `json:"sha256"`
+}
+
+type firmwareFlashSpec struct {
+	Chip    string
+	Baud    string
+	Address string
+}
+
+var releaseFirmwareFlashSpecs = map[string]firmwareFlashSpec{
+	"esp8266_smalltv_st7789": {
+		Chip:    "esp8266",
+		Baud:    "460800",
+		Address: "0x000000",
+	},
+}
+
+func normalizeReleaseRepo(raw string) (string, error) {
+	repo := strings.TrimSpace(raw)
+	repo = strings.TrimPrefix(repo, "https://github.com/")
+	repo = strings.TrimSuffix(repo, ".git")
+	repo = strings.Trim(repo, "/")
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", fmt.Errorf("invalid repository %q", raw)
+	}
+	return parts[0] + "/" + parts[1], nil
+}
+
+func normalizeReleaseVersion(raw string) string {
+	version := strings.TrimSpace(raw)
+	version = strings.TrimPrefix(version, "v")
+	return version
+}
+
+func fetchLatestReleaseVersion(ctx context.Context, repo string) (tag, version string, err error) {
+	endpoint := fmt.Sprintf("%s/repos/%s/releases/latest", githubAPIBaseURL, repo)
+	var payload struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := fetchJSON(ctx, endpoint, &payload); err != nil {
+		return "", "", err
+	}
+	tag = strings.TrimSpace(payload.TagName)
+	if tag == "" {
+		return "", "", fmt.Errorf("latest release response for %s did not include tag_name", repo)
+	}
+	return tag, normalizeReleaseVersion(tag), nil
+}
+
+func downloadReleaseFirmware(ctx context.Context, home, repo, releaseTag, version, firmwareEnv string) (imagePath, manifestPath string, artifact releaseFirmwareArtifact, err error) {
+	version = normalizeReleaseVersion(version)
+	if version == "" {
+		return "", "", releaseFirmwareArtifact{}, errors.New("release version cannot be empty")
+	}
+	releaseTag = strings.TrimSpace(releaseTag)
+	if releaseTag == "" {
+		releaseTag = "v" + version
+	}
+
+	releaseDir := filepath.Join(
+		home,
+		"Library",
+		"Application Support",
+		"codexbar-display",
+		"releases",
+		"firmware",
+		sanitizePathToken(releaseTag),
+	)
+	if err := os.MkdirAll(releaseDir, 0o755); err != nil {
+		return "", "", releaseFirmwareArtifact{}, err
+	}
+
+	manifestAsset := fmt.Sprintf("firmware-manifest-v%s.json", version)
+	manifestPath = filepath.Join(releaseDir, manifestAsset)
+	manifestURL := githubReleaseAssetURL(repo, releaseTag, manifestAsset)
+	if err := downloadURLToFile(ctx, manifestURL, manifestPath, 0o644); err != nil {
+		return "", "", releaseFirmwareArtifact{}, fmt.Errorf("download manifest: %w", err)
+	}
+
+	var manifest releaseFirmwareManifest
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return "", "", releaseFirmwareArtifact{}, err
+	}
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return "", "", releaseFirmwareArtifact{}, fmt.Errorf("parse firmware manifest: %w", err)
+	}
+
+	artifact, err = selectReleaseFirmwareArtifact(manifest, firmwareEnv, version)
+	if err != nil {
+		return "", "", releaseFirmwareArtifact{}, err
+	}
+
+	imagePath = filepath.Join(releaseDir, artifact.Asset)
+	imageURL := githubReleaseAssetURL(repo, releaseTag, artifact.Asset)
+	if err := downloadURLToFile(ctx, imageURL, imagePath, 0o644); err != nil {
+		return "", "", releaseFirmwareArtifact{}, fmt.Errorf("download firmware image: %w", err)
+	}
+
+	actualSHA, err := sha256File(imagePath)
+	if err != nil {
+		return "", "", releaseFirmwareArtifact{}, err
+	}
+	expectedSHA := strings.ToLower(strings.TrimSpace(artifact.SHA256))
+	if expectedSHA == "" {
+		return "", "", releaseFirmwareArtifact{}, fmt.Errorf("manifest artifact %q has empty sha256", artifact.Asset)
+	}
+	if actualSHA != expectedSHA {
+		return "", "", releaseFirmwareArtifact{}, fmt.Errorf("sha256 mismatch for %s: expected %s actual %s", artifact.Asset, expectedSHA, actualSHA)
+	}
+
+	return imagePath, manifestPath, artifact, nil
+}
+
+func githubReleaseAssetURL(repo, releaseTag, asset string) string {
+	return fmt.Sprintf(
+		"%s/%s/releases/download/%s/%s",
+		githubDownloadBaseURL,
+		repo,
+		url.PathEscape(strings.TrimSpace(releaseTag)),
+		url.PathEscape(strings.TrimSpace(asset)),
+	)
+}
+
+func selectReleaseFirmwareArtifact(manifest releaseFirmwareManifest, firmwareEnv, version string) (releaseFirmwareArtifact, error) {
+	firmwareEnv = strings.TrimSpace(firmwareEnv)
+	version = normalizeReleaseVersion(version)
+	for _, artifact := range manifest.Artifacts {
+		if strings.TrimSpace(artifact.FirmwareEnv) != firmwareEnv {
+			continue
+		}
+		if version != "" && normalizeReleaseVersion(artifact.FirmwareVersion) != version {
+			return releaseFirmwareArtifact{}, fmt.Errorf(
+				"manifest artifact for %s has firmware version %q, expected %q",
+				firmwareEnv,
+				artifact.FirmwareVersion,
+				version,
+			)
+		}
+		if strings.TrimSpace(artifact.Asset) == "" {
+			return releaseFirmwareArtifact{}, fmt.Errorf("manifest artifact for %s has empty asset", firmwareEnv)
+		}
+		if strings.TrimSpace(artifact.SHA256) == "" {
+			return releaseFirmwareArtifact{}, fmt.Errorf("manifest artifact for %s has empty sha256", firmwareEnv)
+		}
+		return artifact, nil
+	}
+	return releaseFirmwareArtifact{}, fmt.Errorf("no firmware artifact for env %q in release manifest", firmwareEnv)
+}
+
+func fetchJSON(ctx context.Context, endpoint string, target any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "codexbar-display-upgrade")
+
+	resp, err := releaseHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("GET %s returned %s", endpoint, resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func downloadURLToFile(ctx context.Context, endpoint, path string, mode os.FileMode) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "codexbar-display-upgrade")
+
+	resp, err := releaseHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("GET %s returned %s", endpoint, resp.Status)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmpPath := fmt.Sprintf("%s.tmp-%d", path, time.Now().UnixNano())
+	out, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func sha256File(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func flashReleaseFirmwareImage(ctx context.Context, port string, artifact releaseFirmwareArtifact, imagePath string) error {
+	env := strings.TrimSpace(artifact.FirmwareEnv)
+	spec, ok := releaseFirmwareFlashSpecs[env]
+	if !ok {
+		return fmt.Errorf("release firmware flashing is not implemented for env %q", env)
+	}
+	if strings.TrimSpace(port) == "" {
+		return errors.New("serial port is empty")
+	}
+	if _, err := exec.LookPath("pio"); err != nil {
+		return fmt.Errorf("PlatformIO CLI not found: %w", err)
+	}
+
+	args := []string{
+		"pkg", "exec",
+		"--package", "platformio/tool-esptoolpy",
+		"--",
+		"esptool.py",
+		"--chip", spec.Chip,
+		"--port", port,
+		"--baud", spec.Baud,
+		"write_flash",
+		"--flash_size", "detect",
+		spec.Address,
+		imagePath,
+	}
+	output, err := exec.CommandContext(ctx, "pio", args...).CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(output))
+		if trimmed != "" {
+			return fmt.Errorf("%w: %s", err, trimmed)
+		}
+		return err
+	}
 	return nil
 }
 

--- a/companion/cmd/codexbar-display/release_commands_test.go
+++ b/companion/cmd/codexbar-display/release_commands_test.go
@@ -1,13 +1,20 @@
 package main
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
-	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/errcode"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/errcode"
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
 )
 
 func TestReleaseStateRoundTrip(t *testing.T) {
@@ -271,6 +278,184 @@ func TestResolveRollbackFirmwareInputsKeepsExplicitImageAndManifest(t *testing.T
 	}
 }
 
+func TestSelectReleaseFirmwareArtifact(t *testing.T) {
+	manifest := releaseFirmwareManifest{
+		Artifacts: []releaseFirmwareArtifact{
+			{
+				FirmwareEnv:     "lilygo_t_display_s3",
+				FirmwareVersion: "1.0.3",
+				Asset:           "lilygo.bin",
+				SHA256:          strings.Repeat("a", 64),
+			},
+			{
+				FirmwareEnv:     "esp8266_smalltv_st7789",
+				FirmwareVersion: "1.0.3",
+				Asset:           "mini.bin",
+				SHA256:          strings.Repeat("b", 64),
+			},
+		},
+	}
+
+	artifact, err := selectReleaseFirmwareArtifact(manifest, "esp8266_smalltv_st7789", "v1.0.3")
+	if err != nil {
+		t.Fatalf("select artifact: %v", err)
+	}
+	if artifact.Asset != "mini.bin" {
+		t.Fatalf("unexpected asset %q", artifact.Asset)
+	}
+}
+
+func TestDownloadReleaseFirmwareVerifiesManifestAndChecksum(t *testing.T) {
+	previousHTTPClient := releaseHTTPClient
+	t.Cleanup(func() {
+		releaseHTTPClient = previousHTTPClient
+	})
+
+	home := t.TempDir()
+	imageBody := "firmware image"
+	imageSHA := sha256String(imageBody)
+	manifestBody := `{
+  "schemaVersion": 1,
+  "release": "v1.0.3",
+  "protocolVersion": 1,
+  "artifacts": [
+    {
+      "firmwareEnv": "esp8266_smalltv_st7789",
+      "board": "esp8266-smalltv-st7789",
+      "firmwareVersion": "1.0.3",
+      "asset": "codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.3.bin",
+      "sha256": "` + imageSHA + `"
+    }
+  ]
+}`
+
+	releaseHTTPClient = fakeReleaseHTTPClient{
+		responses: map[string]string{
+			"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.0.3/firmware-manifest-v1.0.3.json":                               manifestBody,
+			"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.0.3/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.3.bin": imageBody,
+		},
+	}
+
+	imagePath, manifestPath, artifact, err := downloadReleaseFirmware(
+		context.Background(),
+		home,
+		"DreamyTalesPAN/CodexBar-Display",
+		"v1.0.3",
+		"1.0.3",
+		"esp8266_smalltv_st7789",
+	)
+	if err != nil {
+		t.Fatalf("download release firmware: %v", err)
+	}
+	if artifact.Asset != "codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.3.bin" {
+		t.Fatalf("unexpected artifact asset %q", artifact.Asset)
+	}
+	if data, err := os.ReadFile(imagePath); err != nil || string(data) != imageBody {
+		t.Fatalf("unexpected image data data=%q err=%v", string(data), err)
+	}
+	if data, err := os.ReadFile(manifestPath); err != nil || !strings.Contains(string(data), `"release": "v1.0.3"`) {
+		t.Fatalf("unexpected manifest data data=%q err=%v", string(data), err)
+	}
+}
+
+func TestRunUpgradeDownloadsAndFlashesReleaseFirmware(t *testing.T) {
+	previousResolve := resolveSerialPortFn
+	previousEnsureBusy := ensureSerialPortNotBusyFn
+	previousStop := upgradeStopLaunchAgentFn
+	previousRestart := upgradeRestartLaunchAgentFn
+	previousLoadState := loadReleaseStateFn
+	previousSaveState := saveReleaseStateFn
+	previousSnapshot := snapshotInstalledCompanionBinaryFn
+	previousReadHello := readDeviceHelloFn
+	previousHTTPClient := releaseHTTPClient
+	previousFlash := flashReleaseFirmwareImageFn
+	t.Cleanup(func() {
+		resolveSerialPortFn = previousResolve
+		ensureSerialPortNotBusyFn = previousEnsureBusy
+		upgradeStopLaunchAgentFn = previousStop
+		upgradeRestartLaunchAgentFn = previousRestart
+		loadReleaseStateFn = previousLoadState
+		saveReleaseStateFn = previousSaveState
+		snapshotInstalledCompanionBinaryFn = previousSnapshot
+		readDeviceHelloFn = previousReadHello
+		releaseHTTPClient = previousHTTPClient
+		flashReleaseFirmwareImageFn = previousFlash
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	imageBody := "firmware image"
+	imageSHA := sha256String(imageBody)
+	manifestBody := `{
+  "schemaVersion": 1,
+  "release": "v1.0.3",
+  "protocolVersion": 1,
+  "artifacts": [
+    {
+      "firmwareEnv": "esp8266_smalltv_st7789",
+      "board": "esp8266-smalltv-st7789",
+      "firmwareVersion": "1.0.3",
+      "asset": "codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.3.bin",
+      "sha256": "` + imageSHA + `"
+    }
+  ]
+}`
+
+	releaseHTTPClient = fakeReleaseHTTPClient{
+		responses: map[string]string{
+			"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.0.3/firmware-manifest-v1.0.3.json":                               manifestBody,
+			"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.0.3/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.3.bin": imageBody,
+		},
+	}
+	resolveSerialPortFn = func(port string) (string, error) {
+		return strings.TrimSpace(port), nil
+	}
+	ensureSerialPortNotBusyFn = func(string) error { return nil }
+	upgradeStopLaunchAgentFn = func() {}
+	upgradeRestartLaunchAgentFn = func(string) error { return nil }
+	loadReleaseStateFn = func(string) (releaseState, error) { return releaseState{}, nil }
+	saveCalls := 0
+	saveReleaseStateFn = func(string, releaseState) error {
+		saveCalls++
+		return nil
+	}
+	snapshotInstalledCompanionBinaryFn = func(string) (string, string, error) {
+		return "", "", nil
+	}
+	readDeviceHelloFn = func(string) (protocol.DeviceHello, error) {
+		return protocol.DeviceHello{}, errors.New("no hello")
+	}
+	flashed := false
+	flashReleaseFirmwareImageFn = func(_ context.Context, port string, artifact releaseFirmwareArtifact, imagePath string) error {
+		flashed = true
+		if port != "/dev/cu.usbserial-110" {
+			t.Fatalf("unexpected port %q", port)
+		}
+		if artifact.FirmwareEnv != "esp8266_smalltv_st7789" {
+			t.Fatalf("unexpected firmware env %q", artifact.FirmwareEnv)
+		}
+		if data, err := os.ReadFile(imagePath); err != nil || string(data) != imageBody {
+			t.Fatalf("unexpected flashed image data=%q err=%v", string(data), err)
+		}
+		return nil
+	}
+
+	err := runUpgrade([]string{
+		"--port", "/dev/cu.usbserial-110",
+		"--target-firmware-version", "1.0.3",
+		"--skip-version-guard",
+	})
+	if err != nil {
+		t.Fatalf("runUpgrade failed: %v", err)
+	}
+	if !flashed {
+		t.Fatal("expected flash function to be called")
+	}
+	if saveCalls != 2 {
+		t.Fatalf("expected release state save twice, got %d", saveCalls)
+	}
+}
+
 func TestBeginUpgradeLaunchAgentRecoveryRestartsOnErrorPath(t *testing.T) {
 	previousStop := upgradeStopLaunchAgentFn
 	previousRestart := upgradeRestartLaunchAgentFn
@@ -531,4 +716,31 @@ func repoRoot(t *testing.T) string {
 		}
 		dir = parent
 	}
+}
+
+type fakeReleaseHTTPClient struct {
+	responses map[string]string
+}
+
+func (f fakeReleaseHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	body, ok := f.responses[req.URL.String()]
+	if !ok {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Status:     "404 Not Found",
+			Body:       io.NopCloser(strings.NewReader("not found")),
+			Header:     make(http.Header),
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func sha256String(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:])
 }

--- a/docs/customer-setup.md
+++ b/docs/customer-setup.md
@@ -50,6 +50,22 @@ Open Terminal and run this command:
 curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash
 ```
 
+### Firmware update path
+
+If support asks you to update the firmware, run:
+
+```bash
+curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --flash-firmware
+```
+
+Firmware flashing requires PlatformIO CLI (`pio`). If it is missing, the installer will stop with a recovery hint.
+
+If you need to use a specific serial port, run:
+
+```bash
+curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --flash-firmware -- --port /dev/cu.usbserial-110
+```
+
 ## What the Installer Does
 
 The installer handles everything automatically:
@@ -60,7 +76,8 @@ The installer handles everything automatically:
 4. It installs CodexBar if CodexBar is missing.
 5. It runs `codexbar-display setup --yes --skip-flash`.
 6. It starts the background service that sends frames to the display.
-7. It runs a health check at the end.
+7. If `--flash-firmware` is passed, it downloads the matching firmware from the GitHub release, verifies it, and flashes the connected device.
+8. It runs a health check at the end.
 
 ## What Success Looks Like
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,7 +12,9 @@ CODEXBAR_CONFIG_PATH="${CODEXBAR_CONFIG_DIR}/config.json"
 
 REPO="${CODEXBAR_DISPLAY_REPO:-$DEFAULT_REPO}"
 RELEASE_VERSION="${CODEXBAR_DISPLAY_VERSION:-}"
+FLASH_FIRMWARE="${CODEXBAR_DISPLAY_FLASH_FIRMWARE:-0}"
 SETUP_ARGS=()
+FIRMWARE_UPGRADE_ARGS=()
 TMPDIR_INSTALL=""
 DOWNLOAD_BIN=""
 CHECKSUMS_FILE=""
@@ -22,19 +24,21 @@ BINARY_ARCH=""
 usage() {
   cat <<'EOF'
 Usage:
-  install.sh [--repo owner/name] [--version x.y.z] [--] [setup args...]
+  install.sh [--repo owner/name] [--version x.y.z] [--flash-firmware] [--] [setup args...]
 
 What it does:
   - detects macOS architecture
   - downloads the matching codexbar-display release binary from GitHub Releases
   - verifies the SHA-256 checksum from the release checksum file
   - runs `codexbar-display setup --yes --skip-flash`
+  - optionally runs `codexbar-display upgrade` to flash release firmware when --flash-firmware is passed
   - warms up CodexBar on fresh installs so providers are usable
   - runs a health check after setup
 
 Examples:
   curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash
   curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --port /dev/cu.usbserial-110
+  curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --flash-firmware -- --port /dev/cu.usbserial-110
   curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --version 1.0.0
 EOF
 }
@@ -105,6 +109,32 @@ verify_checksum() {
   if [[ "$actual" != "$expected" ]]; then
     die "checksum mismatch for ${DOWNLOAD_BIN##*/}"
   fi
+}
+
+build_firmware_upgrade_args() {
+  local args=("$@")
+  local i arg next
+
+  FIRMWARE_UPGRADE_ARGS=(--repo "$REPO" --target-firmware-version "$RELEASE_VERSION")
+
+  i=0
+  while [[ "$i" -lt "${#args[@]}" ]]; do
+    arg="${args[$i]}"
+    case "$arg" in
+      --port|--firmware-env)
+        next=$((i + 1))
+        if [[ "$next" -lt "${#args[@]}" ]]; then
+          FIRMWARE_UPGRADE_ARGS+=("$arg" "${args[$next]}")
+          i=$((i + 2))
+          continue
+        fi
+        ;;
+      --port=*|--firmware-env=*)
+        FIRMWARE_UPGRADE_ARGS+=("$arg")
+        ;;
+    esac
+    i=$((i + 1))
+  done
 }
 
 seed_codexbar_config_if_missing() {
@@ -242,6 +272,10 @@ main() {
         RELEASE_VERSION="$(normalize_version "${1#*=}")"
         shift
         ;;
+      --flash-firmware)
+        FLASH_FIRMWARE=1
+        shift
+        ;;
       --)
         shift
         SETUP_ARGS=("$@")
@@ -294,6 +328,12 @@ main() {
   seed_codexbar_config_if_missing
   if ! wait_for_codexbar_ready; then
     die "CodexBar installed, but provider warm-up did not complete. Open CodexBar once, make sure at least one provider is active, then rerun the installer."
+  fi
+
+  if [[ "$FLASH_FIRMWARE" == "1" ]]; then
+    log "vibetv: upgrading firmware from release..."
+    build_firmware_upgrade_args "${SETUP_ARGS[@]}"
+    "$INSTALL_PATH" upgrade "${FIRMWARE_UPGRADE_ARGS[@]}"
   fi
 
   log "vibetv: installed binary at ${INSTALL_PATH}"


### PR DESCRIPTION
## Summary

Adds a release-based firmware upgrade path for VibeTV devices so customers/support can flash firmware without a local repo checkout.

- `codexbar-display upgrade` now resolves a GitHub release, downloads `firmware-manifest-vX.Y.Z.json`, selects the matching firmware env artifact, verifies SHA256, and flashes the downloaded `.bin`
- defaults to the latest GitHub release when no `--target-firmware-version` is passed
- adds `--repo owner/name` for test/fork releases
- keeps a board guard when device hello reports a board ID
- adds `install.sh --flash-firmware` to run setup and then firmware upgrade
- documents the firmware update path in customer setup docs

## Validation

- `go test ./...` from `companion`
- `bash -n scripts/install.sh scripts/upgrade-with-preflight.sh scripts/rollback-last-known-good.sh`
- `pio run -d firmware_esp8266 -e esp8266_smalltv_st7789`

## Notes

Release firmware flashing currently implements the release-gated `esp8266_smalltv_st7789` target. The ESP32 target remains experimental and should get a separate flash-spec implementation before customer use.