### PR TITLE
[codex] Harden launch agent setup restart

### DIFF
--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -884,8 +884,9 @@ func ensureSerialPortNotBusy(port string) error {
 }
 
 func stopLaunchAgentBestEffort() {
-	service := fmt.Sprintf("gui/%d/com.codexbar-display.daemon", os.Getuid())
-	_, _ = exec.Command("launchctl", "bootout", service).CombinedOutput()
+	domain := fmt.Sprintf("gui/%d", os.Getuid())
+	service := domain + "/com.codexbar-display.daemon"
+	bootoutLaunchAgentBestEffort(domain, service, "")
 }
 
 func beginUpgradeLaunchAgentRecovery(home string, retErr *error) func() {
@@ -1106,15 +1107,11 @@ func restartLaunchAgent(home string) error {
 
 	domain := fmt.Sprintf("gui/%d", os.Getuid())
 	service := domain + "/" + strings.TrimSuffix(launchAgentLabel, ".plist")
-	_, _ = exec.Command("launchctl", "bootout", service).CombinedOutput()
+	bootoutLaunchAgentBestEffort(domain, service, plist)
 	_, _ = exec.Command("launchctl", "enable", service).CombinedOutput()
 
-	bootstrapOut, bootstrapErr := exec.Command("launchctl", "bootstrap", domain, plist).CombinedOutput()
-	if bootstrapErr != nil {
-		trimmed := strings.TrimSpace(string(bootstrapOut))
-		if !strings.Contains(trimmed, "already") {
-			return fmt.Errorf("bootstrap launchagent: %w (%s)", bootstrapErr, trimmed)
-		}
+	if err := bootstrapLaunchAgentWithRetry(domain, service, plist, 3, 300*time.Millisecond); err != nil {
+		return err
 	}
 
 	kickOut, kickErr := exec.Command("launchctl", "kickstart", "-k", service).CombinedOutput()
@@ -1122,6 +1119,45 @@ func restartLaunchAgent(home string) error {
 		return fmt.Errorf("kickstart launchagent: %w (%s)", kickErr, strings.TrimSpace(string(kickOut)))
 	}
 	return nil
+}
+
+func bootstrapLaunchAgentWithRetry(domain, service, plist string, attempts int, delay time.Duration) error {
+	if attempts <= 0 {
+		attempts = 1
+	}
+
+	var lastOut []byte
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		out, err := exec.Command("launchctl", "bootstrap", domain, plist).CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		lastOut = out
+		lastErr = err
+
+		if launchAgentLoaded(service) {
+			return nil
+		}
+
+		if attempt < attempts {
+			bootoutLaunchAgentBestEffort(domain, service, plist)
+			time.Sleep(delay)
+		}
+	}
+
+	return fmt.Errorf("bootstrap launchagent: %w (%s)", lastErr, strings.TrimSpace(string(lastOut)))
+}
+
+func launchAgentLoaded(service string) bool {
+	return exec.Command("launchctl", "print", service).Run() == nil
+}
+
+func bootoutLaunchAgentBestEffort(domain, service, plist string) {
+	_, _ = exec.Command("launchctl", "bootout", service).CombinedOutput()
+	if strings.TrimSpace(plist) != "" {
+		_, _ = exec.Command("launchctl", "bootout", domain, plist).CombinedOutput()
+	}
 }
 
 func startLaunchAgent(home string) error {

--- a/companion/internal/setup/setup.go
+++ b/companion/internal/setup/setup.go
@@ -882,10 +882,10 @@ func reloadLaunchAgent(ctx context.Context, d deps, plistPath string) error {
 	domain := fmt.Sprintf("gui/%d", d.uid())
 	service := launchServiceTarget(d.uid())
 
-	_, _ = d.runCommand(ctx, "", "launchctl", "bootout", service)
+	bootoutLaunchAgentBestEffort(ctx, d, domain, service, plistPath)
 	_, _ = d.runCommand(ctx, "", "launchctl", "enable", service)
 
-	output, err := d.runCommand(ctx, "", "launchctl", "bootstrap", domain, plistPath)
+	output, err := bootstrapLaunchAgentWithRetry(ctx, d, domain, service, plistPath, 3, 300*time.Millisecond)
 	if err != nil {
 		return &StepError{
 			Step:   "launchagent-bootstrap",
@@ -924,6 +924,50 @@ func reloadLaunchAgent(ctx context.Context, d deps, plistPath string) error {
 	}
 
 	return nil
+}
+
+func bootstrapLaunchAgentWithRetry(ctx context.Context, d deps, domain, service, plistPath string, attempts int, delay time.Duration) (string, error) {
+	if attempts <= 0 {
+		attempts = 1
+	}
+
+	var lastOutput string
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		output, err := d.runCommand(ctx, "", "launchctl", "bootstrap", domain, plistPath)
+		if err == nil {
+			return output, nil
+		}
+		lastOutput = output
+		lastErr = err
+
+		if launchAgentLoaded(ctx, d, service) {
+			return output, nil
+		}
+
+		if attempt < attempts {
+			bootoutLaunchAgentBestEffort(ctx, d, domain, service, plistPath)
+			select {
+			case <-ctx.Done():
+				return lastOutput, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+	}
+
+	return lastOutput, lastErr
+}
+
+func launchAgentLoaded(ctx context.Context, d deps, service string) bool {
+	_, err := d.runCommand(ctx, "", "launchctl", "print", service)
+	return err == nil
+}
+
+func bootoutLaunchAgentBestEffort(ctx context.Context, d deps, domain, service, plistPath string) {
+	_, _ = d.runCommand(ctx, "", "launchctl", "bootout", service)
+	if strings.TrimSpace(plistPath) != "" {
+		_, _ = d.runCommand(ctx, "", "launchctl", "bootout", domain, plistPath)
+	}
 }
 
 func waitForLaunchAgentState(ctx context.Context, d deps, service string, attempts int, delay time.Duration) (string, error) {
@@ -1001,8 +1045,13 @@ func runSystemCommand(ctx context.Context, dir string, name string, args ...stri
 }
 
 func stopLaunchAgentBestEffort(ctx context.Context, d deps) {
+	domain := fmt.Sprintf("gui/%d", d.uid())
 	service := launchServiceTarget(d.uid())
-	_, _ = d.runCommand(ctx, "", "launchctl", "bootout", service)
+	plistPath := ""
+	if home, err := d.homeDir(); err == nil {
+		plistPath = filepath.Join(home, "Library", "LaunchAgents", launchAgentLabel+".plist")
+	}
+	bootoutLaunchAgentBestEffort(ctx, d, domain, service, plistPath)
 }
 
 func installRecoveryAssets(repoRoot, home string) (string, string, error) {

--- a/companion/internal/setup/setup_test.go
+++ b/companion/internal/setup/setup_test.go
@@ -654,6 +654,140 @@ func TestRunWithDepsWaitsForLaunchAgentToBecomeRunning(t *testing.T) {
 	}
 }
 
+func TestRunWithDepsRetriesLaunchAgentBootstrapRace(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	repo := filepath.Join(tmp, "repo")
+	execPath := filepath.Join(tmp, "bin", "codexbar-display-source")
+
+	mustWriteFile(t, filepath.Join(repo, "firmware_esp32", "platformio.ini"), []byte("[env]"), 0o644)
+	mustWriteFile(t, filepath.Join(repo, "companion", "go.mod"), []byte("module test"), 0o644)
+	mustWriteFile(t, execPath, []byte("binary-content"), 0o755)
+
+	bootstrapAttempts := 0
+
+	err := runWithDeps(context.Background(), Options{Port: "/dev/cu.usbserial10", AssumeYes: true, SkipFlash: true}, deps{
+		stdin:  strings.NewReader(""),
+		stdout: &bytes.Buffer{},
+		cwd: func() (string, error) {
+			return filepath.Join(repo, "companion"), nil
+		},
+		executablePath: func() (string, error) {
+			return execPath, nil
+		},
+		homeDir: func() (string, error) {
+			return home, nil
+		},
+		uid: func() int { return 501 },
+		resolvePort: func(p string) (string, error) {
+			if p != "" {
+				return p, nil
+			}
+			return "/dev/cu.usbserial10", nil
+		},
+		probePort: func(string) error { return nil },
+		findCodexbar: func() (string, error) {
+			return "/opt/homebrew/bin/codexbar", nil
+		},
+		lookPath: func(file string) (string, error) {
+			switch file {
+			case "pio", "brew", "open":
+				return "/usr/bin/" + file, nil
+			default:
+				return "", errors.New("not found")
+			}
+		},
+		runCommand: func(_ context.Context, _ string, name string, args ...string) (string, error) {
+			if name == "launchctl" && len(args) > 0 {
+				switch args[0] {
+				case "bootstrap":
+					bootstrapAttempts++
+					if bootstrapAttempts == 1 {
+						return "Bootstrap failed: 5: Input/output error", errors.New("exit status 5")
+					}
+				case "print":
+					if bootstrapAttempts == 1 {
+						return "Could not find service", errors.New("exit status 113")
+					}
+					return "state = running", nil
+				}
+			}
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected setup success after bootstrap retry, got %v", err)
+	}
+	if bootstrapAttempts != 2 {
+		t.Fatalf("expected bootstrap retry, got %d attempts", bootstrapAttempts)
+	}
+}
+
+func TestRunWithDepsFallsBackToKickstartWhenLaunchAgentAlreadyLoaded(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	repo := filepath.Join(tmp, "repo")
+	execPath := filepath.Join(tmp, "bin", "codexbar-display-source")
+
+	mustWriteFile(t, filepath.Join(repo, "firmware_esp32", "platformio.ini"), []byte("[env]"), 0o644)
+	mustWriteFile(t, filepath.Join(repo, "companion", "go.mod"), []byte("module test"), 0o644)
+	mustWriteFile(t, execPath, []byte("binary-content"), 0o755)
+
+	kickstartCalled := false
+
+	err := runWithDeps(context.Background(), Options{Port: "/dev/cu.usbserial10", AssumeYes: true, SkipFlash: true}, deps{
+		stdin:  strings.NewReader(""),
+		stdout: &bytes.Buffer{},
+		cwd: func() (string, error) {
+			return filepath.Join(repo, "companion"), nil
+		},
+		executablePath: func() (string, error) {
+			return execPath, nil
+		},
+		homeDir: func() (string, error) {
+			return home, nil
+		},
+		uid: func() int { return 501 },
+		resolvePort: func(p string) (string, error) {
+			if p != "" {
+				return p, nil
+			}
+			return "/dev/cu.usbserial10", nil
+		},
+		probePort: func(string) error { return nil },
+		findCodexbar: func() (string, error) {
+			return "/opt/homebrew/bin/codexbar", nil
+		},
+		lookPath: func(file string) (string, error) {
+			switch file {
+			case "pio", "brew", "open":
+				return "/usr/bin/" + file, nil
+			default:
+				return "", errors.New("not found")
+			}
+		},
+		runCommand: func(_ context.Context, _ string, name string, args ...string) (string, error) {
+			if name == "launchctl" && len(args) > 0 {
+				switch args[0] {
+				case "bootstrap":
+					return "Bootstrap failed: 5: Input/output error", errors.New("exit status 5")
+				case "kickstart":
+					kickstartCalled = true
+				case "print":
+					return "state = running", nil
+				}
+			}
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected setup success with loaded launch agent fallback, got %v", err)
+	}
+	if !kickstartCalled {
+		t.Fatalf("expected kickstart fallback")
+	}
+}
+
 func TestRunWithDepsStopsLaunchAgentBeforeSerialProbe(t *testing.T) {
 	bootoutCalled := false
 


### PR DESCRIPTION
## Summary
- retry LaunchAgent bootstrap after transient macOS EIO failures
- fall back to kickstart when launchd already has the agent loaded
- use plist-based bootout alongside service-target bootout

## Verification
- go test ./...
- go run ./cmd/codexbar-display setup --yes --skip-flash --port /dev/cu.usbserial-10