### PR TITLE
Show fallback IP on VibeTV setup screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Vibe TV ships ready for WiFi setup.
 2. Join the `VibeTV-Setup` WiFi hotspot from your Mac or phone.
 3. If your device opens a setup browser automatically, use it. Otherwise open `http://vibetv.local`. If that does not load, open `http://192.168.4.1`.
 4. Choose your home WiFi, enter the password, and save.
-5. After Vibe TV restarts, the display shows `Open Setup` and `vibetv.local`.
-6. Open `http://vibetv.local` in your browser and select `Copy Mac Setup Command`.
+5. After Vibe TV restarts, the display shows `vibetv.local` plus a fallback IP address.
+6. Open `http://vibetv.local` in your browser. If that does not load, use the fallback IP shown on the display. Then select `Copy Mac Setup Command`.
 7. Open Terminal (on Mac: Cmd + Space, type Terminal, hit enter), paste the copied command, and press Enter.
 
 ```bash

--- a/docs/customer-setup.md
+++ b/docs/customer-setup.md
@@ -17,7 +17,7 @@ Vibe TV ships with firmware installed. USB debugging and manual firmware flashin
 3. Join `VibeTV-Setup` from your Mac or phone.
 4. If your device opens a setup browser automatically, use it. Otherwise open `http://vibetv.local`. If that does not load, open `http://192.168.4.1`.
 5. Select your home WiFi, enter the password, and save.
-6. Vibe TV restarts and connects to your WiFi. The display shows `Open Setup` and `vibetv.local`.
+6. Vibe TV restarts and connects to your WiFi. The display shows `vibetv.local` plus a fallback IP address.
 
 ## Install the Mac Companion
 
@@ -54,7 +54,7 @@ If you cannot act directly, do not dump a long checklist. Give me only the next 
 
 ### Alternative: run the installer directly
 
-Open `http://vibetv.local` in your browser and select `Copy Mac Setup Command`.
+Open `http://vibetv.local` in your browser. If that does not load, use the fallback IP shown on the Vibe TV display. Then select `Copy Mac Setup Command`.
 Then open Terminal and paste the copied command. It looks like this:
 
 ```bash

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -184,7 +184,7 @@ Per device:
 - confirm `/health`, `/hello`, `/assets`, LittleFS upload, and the `mini` smoke frame pass
 
 During normal operation the display uses explicit support states:
-- `Open Setup`: WiFi is connected and the device is waiting for the Mac Companion setup command. `vibetv.local` is shown on-screen; the local Web UI also shows the fallback IP.
+- `Open Setup`: WiFi is connected and the device is waiting for the Mac Companion setup command. `vibetv.local` and the fallback IP are shown on-screen; the local Web UI also shows the fallback IP.
 - `Check Mac App`: the device previously had data, but no fresh frame arrived for more than two minutes.
 - `Update Mac App`: the Companion reported an incompatible usage app version or payload format.
 

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -105,7 +105,7 @@ String jsonEscape(const String& raw) {
 }
 
 void drawWaitingForCompanionStatus() {
-  renderer.DrawConnectedSetupInstructions(runtimeCtx, kMdnsHost);
+  renderer.DrawConnectedSetupInstructions(runtimeCtx, kMdnsHost, WiFi.localIP().toString());
   waitStatusRendered = true;
 }
 

--- a/firmware_esp8266/src/renderer_esp8266.cpp
+++ b/firmware_esp8266/src/renderer_esp8266.cpp
@@ -216,7 +216,10 @@ void RendererESP8266::DrawSetupInstructions(app::RuntimeContext& ctx, const Stri
 #endif
 }
 
-void RendererESP8266::DrawConnectedSetupInstructions(app::RuntimeContext& ctx, const String& ip) {
+void RendererESP8266::DrawConnectedSetupInstructions(
+    app::RuntimeContext& ctx,
+    const String& host,
+    const String& fallbackIp) {
 #ifndef CODEXBAR_DISPLAY_PROBE_ONLY
   display::AttachContext(ctx);
   display::StopMiniGifPlayback();
@@ -229,16 +232,21 @@ void RendererESP8266::DrawConnectedSetupInstructions(app::RuntimeContext& ctx, c
   const char* title = "VIBE TV";
   const char* action = "Open this address";
   const char* detail = "in your browser";
+  const char* fallback = "Fallback IP:";
   const int titleSize = display::ChooseTextSizeToFit(title, 3, 2, tft.width() - 8);
-  const int ipSize = display::ChooseTextSizeToFit(ip.c_str(), 3, 2, tft.width() - 8);
+  const int hostSize = display::ChooseTextSizeToFit(host.c_str(), 3, 2, tft.width() - 8);
   const int actionSize = display::ChooseTextSizeToFit(action, 2, 1, tft.width() - 14);
   const int detailSize = display::ChooseTextSizeToFit(detail, 2, 1, tft.width() - 14);
+  const int fallbackSize = display::ChooseTextSizeToFit(fallback, 2, 1, tft.width() - 14);
+  const int fallbackIpSize = display::ChooseTextSizeToFit(fallbackIp.c_str(), 2, 1, tft.width() - 8);
 
   const int totalH =
       display::TextPixelHeight(titleSize) + 12 +
       display::TextPixelHeight(actionSize) + 4 +
       display::TextPixelHeight(detailSize) + 8 +
-      display::TextPixelHeight(ipSize);
+      display::TextPixelHeight(hostSize) + 10 +
+      display::TextPixelHeight(fallbackSize) + 4 +
+      display::TextPixelHeight(fallbackIpSize);
   int y = (tft.height() - totalH) / 2;
   if (y < 6) {
     y = 6;
@@ -262,17 +270,29 @@ void RendererESP8266::DrawConnectedSetupInstructions(app::RuntimeContext& ctx, c
   tft.print(detail);
 
   y += display::TextPixelHeight(detailSize) + 8;
-  display::SetClassicTextSize(ipSize);
+  display::SetClassicTextSize(hostSize);
   tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
-  tft.setCursor(display::CenteredTextX(ip.c_str(), ipSize), y);
-  tft.print(ip);
+  tft.setCursor(display::CenteredTextX(host.c_str(), hostSize), y);
+  tft.print(host);
+
+  y += display::TextPixelHeight(hostSize) + 10;
+  display::SetClassicTextSize(fallbackSize);
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  tft.setCursor(display::CenteredTextX(fallback, fallbackSize), y);
+  tft.print(fallback);
+
+  y += display::TextPixelHeight(fallbackSize) + 4;
+  display::SetClassicTextSize(fallbackIpSize);
+  tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+  tft.setCursor(display::CenteredTextX(fallbackIp.c_str(), fallbackIpSize), y);
+  tft.print(fallbackIp);
 
   ctx.lastRenderedSecs = -1;
   ctx.lastRenderedMinuteBucket = -1;
   ctx.screenDirty = false;
 #else
   (void)ctx;
-  Serial.printf("probe_connected_setup ip=%s\n", ip.c_str());
+  Serial.printf("probe_connected_setup host=%s fallback_ip=%s\n", host.c_str(), fallbackIp.c_str());
 #endif
 }
 

--- a/firmware_esp8266/src/renderer_esp8266.h
+++ b/firmware_esp8266/src/renderer_esp8266.h
@@ -16,7 +16,7 @@ class RendererESP8266 : public app::Renderer {
   void TickSplash(app::RuntimeContext& ctx) override;
   void DrawStatus(app::RuntimeContext& ctx, const String& title, const String& line1, const String& line2);
   void DrawSetupInstructions(app::RuntimeContext& ctx, const String& ssid, const String& address);
-  void DrawConnectedSetupInstructions(app::RuntimeContext& ctx, const String& ip);
+  void DrawConnectedSetupInstructions(app::RuntimeContext& ctx, const String& host, const String& fallbackIp);
   void TickActive(app::RuntimeContext& ctx) override;
   void DrawError(app::RuntimeContext& ctx, const String& message) override;
   void DrawUsage(app::RuntimeContext& ctx) override;


### PR DESCRIPTION
## Summary
- show the fallback IP directly on the connected setup screen below vibetv.local
- keep docs aligned with the fallback-IP customer flow

Fixes #58

## Tests
- CODEXBAR_DISPLAY_FW_VERSION=1.0.10 pio run -d firmware_esp8266 -e esp8266_smalltv_st7789
- cd companion && go test ./...