### PR TITLE
CODEX Add WiFi reconnect setup fallback

### DIFF
--- a/docs/customer-setup.md
+++ b/docs/customer-setup.md
@@ -96,6 +96,7 @@ The installer handles everything automatically:
 - `Open Setup` means Vibe TV is on WiFi and is waiting for the Mac Companion setup command.
 - `Check Mac App` means Vibe TV had data before, but no fresh frame arrived for more than two minutes.
 - `Update Mac App` means the Mac Companion can reach Vibe TV, but the usage app needs an update.
+- `Reconnecting WiFi` means Vibe TV lost WiFi and is retrying. If WiFi does not recover, it starts the `VibeTV-Setup` hotspot again.
 - If WiFi sending fails, verify `http://vibetv.local` opens from the Mac. The API check is `http://vibetv.local/hello`.
 - If the IP changed, rerun the installer with the new `--target`.
 - If CodexBar is missing or does not start, run the installer again.

--- a/docs/hardware-contract.md
+++ b/docs/hardware-contract.md
@@ -43,6 +43,7 @@ Companion negotiation:
 - Connected devices expose `http://vibetv.local` with mDNS, show/log the fallback IP, serve a local setup hub with a copyable Mac setup command, and wait for the Mac Companion.
 - Companion runtime defaults to WiFi with `http://vibetv.local`; explicit device IPs remain supported when `.local` does not resolve.
 - Saved WiFi credentials can be cleared from the local web UI with `POST /reset-wifi`.
+- If a connected device loses WiFi, it retries in station mode first. After a persistent outage it starts `VibeTV-Setup` again so the user can choose a different network.
 - If the device is not reachable on WiFi, three interrupted early boots clear saved WiFi credentials and return the device to `VibeTV-Setup`.
 - Generic theme assets can be managed over WiFi with `GET /assets`, `POST /assets?path=...`, and `DELETE /assets?path=...`.
 

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -37,6 +37,8 @@ constexpr size_t kBootRecoveryOffset = kWifiCredsBytes;
 constexpr size_t kBootRecoveryBytes = 5;
 constexpr size_t kEepromBytes = kWifiCredsBytes + kBootRecoveryBytes;
 constexpr unsigned long kWifiConnectTimeoutMs = 20000UL;
+constexpr unsigned long kWifiReconnectRetryMs = 5000UL;
+constexpr unsigned long kWifiReconnectFallbackMs = 120000UL;
 constexpr unsigned long kRebootDelayMs = 750UL;
 constexpr unsigned long kBootRecoveryStableMs = 30000UL;
 constexpr unsigned long kFrameStaleWarningMs = 150000UL;
@@ -69,6 +71,9 @@ unsigned long lastFrameAcceptedAtMs = 0;
 bool frameStaleStatusRendered = false;
 bool captiveDnsStarted = false;
 bool mdnsStarted = false;
+unsigned long wifiDisconnectedAtMs = 0;
+unsigned long wifiReconnectAttemptAtMs = 0;
+bool wifiReconnectStatusRendered = false;
 
 String jsonEscape(const String& raw) {
   String escaped;
@@ -102,6 +107,12 @@ String jsonEscape(const String& raw) {
 void drawWaitingForCompanionStatus() {
   renderer.DrawConnectedSetupInstructions(runtimeCtx, kMdnsHost);
   waitStatusRendered = true;
+}
+
+void resetWifiReconnectState() {
+  wifiDisconnectedAtMs = 0;
+  wifiReconnectAttemptAtMs = 0;
+  wifiReconnectStatusRendered = false;
 }
 
 void startMdnsResponder(const IPAddress& address) {
@@ -967,6 +978,7 @@ void startHttpServer() {
 
 void startSetupAccessPoint() {
   setupMode = true;
+  resetWifiReconnectState();
   scanSetupNetworks();
   WiFi.mode(WIFI_AP);
   WiFi.softAP(kSetupApSsid);
@@ -978,6 +990,49 @@ void startSetupAccessPoint() {
   waitStatusRendered = true;
   startHttpServer();
   startMdnsResponder(WiFi.softAPIP());
+}
+
+void maintainWifiConnection() {
+  if (setupMode || rebootPending) {
+    return;
+  }
+  if (WiFi.status() == WL_CONNECTED) {
+    if (wifiDisconnectedAtMs != 0) {
+      Serial.printf("wifi_reconnected ip=%s\n", WiFi.localIP().toString().c_str());
+      drawWaitingForCompanionStatus();
+    }
+    resetWifiReconnectState();
+    return;
+  }
+
+  const unsigned long nowMs = millis();
+  if (wifiDisconnectedAtMs == 0) {
+    wifiDisconnectedAtMs = nowMs;
+    wifiReconnectAttemptAtMs = 0;
+    Serial.printf("wifi_disconnected status=%d fallback_ms=%lu\n",
+                  static_cast<int>(WiFi.status()),
+                  kWifiReconnectFallbackMs);
+  }
+
+  if (!wifiReconnectStatusRendered) {
+    renderer.DrawStatus(runtimeCtx, "VIBE TV", "Reconnecting WiFi", "Please wait");
+    wifiReconnectStatusRendered = true;
+  }
+
+  if (wifiReconnectAttemptAtMs == 0 || (nowMs - wifiReconnectAttemptAtMs) >= kWifiReconnectRetryMs) {
+    wifiReconnectAttemptAtMs = nowMs;
+    WiFi.reconnect();
+    Serial.printf("wifi_reconnect_attempt status=%d elapsed_ms=%lu\n",
+                  static_cast<int>(WiFi.status()),
+                  nowMs - wifiDisconnectedAtMs);
+  }
+
+  if ((nowMs - wifiDisconnectedAtMs) >= kWifiReconnectFallbackMs) {
+    Serial.println("wifi_reconnect_failed action=setup_ap");
+    renderer.DrawStatus(runtimeCtx, "VIBE TV SETUP", "WiFi unavailable", "Starting setup");
+    delay(750);
+    startSetupAccessPoint();
+  }
 }
 
 #ifdef CODEXBAR_DISPLAY_RUNTIME_BENCH
@@ -1066,6 +1121,8 @@ void loop() {
   if (codexbar_display::app::ConsumeSerial(runtimeCtx, true, millis(), event)) {
     markFrameAccepted(event, "usb");
   }
+
+  maintainWifiConnection();
 
   if (codexbar_display::app::HasFrame(runtimeCtx) &&
       !codexbar_display::app::CurrentFrame(runtimeCtx).hasError &&


### PR DESCRIPTION
## Summary
- Add a firmware WiFi watchdog for connected Vibe TV devices.
- Retry station reconnects every 5 seconds after WiFi is lost.
- After 2 minutes without reconnecting, start the `VibeTV-Setup` hotspot again so the user can choose another network.
- Document the new `Reconnecting WiFi` status.

## Validation
- `pio run -d firmware_esp8266 -e esp8266_smalltv_st7789`
- `cd companion && go test ./...`
- `cd companion && go vet ./...`
