### PR TITLE
[codex] Fix release upgrade serial port handoff

### DIFF
--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -40,6 +40,7 @@ var (
 	rollbackRestartLaunchAgentFn                       = restartLaunchAgent
 	resolveSerialPortFn                                = usb.ResolvePort
 	readDeviceHelloFn                                  = usb.ReadDeviceHello
+	closeDefaultSenderFn                               = usb.CloseDefaultSender
 	ensureSerialPortNotBusyFn                          = ensureSerialPortNotBusy
 	loadReleaseStateFn                                 = loadReleaseState
 	saveReleaseStateFn                                 = saveReleaseState
@@ -284,6 +285,7 @@ func runUpgrade(args []string) (retErr error) {
 	}
 
 	hello, helloErr := readDeviceHelloFn(resolvedPort)
+	closeDefaultSenderFn()
 	if helloErr == nil {
 		fmt.Printf("device hello: board=%s firmware=%s protocol=%d\n", hello.Board, hello.Firmware, hello.ProtocolVersion)
 	} else {
@@ -363,6 +365,7 @@ func runUpgrade(args []string) (retErr error) {
 	fmt.Println("firmware flash: ok")
 
 	postHello, postHelloErr := readDeviceHelloFn(resolvedPort)
+	closeDefaultSenderFn()
 	if postHelloErr == nil {
 		fmt.Printf("post-upgrade hello: board=%s firmware=%s protocol=%d\n", postHello.Board, postHello.Firmware, postHello.ProtocolVersion)
 		if !*skipVersionGuard && strings.TrimSpace(postHello.Firmware) != "" {

--- a/companion/cmd/codexbar-display/release_commands_test.go
+++ b/companion/cmd/codexbar-display/release_commands_test.go
@@ -367,6 +367,7 @@ func TestRunUpgradeDownloadsAndFlashesReleaseFirmware(t *testing.T) {
 	previousSaveState := saveReleaseStateFn
 	previousSnapshot := snapshotInstalledCompanionBinaryFn
 	previousReadHello := readDeviceHelloFn
+	previousCloseDefaultSender := closeDefaultSenderFn
 	previousHTTPClient := releaseHTTPClient
 	previousFlash := flashReleaseFirmwareImageFn
 	t.Cleanup(func() {
@@ -378,6 +379,7 @@ func TestRunUpgradeDownloadsAndFlashesReleaseFirmware(t *testing.T) {
 		saveReleaseStateFn = previousSaveState
 		snapshotInstalledCompanionBinaryFn = previousSnapshot
 		readDeviceHelloFn = previousReadHello
+		closeDefaultSenderFn = previousCloseDefaultSender
 		releaseHTTPClient = previousHTTPClient
 		flashReleaseFirmwareImageFn = previousFlash
 	})
@@ -425,6 +427,10 @@ func TestRunUpgradeDownloadsAndFlashesReleaseFirmware(t *testing.T) {
 	readDeviceHelloFn = func(string) (protocol.DeviceHello, error) {
 		return protocol.DeviceHello{}, errors.New("no hello")
 	}
+	closeCalls := 0
+	closeDefaultSenderFn = func() {
+		closeCalls++
+	}
 	flashed := false
 	flashReleaseFirmwareImageFn = func(_ context.Context, port string, artifact releaseFirmwareArtifact, imagePath string) error {
 		flashed = true
@@ -450,6 +456,9 @@ func TestRunUpgradeDownloadsAndFlashesReleaseFirmware(t *testing.T) {
 	}
 	if !flashed {
 		t.Fatal("expected flash function to be called")
+	}
+	if closeCalls != 2 {
+		t.Fatalf("expected sender close after pre/post hello reads, got %d", closeCalls)
 	}
 	if saveCalls != 2 {
 		t.Fatalf("expected release state save twice, got %d", saveCalls)


### PR DESCRIPTION
## Summary

Fixes the release firmware upgrade path after the real-device test hit `Resource busy` during `esptool` flashing.

- closes the shared USB serial sender immediately after the pre-flash device hello read
- also closes it after the post-flash hello read
- extends the upgrade test to assert the sender is closed after both hello attempts

## Validation

- `go test ./...` from `companion`
- real-device upgrade test: `go run ./cmd/codexbar-display upgrade --port /dev/cu.usbserial-10 --target-firmware-version 1.0.3 --skip-version-guard`

## Result

The upgrade path now downloads the `v1.0.3` release firmware, verifies it, flashes successfully, and restarts the LaunchAgent without leaving the port busy.