### PR TITLE
CODEX Default companion launch to WiFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Vibe TV ships ready for WiFi setup.
 7. Open Terminal (on Mac: Cmd + Space, type Terminal, hit enter), paste the copied command, and press Enter.
 
 ```bash
-curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --transport wifi --target http://vibetv.local --theme mini
+curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash
 ```
 
-The Web UI fills in the target automatically.
+The installer defaults to WiFi, `http://vibetv.local`, and the Mini theme.
 
 Or copy this prompt into any AI:
 
@@ -30,7 +30,7 @@ Your job:
 - Assume I want the standard setup flow on macOS.
 - If you have terminal or tool access, do the setup yourself instead of asking me to copy commands.
 - Use the official installer:
-  curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --transport wifi --target http://vibetv.local --theme mini
+  curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash
 - After running it, verify that the setup worked.
 - Only if you cannot run commands yourself, explain exactly what I should do in simple ELI5 language, one small step at a time.
 
@@ -43,7 +43,7 @@ If something fails, troubleshoot in this order:
 - confirm the Vibe TV IP address
 - confirm the Mac is on the same WiFi
 - rerun the installer
-- check the daemon target with --transport wifi --target http://vibetv.local
+- check that the daemon target is http://vibetv.local
 
 If you cannot act directly, do not dump a long checklist. Give me only the next action, wait for the result, and then continue.
 ```

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -74,7 +74,7 @@ func main() {
 
 func printUsage() {
 	fmt.Println("codexbar-display commands:")
-	fmt.Println("  codexbar-display daemon [--transport usb|wifi] [--port /dev/cu.usbserial-10] [--target http://192.168.178.123] [--interval 60s] [--once] [--theme classic|crt|mini]")
+	fmt.Println("  codexbar-display daemon [--transport wifi|usb] [--target http://vibetv.local] [--port /dev/cu.usbserial-10] [--interval 60s] [--once] [--theme classic|crt|mini]")
 	fmt.Println("  codexbar-display doctor")
 	fmt.Println("  codexbar-display health")
 	fmt.Println("  codexbar-display service <start|stop|status>")
@@ -84,7 +84,7 @@ func printUsage() {
 	fmt.Println("  codexbar-display restore-known-good [--port /dev/cu.usbserial-10] [--image path/to/backup.bin] [--backup-dir <dir>] [--script-path <path>] [--manifest <path>] [--skip-verify]")
 	fmt.Println("  codexbar-display theme-validate --spec path/to/theme-spec.json [--port /dev/cu.usbserial-10] [--allow-unknown-capabilities]")
 	fmt.Println("  codexbar-display theme-apply --spec path/to/theme-spec.json [--port /dev/cu.usbserial-10] [--allow-unknown-capabilities]")
-	fmt.Println("  codexbar-display setup [--transport usb|wifi] [--target http://192.168.178.123] [--port /dev/cu.usbserial-10] [--yes] [--skip-flash] [--pin-port] [--firmware-env env] [--theme classic|crt|mini|none] [--validate-only] [--dry-run]")
+	fmt.Println("  codexbar-display setup [--transport wifi|usb] [--target http://vibetv.local] [--port /dev/cu.usbserial-10] [--yes] [--skip-flash] [--pin-port] [--firmware-env env] [--theme classic|crt|mini|none] [--validate-only] [--dry-run]")
 }
 
 func runDaemon(args []string) error {
@@ -98,8 +98,8 @@ func runDaemon(args []string) error {
 func parseDaemonOptions(args []string) (daemon.Options, error) {
 	fs := flag.NewFlagSet("daemon", flag.ContinueOnError)
 	port := fs.String("port", "", "serial port (auto-detect when empty)")
-	transportName := fs.String("transport", "usb", "device transport: usb|wifi")
-	target := fs.String("target", "", "WiFi target base URL, for example http://192.168.178.123")
+	transportName := fs.String("transport", setup.DefaultTransport(), "device transport: wifi|usb")
+	target := fs.String("target", setup.DefaultWiFiTarget(), "WiFi target base URL, for example http://vibetv.local")
 	interval := fs.Duration("interval", 60*time.Second, "poll interval")
 	once := fs.Bool("once", false, "run one cycle and exit")
 	theme := fs.String("theme", "", "optional runtime theme override: classic|crt|mini")
@@ -109,7 +109,7 @@ func parseDaemonOptions(args []string) (daemon.Options, error) {
 
 	normalizedTransport := strings.TrimSpace(strings.ToLower(*transportName))
 	if normalizedTransport == "" {
-		normalizedTransport = "usb"
+		normalizedTransport = setup.DefaultTransport()
 	}
 	if normalizedTransport != "usb" && normalizedTransport != "wifi" {
 		return daemon.Options{}, fmt.Errorf("unsupported transport %q", *transportName)
@@ -281,8 +281,8 @@ func runDoctorRuntimeChecks(ports []string) error {
 func runSetup(args []string) error {
 	fs := flag.NewFlagSet("setup", flag.ContinueOnError)
 	port := fs.String("port", "", "serial port (auto-detect when empty)")
-	transportName := fs.String("transport", "usb", "device transport for LaunchAgent: usb|wifi")
-	target := fs.String("target", "", "WiFi target base URL, for example http://192.168.178.123")
+	transportName := fs.String("transport", setup.DefaultTransport(), "device transport for LaunchAgent: wifi|usb")
+	target := fs.String("target", setup.DefaultWiFiTarget(), "WiFi target base URL, for example http://vibetv.local")
 	yes := fs.Bool("yes", false, "auto-select defaults without prompts")
 	skipFlash := fs.Bool("skip-flash", false, "skip firmware flashing")
 	pinPort := fs.Bool("pin-port", false, "pin daemon to selected --port in LaunchAgent (default: auto-detect)")

--- a/companion/cmd/codexbar-display/main_test.go
+++ b/companion/cmd/codexbar-display/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+func TestParseDaemonOptionsWiFiTarget(t *testing.T) {
+	opts, err := parseDaemonOptions([]string{
+		"--transport", "wifi",
+		"--target", "http://192.168.178.123",
+		"--once",
+	})
+	if err != nil {
+		t.Fatalf("parseDaemonOptions returned error: %v", err)
+	}
+	if opts.Transport != "wifi" {
+		t.Fatalf("expected wifi transport, got %q", opts.Transport)
+	}
+	if opts.Target != "http://192.168.178.123" {
+		t.Fatalf("unexpected target %q", opts.Target)
+	}
+	if !opts.Once {
+		t.Fatalf("expected once option")
+	}
+}
+
+func TestParseDaemonOptionsDefaultsToWiFi(t *testing.T) {
+	opts, err := parseDaemonOptions(nil)
+	if err != nil {
+		t.Fatalf("parseDaemonOptions returned error: %v", err)
+	}
+	if opts.Transport != "wifi" {
+		t.Fatalf("expected wifi transport default, got %q", opts.Transport)
+	}
+	if opts.Target != "http://vibetv.local" {
+		t.Fatalf("expected default WiFi target, got %q", opts.Target)
+	}
+}

--- a/companion/internal/daemon/daemon.go
+++ b/companion/internal/daemon/daemon.go
@@ -466,7 +466,7 @@ func resolveCycleDevice(requestedPort string, deps runtimeDeps) (string, protoco
 	if err != nil {
 		hint := errcode.DefaultRecovery(errcode.RuntimeSerialResolve)
 		if deps.transportName == "wifi" {
-			hint = "Pass `--transport wifi --target http://<device-ip>` and verify the Mac can reach the VibeTV IP."
+			hint = "Verify the Mac can open http://vibetv.local. If not, rerun setup with --target http://<device-ip>."
 		}
 		return "", protocol.DeviceCapabilities{}, 0, &RuntimeError{
 			Kind: runtimeErrorSerialResolve,

--- a/companion/internal/health/health.go
+++ b/companion/internal/health/health.go
@@ -101,7 +101,7 @@ func runWithDeps(ctx context.Context, d deps) error {
 	if config.Transport == "wifi" {
 		fmt.Fprintln(d.stdout, "transport: wifi")
 		if config.Target == "" {
-			fmt.Fprintln(d.stdout, "device target: unavailable (run setup with --transport wifi --target http://vibetv.local)")
+			fmt.Fprintln(d.stdout, "device target: unavailable (rerun setup)")
 		} else {
 			fmt.Fprintf(d.stdout, "device target: %s\n", config.Target)
 		}

--- a/companion/internal/setup/setup.go
+++ b/companion/internal/setup/setup.go
@@ -27,6 +27,8 @@ const (
 	launchAgentLabel      = "com.codexbar-display.daemon"
 	defaultDaemonInterval = "60s"
 	defaultLastGoodMaxAge = "168h"
+	defaultTransport      = "wifi"
+	defaultWiFiTarget     = "http://vibetv.local"
 	codexbarInstallURL    = "https://codexbar.app/"
 	codexbarBrewCask      = "steipete/tap/codexbar"
 )
@@ -42,6 +44,14 @@ type Options struct {
 	Theme         string
 	ValidateOnly  bool
 	DryRun        bool
+}
+
+func DefaultTransport() string {
+	return defaultTransport
+}
+
+func DefaultWiFiTarget() string {
+	return defaultWiFiTarget
 }
 
 type commandRunner func(ctx context.Context, dir string, name string, args ...string) (string, error)
@@ -238,21 +248,24 @@ func runWithDeps(ctx context.Context, opts Options, d deps) error {
 
 	transportName := normalizeSetupTransport(opts.Transport)
 	if transportName == "" {
-		transportName = "usb"
+		transportName = defaultTransport
 	}
 	if transportName != "usb" && transportName != "wifi" {
 		return &StepError{
 			Step: "validate-transport",
 			Err:  fmt.Errorf("unsupported transport %q", opts.Transport),
-			Hint: "use --transport usb or --transport wifi",
+			Hint: "use --transport wifi or --transport usb",
 		}
 	}
 	target := normalizeSetupTarget(opts.Target)
 	if transportName == "wifi" && target == "" {
+		target = defaultWiFiTarget
+	}
+	if transportName == "wifi" && target == "" {
 		return &StepError{
 			Step: "validate-target",
 			Err:  errors.New("--target is required with --transport wifi"),
-			Hint: "use the IP shown on Vibe TV, for example --target http://192.168.178.66",
+			Hint: "use --target http://vibetv.local or the IP shown on Vibe TV",
 		}
 	}
 	fmt.Fprintf(d.stdout, "Launch agent transport: %s\n", transportName)

--- a/companion/internal/setup/setup_test.go
+++ b/companion/internal/setup/setup_test.go
@@ -34,7 +34,7 @@ func TestRunWithDepsInstallsCodexbarAndCompletesSetup(t *testing.T) {
 	var calls []commandCall
 	findCount := 0
 
-	err := runWithDeps(context.Background(), Options{}, deps{
+	err := runWithDeps(context.Background(), Options{Transport: "usb"}, deps{
 		stdin:  strings.NewReader("2\n"),
 		stdout: &stdout,
 		cwd: func() (string, error) {
@@ -133,6 +133,7 @@ func TestRunWithDepsPinsDaemonPortWhenRequested(t *testing.T) {
 	execPath := mustCreateExecutable(t)
 
 	err := runWithDeps(context.Background(), Options{
+		Transport:     "usb",
 		Port:          "/dev/cu.usbserial10",
 		AssumeYes:     true,
 		SkipFlash:     true,
@@ -257,22 +258,62 @@ func TestRunWithDepsConfiguresWiFiLaunchAgentTarget(t *testing.T) {
 	}
 }
 
-func TestRunWithDepsRequiresWiFiTarget(t *testing.T) {
+func TestRunWithDepsDefaultsToWiFiLaunchAgentTarget(t *testing.T) {
+	home := t.TempDir()
+	execPath := mustCreateExecutable(t)
+
 	err := runWithDeps(context.Background(), Options{
-		Transport: "wifi",
 		AssumeYes: true,
 		SkipFlash: true,
 	}, deps{
+		stdin:  strings.NewReader(""),
 		stdout: &bytes.Buffer{},
+		executablePath: func() (string, error) {
+			return execPath, nil
+		},
+		homeDir: func() (string, error) {
+			return home, nil
+		},
+		uid: func() int { return 501 },
+		listPorts: func() ([]string, error) {
+			t.Fatalf("default setup must not list serial ports")
+			return nil, nil
+		},
+		resolvePort: func(string) (string, error) {
+			t.Fatalf("default setup must not resolve serial ports")
+			return "", nil
+		},
 		findCodexbar: func() (string, error) {
 			return "/opt/homebrew/bin/codexbar", nil
 		},
+		lookPath: func(file string) (string, error) {
+			if file == "launchctl" {
+				return "/bin/launchctl", nil
+			}
+			return "", errors.New("not found")
+		},
+		runCommand: func(_ context.Context, _ string, name string, args ...string) (string, error) {
+			if name == "launchctl" && len(args) > 0 && args[0] == "print" {
+				return "state = running", nil
+			}
+			return "", nil
+		},
 	})
-	if err == nil {
-		t.Fatalf("expected setup to require --target for WiFi")
+	if err != nil {
+		t.Fatalf("expected default WiFi setup success, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "--target is required") {
-		t.Fatalf("expected target validation error, got %v", err)
+
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", launchAgentLabel+".plist")
+	plistData, readErr := os.ReadFile(plistPath)
+	if readErr != nil {
+		t.Fatalf("read plist: %v", readErr)
+	}
+	plist := string(plistData)
+	if !strings.Contains(plist, "<string>--transport</string>") ||
+		!strings.Contains(plist, "<string>wifi</string>") ||
+		!strings.Contains(plist, "<string>--target</string>") ||
+		!strings.Contains(plist, "<string>http://vibetv.local</string>") {
+		t.Fatalf("expected default WiFi launch agent target in plist, got:\n%s", plist)
 	}
 }
 
@@ -281,6 +322,7 @@ func TestRunWithDepsWritesRuntimeThemeConfig(t *testing.T) {
 	execPath := mustCreateExecutable(t)
 
 	err := runWithDeps(context.Background(), Options{
+		Transport: "usb",
 		Port:      "/dev/cu.usbserial10",
 		AssumeYes: true,
 		SkipFlash: true,
@@ -333,6 +375,7 @@ func TestRunWithDepsWritesDefaultMiniThemeConfigWhenUnset(t *testing.T) {
 	execPath := mustCreateExecutable(t)
 
 	err := runWithDeps(context.Background(), Options{
+		Transport: "usb",
 		Port:      "/dev/cu.usbserial10",
 		AssumeYes: true,
 		SkipFlash: true,
@@ -384,6 +427,7 @@ func TestRunWithDepsRejectsBluetoothOnlyPortsWhenUnset(t *testing.T) {
 	execPath := mustCreateExecutable(t)
 
 	err := runWithDeps(context.Background(), Options{
+		Transport: "usb",
 		AssumeYes: true,
 		SkipFlash: true,
 	}, deps{
@@ -435,6 +479,7 @@ func TestRunWithDepsKeepsExistingThemeWhenUnset(t *testing.T) {
 	}
 
 	err := runWithDeps(context.Background(), Options{
+		Transport: "usb",
 		Port:      "/dev/cu.usbserial10",
 		AssumeYes: true,
 		SkipFlash: true,
@@ -487,6 +532,7 @@ func TestRunWithDepsContinuesWhenSkipFlashAndProbeFails(t *testing.T) {
 	var stdout bytes.Buffer
 
 	err := runWithDeps(context.Background(), Options{
+		Transport: "usb",
 		Port:      "/dev/cu.usbserial10",
 		AssumeYes: true,
 		SkipFlash: true,
@@ -581,7 +627,7 @@ func TestRunWithDepsFailsWithRecoveryWhenCodexbarInstallNotPossible(t *testing.T
 }
 
 func TestRunWithDepsRejectsInvalidInteractivePortSelection(t *testing.T) {
-	err := runWithDeps(context.Background(), Options{SkipFlash: true}, deps{
+	err := runWithDeps(context.Background(), Options{Transport: "usb", SkipFlash: true}, deps{
 		stdin:  strings.NewReader("9\n"),
 		stdout: &bytes.Buffer{},
 		executablePath: func() (string, error) {
@@ -633,7 +679,7 @@ func TestRunWithDepsReportsFlashFailureWithConcreteHint(t *testing.T) {
 	mustWriteFile(t, filepath.Join(repo, "companion", "go.mod"), []byte("module test"), 0o644)
 	mustWriteFile(t, execPath, []byte("binary-content"), 0o755)
 
-	err := runWithDeps(context.Background(), Options{AssumeYes: true}, deps{
+	err := runWithDeps(context.Background(), Options{Transport: "usb", AssumeYes: true}, deps{
 		stdin:  strings.NewReader(""),
 		stdout: &bytes.Buffer{},
 		cwd: func() (string, error) {
@@ -697,7 +743,7 @@ func TestRunWithDepsWaitsForLaunchAgentToBecomeRunning(t *testing.T) {
 
 	printAttempts := 0
 
-	err := runWithDeps(context.Background(), Options{AssumeYes: true}, deps{
+	err := runWithDeps(context.Background(), Options{Transport: "usb", AssumeYes: true}, deps{
 		stdin:  strings.NewReader(""),
 		stdout: &bytes.Buffer{},
 		cwd: func() (string, error) {
@@ -757,7 +803,7 @@ func TestRunWithDepsRetriesLaunchAgentBootstrapRace(t *testing.T) {
 
 	bootstrapAttempts := 0
 
-	err := runWithDeps(context.Background(), Options{Port: "/dev/cu.usbserial10", AssumeYes: true, SkipFlash: true}, deps{
+	err := runWithDeps(context.Background(), Options{Transport: "usb", Port: "/dev/cu.usbserial10", AssumeYes: true, SkipFlash: true}, deps{
 		stdin:  strings.NewReader(""),
 		stdout: &bytes.Buffer{},
 		cwd: func() (string, error) {
@@ -826,7 +872,7 @@ func TestRunWithDepsFallsBackToKickstartWhenLaunchAgentAlreadyLoaded(t *testing.
 
 	kickstartCalled := false
 
-	err := runWithDeps(context.Background(), Options{Port: "/dev/cu.usbserial10", AssumeYes: true, SkipFlash: true}, deps{
+	err := runWithDeps(context.Background(), Options{Transport: "usb", Port: "/dev/cu.usbserial10", AssumeYes: true, SkipFlash: true}, deps{
 		stdin:  strings.NewReader(""),
 		stdout: &bytes.Buffer{},
 		cwd: func() (string, error) {
@@ -883,6 +929,7 @@ func TestRunWithDepsStopsLaunchAgentBeforeSerialProbe(t *testing.T) {
 	bootoutCalled := false
 
 	err := runWithDeps(context.Background(), Options{
+		Transport: "usb",
 		Port:      "/dev/cu.usbserial10",
 		AssumeYes: true,
 		SkipFlash: true,
@@ -945,6 +992,7 @@ func TestRunWithDepsSkipsSerialProbeOnFlashPath(t *testing.T) {
 	probeCalled := false
 
 	err := runWithDeps(context.Background(), Options{
+		Transport: "usb",
 		Port:      "/dev/cu.usbserial10",
 		AssumeYes: true,
 	}, deps{
@@ -1006,6 +1054,7 @@ func TestRunWithDepsUsesEsp8266FirmwareProjectForEsp8266Environment(t *testing.T
 
 	var pioCall *commandCall
 	err := runWithDeps(context.Background(), Options{
+		Transport:   "usb",
 		AssumeYes:   true,
 		FirmwareEnv: "esp8266_smalltv_st7789",
 	}, deps{
@@ -1078,6 +1127,7 @@ func TestRunWithDepsValidateOnlyPerformsChecksWithoutApplyingChanges(t *testing.
 
 	var calls []commandCall
 	err := runWithDeps(context.Background(), Options{
+		Transport:     "usb",
 		AssumeYes:     true,
 		ValidateOnly:  true,
 		FirmwareEnv:   "esp8266_smalltv_st7789",
@@ -1236,6 +1286,7 @@ func TestRunWithDepsFailsWhenDetectedBoardMismatchesFirmwareEnvironment(t *testi
 	mustWriteFile(t, execPath, []byte("binary-content"), 0o755)
 
 	err := runWithDeps(context.Background(), Options{
+		Transport:   "usb",
 		AssumeYes:   true,
 		SkipFlash:   true,
 		FirmwareEnv: "esp8266_smalltv_st7789",

--- a/docs/customer-setup.md
+++ b/docs/customer-setup.md
@@ -34,7 +34,7 @@ Your job:
 - Assume I want the standard setup flow on macOS.
 - If you have terminal or tool access, do the setup yourself instead of asking me to copy commands.
 - Use the official installer:
-  curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --transport wifi --target http://vibetv.local --theme mini
+  curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash
 - After running it, verify that the setup worked.
 - Only if you cannot run commands yourself, explain exactly what I should do in simple ELI5 language, one small step at a time.
 
@@ -47,7 +47,7 @@ If something fails, troubleshoot in this order:
 - confirm the Vibe TV IP address
 - confirm the Mac is on the same WiFi
 - rerun the installer
-- check the daemon target with --transport wifi --target http://vibetv.local
+- check that the daemon target is http://vibetv.local
 
 If you cannot act directly, do not dump a long checklist. Give me only the next action, wait for the result, and then continue.
 ```
@@ -58,26 +58,20 @@ Open `http://vibetv.local` in your browser and select `Copy Mac Setup Command`.
 Then open Terminal and paste the copied command. It looks like this:
 
 ```bash
-curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --transport wifi --target http://vibetv.local --theme mini
+curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash
 ```
 
-The Web UI also shows the fallback IP if `.local` does not resolve.
+The installer defaults to WiFi, `http://vibetv.local`, and the Mini theme. The Web UI also shows the fallback IP if `.local` does not resolve.
 
-### Firmware update path
+### Update path
 
-If support asks you to update the firmware, run:
+If support asks you to update the Mac Companion, rerun:
 
 ```bash
-curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --flash-firmware
+curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash
 ```
 
-Firmware flashing requires PlatformIO CLI (`pio`). If it is missing, the installer will stop with a recovery hint.
-
-If you need to use a specific serial port, run:
-
-```bash
-curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --flash-firmware -- --port /dev/cu.usbserial-110
-```
+Firmware updates are handled by support over the Vibe TV web updater. USB flashing is not part of the customer flow.
 
 ## What the Installer Does
 
@@ -87,10 +81,9 @@ The installer handles everything automatically:
 2. It downloads the matching `codexbar-display` version from the latest GitHub release.
 3. It verifies the checksum.
 4. It installs CodexBar if CodexBar is missing.
-5. It runs `codexbar-display setup --yes --skip-flash --transport wifi --target http://vibetv.local --theme mini`.
+5. It runs `codexbar-display setup --yes --skip-flash`.
 6. It starts the background service that sends frames to the Vibe TV IP.
-7. If `--flash-firmware` is passed, it downloads the matching firmware from the GitHub release, verifies it, and flashes the connected device.
-8. It runs a health check at the end.
+7. It runs a health check at the end.
 
 ## What Success Looks Like
 
@@ -117,4 +110,4 @@ If the device is not reachable, unplug power during early boot three times in a 
 
 - The standard setup flow is for macOS.
 - You do not need to flash firmware manually in the standard setup flow.
-- USB-C is used for power in the standard setup flow. USB serial remains available for development and support.
+- USB-C is used for power in the standard setup flow. USB serial is only for development and support.

--- a/docs/hardware-contract.md
+++ b/docs/hardware-contract.md
@@ -41,7 +41,7 @@ Companion negotiation:
 - Setup UI is served at `http://vibetv.local`. In setup mode this is backed by AP mDNS plus captive DNS; `http://192.168.4.1` remains the fallback address.
 - The setup flow stores home WiFi credentials and restarts the device.
 - Connected devices expose `http://vibetv.local` with mDNS, show/log the fallback IP, serve a local setup hub with a copyable Mac setup command, and wait for the Mac Companion.
-- Companion runtime command: `codexbar-display daemon --transport wifi --target http://<device-ip>`.
+- Companion runtime defaults to WiFi with `http://vibetv.local`; explicit device IPs remain supported when `.local` does not resolve.
 - Saved WiFi credentials can be cleared from the local web UI with `POST /reset-wifi`.
 - If the device is not reachable on WiFi, three interrupted early boots clear saved WiFi credentials and return the device to `VibeTV-Setup`.
 - Generic theme assets can be managed over WiFi with `GET /assets`, `POST /assets?path=...`, and `DELETE /assets?path=...`.

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -49,14 +49,29 @@ Behavior:
 
 ## Setup
 
-`setup` is idempotent and handles the common serial busy case by stopping the LaunchAgent
-before flash operations.
+`setup` is idempotent. The default LaunchAgent runtime is WiFi and targets `http://vibetv.local`.
+USB setup is an explicit development/support path.
 
-### Default firmware target (ESP8266 SmallTV)
+### Default WiFi runtime
 
 ```bash
 cd companion
 ../codexbar-display setup --yes
+```
+
+This installs the companion runtime, persists the Mini theme on fresh installs, and writes a WiFi LaunchAgent.
+It does not require USB serial.
+
+### USB development flash path
+
+Use only when a device is physically attached with a working data-capable USB serial connection:
+
+```bash
+cd companion
+../codexbar-display setup --yes \
+  --transport usb \
+  --port /dev/cu.usbserial-10 \
+  --firmware-env esp8266_smalltv_st7789
 ```
 
 ### ESP32-S3 target (override)
@@ -66,6 +81,7 @@ Experimental fallback path (non-blocking):
 ```bash
 cd companion
 ../codexbar-display setup --yes \
+  --transport usb \
   --port /dev/cu.usbmodem101 \
   --firmware-env lilygo_t_display_s3
 ```

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -408,10 +408,8 @@ String setupPageHTML() {
 String connectedPageHTML() {
   const String ip = WiFi.localIP().toString();
   String setupCommand;
-  setupCommand.reserve(220);
-  setupCommand += "curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --transport wifi --target http://";
-  setupCommand += kMdnsHost;
-  setupCommand += " --theme mini";
+  setupCommand.reserve(120);
+  setupCommand += "curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash";
 
   String html;
   html.reserve(2600);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,9 +37,7 @@ What it does:
 
 Examples:
   curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash
-  curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --transport wifi --target http://vibetv.local --theme mini
-  curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --port /dev/cu.usbserial-110
-  curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --flash-firmware -- --port /dev/cu.usbserial-110
+  curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --target http://vibetv.local --theme mini
   curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash -s -- --version 1.0.0
 EOF
 }


### PR DESCRIPTION
## Summary
- Make WiFi the default companion setup and daemon transport with `http://vibetv.local` as the default target.
- Keep USB available only as an explicit development/support override via `--transport usb`.
- Simplify the customer installer command in README, customer setup docs, installer help, and the Vibe TV Web UI copy button.
- Update setup tests and operator docs around the new WiFi-first launch behavior.

## Validation
- `cd companion && go test ./...`
- `cd companion && go vet ./...`
- `pio run -d firmware_esp8266 -e esp8266_smalltv_st7789`
- `cd companion && go run ./cmd/codexbar-display setup --dry-run --yes`
