### PR TITLE
Harden VibeTV provisioning and display diagnostics

### DIFF
--- a/docs/customer-setup.md
+++ b/docs/customer-setup.md
@@ -91,6 +91,23 @@ The installer handles everything automatically:
 - The device no longer stays on the Open Setup screen.
 - Usage appears automatically on the display.
 
+## Display Messages
+
+The small display uses short English status messages:
+
+| Display | Meaning | What to do |
+| --- | --- | --- |
+| `Starting` | Vibe TV is booting. | Wait. |
+| `Join WiFi` / `VibeTV-Setup` | Vibe TV is in setup mode. | Join the `VibeTV-Setup` WiFi and open the browser address shown on the display. |
+| `Connecting WiFi` | Vibe TV is joining your home WiFi. | Wait. |
+| `Open Setup` | WiFi works; Vibe TV is waiting for the Mac Companion setup. | Open the shown browser address or run the Mac setup command. |
+| `Check Mac App` | Vibe TV had data before, but no fresh data arrived. | Check that the Mac is on, CodexBar is running, and the Mac is on the same WiFi. |
+| `Update Mac App` | The Mac app reached Vibe TV, but the app is too old or sent an old format. | Rerun the installer. |
+| `Update running` | Firmware or display assets are being updated. | Do not unplug power. |
+| `WiFi reset` | Saved WiFi settings are being cleared. | Wait for `VibeTV-Setup` to appear again. |
+
+The setup screen shows the setup IP. The waiting screen shows `vibetv.local` and the fallback IP, so support can ask for the address directly from the display.
+
 ## If Something Does Not Work
 
 - `Open Setup` means Vibe TV is on WiFi and is waiting for the Mac Companion setup command.

--- a/docs/firmware-provisioning.md
+++ b/docs/firmware-provisioning.md
@@ -27,7 +27,7 @@ The package is written to `dist/vibetv-ota/<timestamp>-esp8266_smalltv_st7789/` 
 - `firmware.bin`
 - `littlefs.bin`
 - `SHA256SUMS`
-- `manifest.json`
+- `manifest.json` with required theme asset paths, byte sizes, and SHA-256 hashes
 
 Use a fixed output directory when the same artifact set should be reused across a provisioning run:
 
@@ -64,21 +64,23 @@ What this does:
 1. Builds `firmware.bin` and `littlefs.bin`.
 2. Verifies `SHA256SUMS`.
 3. Uploads `firmware.bin` to the GeekMagic factory endpoint with multipart field `firmware`.
-4. Waits for the new firmware to answer `/health` and `/hello`.
+4. Waits for the new firmware to answer `/health`, `/hello`, and `/assets`.
 5. Uploads `littlefs.bin` to the VibeTV endpoint with multipart field `filesystem`.
-6. Checks `/health` and `/hello` again.
-7. Checks `/assets` and requires the runtime theme assets for the bundled theme.
+6. Checks `/health`, `/hello`, and `/assets` again.
+7. Compares the runtime theme asset metadata from `/assets` against the package `manifest.json`.
 8. Sends one `mini` frame to `/frame` and requires `ok`.
 
-`/health` reports generic filesystem status. `/assets` is the generic inspection path for future theme-pack tooling.
+`/health` reports generic filesystem status plus display debug state. `display.activeTheme` names the active built-in theme, and `display.gif` reports the active GIF path, file/decoder open state, backoff state, and `lastError` when GIF open or decode fails. `/assets` is the generic inspection path for future theme-pack tooling. Each asset entry must include `path`, `sizeBytes`, and `sha256`. Required assets must be present, non-empty, byte-exact, and hash-exact compared with the package manifest.
 
-For devices that close the HTTP connection while rebooting, add:
+The filesystem upload timeout defaults to 300 seconds because slow ESP8266 LittleFS writes can outlive a normal short HTTP timeout. Firmware uploads default to 90 seconds.
+
+Devices can close the HTTP connection while rebooting. The script classifies curl exit 52/56 as a reboot-related close by default, then continues to the post-upload `/health`, `/hello`, and `/assets` checks. Those checks still decide pass/fail. To fail immediately on that curl status instead, add:
 
 ```bash
---allow-reboot-close
+--strict-upload-response
 ```
 
-That treats curl exit 52/56 as an expected reboot close and continues with polling.
+Every failed run prints `provision: FAIL stage=...` so the failing phase is visible: upload, reboot wait, health check, asset verification, or smoke frame. Successful runs end with `provision: PASS`.
 
 ## Reuse a Built Package
 
@@ -94,7 +96,7 @@ For additional devices, keep the package and change only the IP:
 
 Repeat for each device that should receive the same firmware and filesystem artifacts.
 
-The provisioning wrapper is intentionally strict: a device is not accepted if `/hello` reports the wrong board, the filesystem is not mounted, a required asset is missing, or a smoke frame is rejected by `/frame`.
+The provisioning wrapper is intentionally strict: a device is not accepted if `/hello` reports the wrong board, the filesystem is not mounted, a required asset is missing, empty, has the wrong size, has the wrong SHA-256, a smoke frame is rejected by `/frame`, or `/health` reports a mini GIF renderer error after the smoke frame.
 
 ## Endpoint Overrides
 

--- a/docs/hardware-contract.md
+++ b/docs/hardware-contract.md
@@ -46,10 +46,13 @@ Companion negotiation:
 - If a connected device loses WiFi, it retries in station mode first. After a persistent outage it starts `VibeTV-Setup` again so the user can choose a different network.
 - If the device is not reachable on WiFi, three interrupted early boots clear saved WiFi credentials and return the device to `VibeTV-Setup`.
 - Generic theme assets can be managed over WiFi with `GET /assets`, `POST /assets?path=...`, and `DELETE /assets?path=...`.
+- `GET /assets` returns `filesystem.mounted` plus an `assets` array. Every asset entry includes `path`, `sizeBytes`, and `sha256` so provisioning can verify content integrity instead of only checking that a filename exists.
+- `GET /health` returns `display.activeTheme` and `display.gif` so provisioning can see the active GIF path, file/decoder open state, backoff state, and the last GIF open/decode error.
 
 ## Theme Contract
 - Built-in runtime themes: `classic`, `crt`, `mini`.
 - Theme assets are stored as data files in LittleFS and are not hardcoded into the transport protocol.
+- OTA package manifests list required theme assets separately from theme packs. Provisioning compares device `/assets` metadata against that manifest and rejects missing, empty, wrong-size, or wrong-hash required assets.
 - Capability-aware behavior:
   - known + unsupported `theme` => host omits `theme`
   - unknown hello => optimistic `theme` send remains allowed

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -184,11 +184,29 @@ Per device:
 - confirm `/health`, `/hello`, `/assets`, LittleFS upload, and the `mini` smoke frame pass
 
 During normal operation the display uses explicit support states:
+- `Starting`: boot is running before WiFi mode is known.
+- `VIBE TV SETUP` with `VibeTV-Setup` and the setup IP: setup AP is active; customer should join the setup WiFi and open the shown address.
+- `Connecting WiFi`: station mode is connecting to the saved or imported SSID.
 - `Open Setup`: WiFi is connected and the device is waiting for the Mac Companion setup command. `vibetv.local` and the fallback IP are shown on-screen; the local Web UI also shows the fallback IP.
+- Live usage: a valid USB or WiFi frame is rendering; provider/usage data is shown, not theme asset names.
 - `Check Mac App`: the device previously had data, but no fresh frame arrived for more than two minutes.
 - `Update Mac App`: the Companion reported an incompatible usage app version or payload format.
+- `Update running`: firmware, filesystem, or display asset upload is in progress. The display intentionally does not show internal paths such as GIF or theme asset filenames.
+- `WiFi reset`: saved WiFi credentials are being cleared before setup mode restarts.
 
-Before packaging a device for a customer, clear local provisioning WiFi credentials with `POST /reset-wifi` while the device is still reachable. After reboot, the display must show both setup steps on one screen: connect to `VibeTV-Setup`, then open `vibetv.local` in a browser. `192.168.4.1` remains the fallback address.
+Before packaging a device for a customer, clear local provisioning WiFi credentials with `POST /reset-wifi` while the device is still reachable. After reboot, the display must show both setup steps on one screen: connect to `VibeTV-Setup`, then open the shown setup IP in a browser. The web setup flow still supports `vibetv.local`, with `192.168.4.1` as the fallback address in setup AP mode.
+
+QR codes are deferred. They would be useful on the setup and connected screens, but adding QR generation to the ESP8266 firmware is a larger dependency and rendering-risk item. Keep the plain IP/host display as the supported customer path for now.
+
+Smoke checklist for #53:
+- Boot device and confirm the first screen says `Starting`.
+- Clear WiFi and confirm setup AP screen shows `VibeTV-Setup` plus the setup IP.
+- Save WiFi and confirm the connecting screen shows `Connecting WiFi` plus the SSID.
+- After WiFi connects, confirm the waiting screen shows `Open Setup`, `vibetv.local`, and the fallback IP.
+- Send a USB frame and a WiFi `/frame` frame and confirm normal usage rendering still appears.
+- Stop the Companion for more than two minutes after a frame and confirm `Check Mac App`.
+- Send a runtime error frame and confirm the display shows a customer-friendly CodexBar action, not an internal error code.
+- Start firmware/filesystem/asset upload and confirm the display says `Update running` without asset paths.
 
 Full flow and endpoint overrides are documented in `docs/firmware-provisioning.md`.
 

--- a/firmware_esp8266/src/gif_core_esp8266.cpp
+++ b/firmware_esp8266/src/gif_core_esp8266.cpp
@@ -51,6 +51,20 @@ void GifCoreESP8266::ResetFrameSchedule() {
   nextFrameAtMs_ = 0;
 }
 
+void GifCoreESP8266::ResetForAssetUpdate() {
+  Stop();
+  fsMounted_ = false;
+  filePresent_ = false;
+  assetPath_ = "";
+  lastErrorPath_ = "";
+  lastErrorStage_ = "";
+  lastErrorFailures_ = 0;
+  lastFailureAtMs_ = 0;
+  for (uint8_t i = 0; i < kFailureGuardSlots; ++i) {
+    guards_[i] = GifFailureGuard();
+  }
+}
+
 GifCoreESP8266::GifFailureGuard& GifCoreESP8266::GuardForSlot(GifFailureSlot slot) {
   uint8_t idx = static_cast<uint8_t>(slot);
   if (idx >= kFailureGuardSlots) {
@@ -71,6 +85,10 @@ void GifCoreESP8266::NoteFailure(GifFailureSlot slot, const char* path, const ch
                                             ? static_cast<unsigned int>(
                                                   failuresBefore + (failuresBefore < 255 ? 1 : 0))
                                             : static_cast<unsigned int>(guard.consecutiveFailures);
+  lastErrorPath_ = path;
+  lastErrorStage_ = stage != nullptr ? stage : "unknown";
+  lastErrorFailures_ = reportedFailures;
+  lastFailureAtMs_ = millis();
 
   Serial.printf(
       "gif_playback_failure path=%s stage=%s failures=%u\n",
@@ -91,6 +109,10 @@ void GifCoreESP8266::NoteSuccess(GifFailureSlot slot, const char* path) {
   }
   GifFailureGuard& guard = GuardForSlot(slot);
   GifCorePolicy::RecordSuccess(guard);
+  lastErrorPath_ = "";
+  lastErrorStage_ = "";
+  lastErrorFailures_ = 0;
+  lastFailureAtMs_ = 0;
 }
 
 bool GifCoreESP8266::IsBlocked(GifFailureSlot slot, const char* path) {
@@ -300,6 +322,32 @@ bool GifCoreESP8266::IsCurrentAssetPresent(const char* assetPath) const {
     return false;
   }
   return filePresent_;
+}
+
+GifCoreStatusSnapshot GifCoreESP8266::StatusSnapshot() const {
+  GifCoreStatusSnapshot snapshot;
+  snapshot.activePath = assetPath_;
+  snapshot.fsMounted = fsMounted_;
+  snapshot.filePresent = filePresent_;
+  snapshot.fileOpen = static_cast<bool>(file_);
+  snapshot.decoderOpen = decoderOpen_;
+  snapshot.lastErrorPath = lastErrorPath_;
+  snapshot.lastErrorStage = lastErrorStage_;
+  snapshot.lastErrorFailures = lastErrorFailures_;
+
+  const unsigned long now = millis();
+  const GifFailureGuard& guard = guards_[static_cast<uint8_t>(failureSlot_) < kFailureGuardSlots
+                                             ? static_cast<uint8_t>(failureSlot_)
+                                             : 0];
+  snapshot.consecutiveFailures = guard.consecutiveFailures;
+  if (guard.backoffUntilMs != 0 && static_cast<long>(now - guard.backoffUntilMs) < 0) {
+    snapshot.blocked = true;
+    snapshot.backoffRemainingMs = guard.backoffUntilMs - now;
+  }
+  if (lastFailureAtMs_ != 0) {
+    snapshot.lastErrorAgeMs = now - lastFailureAtMs_;
+  }
+  return snapshot;
 }
 
 void* GifCoreESP8266::OpenCallback(const char* filename, int32_t* fileSize) {

--- a/firmware_esp8266/src/gif_core_esp8266.h
+++ b/firmware_esp8266/src/gif_core_esp8266.h
@@ -35,17 +35,34 @@ struct GifPlaybackRequest {
   GifFailureSlot failureSlot = GifFailureSlot::MiniTheme;
 };
 
+struct GifCoreStatusSnapshot {
+  String activePath;
+  bool fsMounted = false;
+  bool filePresent = false;
+  bool fileOpen = false;
+  bool decoderOpen = false;
+  bool blocked = false;
+  uint8_t consecutiveFailures = 0;
+  unsigned long backoffRemainingMs = 0;
+  String lastErrorPath;
+  String lastErrorStage;
+  unsigned int lastErrorFailures = 0;
+  unsigned long lastErrorAgeMs = 0;
+};
+
 class GifCoreESP8266 {
  public:
   void Setup(const char* preloadAssetPath = nullptr);
   void Stop();
   void ResetFrameSchedule();
+  void ResetForAssetUpdate();
 
   bool EnsureReady(TFT_eSPI& tft, const GifPlaybackRequest& request);
   bool Tick(TFT_eSPI& tft, const GifPlaybackRequest& request, bool forceFrame);
 
   int ReservedWidthFor(const char* assetPath, int fallbackWidth) const;
- bool IsCurrentAssetPresent(const char* assetPath) const;
+  bool IsCurrentAssetPresent(const char* assetPath) const;
+  GifCoreStatusSnapshot StatusSnapshot() const;
 
  private:
   using GifFailureGuard = GifFailureGuardState;
@@ -80,11 +97,15 @@ class GifCoreESP8266 {
   bool decoderOpen_ = false;
   bool suppressDraw_ = false;
   unsigned long nextFrameAtMs_ = 0;
+  unsigned long lastFailureAtMs_ = 0;
   int gifWidth_ = 0;
   int gifHeight_ = 0;
   int drawX_ = 0;
   int drawY_ = 0;
   String assetPath_ = "";
+  String lastErrorPath_ = "";
+  String lastErrorStage_ = "";
+  unsigned int lastErrorFailures_ = 0;
   GifLayoutMode layoutMode_ = GifLayoutMode::BottomRightMini;
   GifFailureSlot failureSlot_ = GifFailureSlot::MiniTheme;
   GifFailureGuard guards_[kFailureGuardSlots];

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -6,6 +6,7 @@
 #include <ESP8266WiFi.h>
 #include <LittleFS.h>
 #include <Updater.h>
+#include <bearssl/bearssl_hash.h>
 
 #include "../../firmware_shared/app_runtime.h"
 #include "../../firmware_shared/app_transport.h"
@@ -104,9 +105,57 @@ String jsonEscape(const String& raw) {
   return escaped;
 }
 
+String bytesToHex(const uint8_t* bytes, size_t len) {
+  static const char kHex[] = "0123456789abcdef";
+  String out;
+  out.reserve(len * 2);
+  for (size_t i = 0; i < len; ++i) {
+    out += kHex[(bytes[i] >> 4) & 0x0f];
+    out += kHex[bytes[i] & 0x0f];
+  }
+  return out;
+}
+
+bool sha256FileHex(const String& path, String& out) {
+  File file = LittleFS.open(path, "r");
+  if (!file) {
+    return false;
+  }
+
+  br_sha256_context ctx;
+  br_sha256_init(&ctx);
+
+  uint8_t buffer[512];
+  while (true) {
+    const size_t readLen = file.read(buffer, sizeof(buffer));
+    if (readLen == 0) {
+      break;
+    }
+    br_sha256_update(&ctx, buffer, readLen);
+    yield();
+  }
+
+  uint8_t digest[br_sha256_SIZE];
+  br_sha256_out(&ctx, digest);
+  out = bytesToHex(digest, sizeof(digest));
+  return true;
+}
+
 void drawWaitingForCompanionStatus() {
   renderer.DrawConnectedSetupInstructions(runtimeCtx, kMdnsHost, WiFi.localIP().toString());
   waitStatusRendered = true;
+}
+
+void drawWifiConnectingStatus(const String& ssid) {
+  renderer.DrawStatus(runtimeCtx, "VIBE TV", "Connecting WiFi", ssid);
+}
+
+void drawWifiResetStatus(const String& line2) {
+  renderer.DrawStatus(runtimeCtx, "VIBE TV RESET", "WiFi reset", line2);
+}
+
+void drawUpdateStatus(const String& line2) {
+  renderer.DrawStatus(runtimeCtx, "VIBE TV UPDATE", "Update running", line2);
 }
 
 void resetWifiReconnectState() {
@@ -142,9 +191,9 @@ String displayErrorMessage(const String& message) {
     return "Check Mac App";
   }
   if (message == "runtime/cycle-timeout") {
-    return "Check Mac Companion";
+    return "Check Mac App";
   }
-  return message;
+  return "Check Mac App";
 }
 
 void markFrameAccepted(const codexbar_display::core::SerialConsumeEvent& event, const char* transport) {
@@ -302,7 +351,7 @@ bool consumeBootRecoveryTrigger() {
     clearWifiCredentials();
     clearBootRecoveryCounter();
     Serial.println("boot_recovery_triggered action=wifi_setup");
-    renderer.DrawStatus(runtimeCtx, "VIBETV RESET", "WiFi cleared", "Setup starts");
+    drawWifiResetStatus("Starting setup");
     delay(1000);
     return true;
   }
@@ -314,7 +363,7 @@ bool consumeBootRecoveryTrigger() {
 
 bool connectToSavedWifi(const WifiCredentials& creds) {
   Serial.printf("wifi_connect ssid=%s\n", creds.ssid);
-  renderer.DrawStatus(runtimeCtx, "VIBETV", "Connecting WiFi", creds.ssid);
+  drawWifiConnectingStatus(creds.ssid);
   WiFi.mode(WIFI_STA);
   WiFi.begin(creds.ssid, creds.password);
 
@@ -344,7 +393,7 @@ bool connectToSdkWifiConfig() {
   }
 
   Serial.printf("wifi_sdk_connect ssid=%s\n", ssid.c_str());
-  renderer.DrawStatus(runtimeCtx, "VIBETV", "Connecting WiFi", ssid);
+  drawWifiConnectingStatus(ssid);
   WiFi.begin();
 
   const unsigned long startedAt = millis();
@@ -507,7 +556,7 @@ void handleResetWifi() {
   clearWifiCredentials();
   clearBootRecoveryCounter();
   webServer.send(200, "text/html; charset=utf-8", "<!doctype html><p>WiFi settings cleared. Vibe TV is restarting setup.</p>");
-  renderer.DrawStatus(runtimeCtx, "VIBETV RESET", "WiFi cleared", "Restarting");
+  drawWifiResetStatus("Restarting");
   waitStatusRendered = true;
   delay(500);
   ESP.restart();
@@ -579,6 +628,41 @@ bool filesystemInfoJSON(String& out) {
   return mounted;
 }
 
+void appendRendererDebugJSON(String& out) {
+  const codexbar_display::esp8266::RendererDebugSnapshot snapshot = renderer.DebugSnapshot();
+  out += "\"display\":{\"activeTheme\":\"";
+  out += jsonEscape(snapshot.activeTheme);
+  out += "\",\"gif\":{\"activePath\":\"";
+  out += jsonEscape(snapshot.gifActivePath);
+  out += "\",\"filePresent\":";
+  out += snapshot.gifFilePresent ? "true" : "false";
+  out += ",\"fileOpen\":";
+  out += snapshot.gifFileOpen ? "true" : "false";
+  out += ",\"decoderOpen\":";
+  out += snapshot.gifDecoderOpen ? "true" : "false";
+  out += ",\"blocked\":";
+  out += snapshot.gifBlocked ? "true" : "false";
+  out += ",\"consecutiveFailures\":";
+  out += String(snapshot.gifConsecutiveFailures);
+  out += ",\"backoffRemainingMs\":";
+  out += String(snapshot.gifBackoffRemainingMs);
+  out += ",\"lastError\":";
+  if (snapshot.gifLastErrorStage.length() == 0) {
+    out += "null";
+  } else {
+    out += "{\"path\":\"";
+    out += jsonEscape(snapshot.gifLastErrorPath);
+    out += "\",\"stage\":\"";
+    out += jsonEscape(snapshot.gifLastErrorStage);
+    out += "\",\"failures\":";
+    out += String(snapshot.gifLastErrorFailures);
+    out += ",\"ageMs\":";
+    out += String(snapshot.gifLastErrorAgeMs);
+    out += "}";
+  }
+  out += "}}";
+}
+
 void appendAssetEntriesJSON(String& out, const String& dirPath, bool& first, uint8_t depth) {
   if (depth > 4) {
     return;
@@ -601,6 +685,14 @@ void appendAssetEntriesJSON(String& out, const String& dirPath, bool& first, uin
     out += jsonEscape(path);
     out += "\",\"sizeBytes\":";
     out += String(dir.fileSize());
+    String sha256;
+    if (sha256FileHex(path, sha256)) {
+      out += ",\"sha256\":\"";
+      out += sha256;
+      out += "\"";
+    } else {
+      out += ",\"sha256\":null,\"hashError\":\"read_failed\"";
+    }
     out += "}";
   }
 }
@@ -636,6 +728,8 @@ void handleHealth() {
   out += wifiConnected ? String(WiFi.RSSI()) : "0";
   out += "},";
   const bool filesystemMounted = filesystemInfoJSON(out);
+  out += ",";
+  appendRendererDebugJSON(out);
   out += ",\"transport\":{\"active\":\"wifi\",\"supported\":[\"usb\",\"wifi\"],\"httpPort\":80,\"maxFrameBytes\":";
   out += String(kMaxFrameBytes);
   out += "}}";
@@ -689,7 +783,8 @@ void handleAssetUpload() {
     assetUploadError = "";
     assetUploadPath = requestedAssetPath();
     Serial.printf("asset_upload_start path=%s filename=%s content_length=%zu\n", assetUploadPath.c_str(), upload.filename.c_str(), upload.contentLength);
-    renderer.DrawStatus(runtimeCtx, "VIBETV ASSETS", "Upload running", assetUploadPath);
+    drawUpdateStatus("Loading display");
+    renderer.ResetGifStateForAssetUpdate();
     waitStatusRendered = true;
 
     if (!isSafeAssetPath(assetUploadPath)) {
@@ -767,6 +862,7 @@ void handleAssetDelete() {
     webServer.send(404, "text/plain; charset=utf-8", "asset not found");
     return;
   }
+  renderer.ResetGifStateForAssetUpdate();
   if (!LittleFS.remove(path)) {
     webServer.send(500, "text/plain; charset=utf-8", "asset delete failed");
     return;
@@ -790,16 +886,16 @@ String updatePageHTML() {
   html += "<form method='post' action='/update/firmware' enctype='multipart/form-data'>";
   html += "<input type='file' name='firmware' accept='.bin,application/octet-stream' required>";
   html += "<button type='submit'>Upload firmware</button></form></section>";
-  html += "<section><h2>LittleFS</h2><p class='muted'><code>littlefs.bin</code> replaces the filesystem partition.</p>";
+  html += "<section><h2>Display files</h2><p class='muted'>Upload the support-provided display package. Vibe TV restarts after a successful upload.</p>";
   html += "<form method='post' action='/update/filesystem' enctype='multipart/form-data'>";
   html += "<input type='file' name='filesystem' accept='.bin,application/octet-stream' required>";
-  html += "<button type='submit'>Upload LittleFS</button></form></section>";
-  html += "<section><h2>Assets</h2><p class='muted'>Upload individual theme files to the filesystem.</p>";
+  html += "<button type='submit'>Upload display files</button></form></section>";
+  html += "<section><h2>Single display file</h2><p class='muted'>Support may ask you to upload one file here.</p>";
   html += "<form method='post' action='/assets' enctype='multipart/form-data'>";
-  html += "<input name='path' placeholder='/themes/example/asset.gif' required>";
+  html += "<input name='path' placeholder='/asset.gif' required>";
   html += "<input type='file' name='asset' accept='.gif,.jpg,.jpeg,.png,.json,application/octet-stream' required>";
-  html += "<button type='submit'>Upload asset</button></form></section>";
-  html += "<p class='muted'><a href='/health'>Health JSON</a> · <a href='/assets'>Assets JSON</a></p></main></body></html>";
+  html += "<button type='submit'>Upload file</button></form></section>";
+  html += "<p class='muted'><a href='/health'>Device status</a> · <a href='/assets'>File list</a></p></main></body></html>";
   return html;
 }
 
@@ -835,10 +931,12 @@ void handleOtaUpload(int command, const char* target) {
         upload.filename.c_str(),
         upload.contentLength,
         maxSize);
-    renderer.DrawStatus(runtimeCtx, "VIBETV UPDATE", target, "Upload running");
+    const String targetLabel = command == U_FS ? "Loading display" : "Loading firmware";
+    drawUpdateStatus(targetLabel);
     waitStatusRendered = true;
 
     if (command == U_FS) {
+      renderer.ResetGifStateForAssetUpdate();
       close_all_fs();
     }
     if (!Update.begin(maxSize, command)) {
@@ -885,7 +983,7 @@ void handleOtaResult(const char* target) {
   html += target;
   html += " was written. Vibe TV is restarting.</p></body></html>";
   webServer.send(200, "text/html; charset=utf-8", html);
-    renderer.DrawStatus(runtimeCtx, "VIBETV UPDATE", target, "Restarting");
+  drawUpdateStatus("Restarting");
   waitStatusRendered = true;
   scheduleReboot(target);
 }
@@ -986,7 +1084,7 @@ void startSetupAccessPoint() {
   dnsServer.start(kDnsPort, "*", WiFi.softAPIP());
   captiveDnsStarted = true;
   Serial.printf("captive_dns_started port=%u host=%s ip=%s\n", kDnsPort, kSetupHost, WiFi.softAPIP().toString().c_str());
-  renderer.DrawSetupInstructions(runtimeCtx, kSetupApSsid, kSetupHost);
+  renderer.DrawSetupInstructions(runtimeCtx, kSetupApSsid, WiFi.softAPIP().toString());
   waitStatusRendered = true;
   startHttpServer();
   startMdnsResponder(WiFi.softAPIP());
@@ -1087,7 +1185,7 @@ void setup() {
   delay(200);
 
   renderer.Setup(runtimeCtx);
-  renderer.DrawSplash(runtimeCtx);
+  renderer.DrawStatus(runtimeCtx, "VIBE TV", "Starting", "Please wait");
   const bool forceSetupMode = consumeBootRecoveryTrigger();
 
   codexbar_display::app::EmitDeviceHello(makeTransportConfig("usb"));
@@ -1167,7 +1265,11 @@ void loop() {
     if (!codexbar_display::app::HasFrame(runtimeCtx)) {
       renderer.DrawSplash(runtimeCtx);
     } else if (codexbar_display::app::CurrentFrame(runtimeCtx).hasError) {
-      renderer.DrawError(runtimeCtx, displayErrorMessage(codexbar_display::app::CurrentFrame(runtimeCtx).error));
+      renderer.DrawStatus(
+          runtimeCtx,
+          "VIBE TV",
+          displayErrorMessage(codexbar_display::app::CurrentFrame(runtimeCtx).error),
+          "On your Mac");
     } else {
       renderer.DrawUsage(runtimeCtx);
     }

--- a/firmware_esp8266/src/renderer_esp8266.cpp
+++ b/firmware_esp8266/src/renderer_esp8266.cpp
@@ -10,6 +10,24 @@
 namespace codexbar_display {
 namespace esp8266 {
 
+#ifndef CODEXBAR_DISPLAY_PROBE_ONLY
+namespace {
+
+const char* themeName(Theme theme) {
+  switch (theme) {
+    case Theme::Mini:
+      return "mini";
+    case Theme::CRT:
+      return "crt";
+    case Theme::Classic:
+    default:
+      return "classic";
+  }
+}
+
+}  // namespace
+#endif
+
 void RendererESP8266::Setup(app::RuntimeContext& ctx) {
 #ifndef CODEXBAR_DISPLAY_PROBE_ONLY
   display::AttachContext(ctx);
@@ -23,6 +41,34 @@ void RendererESP8266::Setup(app::RuntimeContext& ctx) {
   display::GifCore().Setup(display::MiniGifAssetPath());
 #else
   probe::Setup(ctx);
+#endif
+}
+
+RendererDebugSnapshot RendererESP8266::DebugSnapshot() const {
+  RendererDebugSnapshot snapshot;
+#ifndef CODEXBAR_DISPLAY_PROBE_ONLY
+  snapshot.activeTheme = themeName(display::ActiveTheme());
+  const GifCoreStatusSnapshot gif = display::GifCore().StatusSnapshot();
+  snapshot.gifActivePath = gif.activePath;
+  snapshot.gifFilePresent = gif.filePresent;
+  snapshot.gifFileOpen = gif.fileOpen;
+  snapshot.gifDecoderOpen = gif.decoderOpen;
+  snapshot.gifBlocked = gif.blocked;
+  snapshot.gifConsecutiveFailures = gif.consecutiveFailures;
+  snapshot.gifBackoffRemainingMs = gif.backoffRemainingMs;
+  snapshot.gifLastErrorPath = gif.lastErrorPath;
+  snapshot.gifLastErrorStage = gif.lastErrorStage;
+  snapshot.gifLastErrorFailures = gif.lastErrorFailures;
+  snapshot.gifLastErrorAgeMs = gif.lastErrorAgeMs;
+#else
+  snapshot.activeTheme = "probe";
+#endif
+  return snapshot;
+}
+
+void RendererESP8266::ResetGifStateForAssetUpdate() {
+#ifndef CODEXBAR_DISPLAY_PROBE_ONLY
+  display::GifCore().ResetForAssetUpdate();
 #endif
 }
 
@@ -157,7 +203,6 @@ void RendererESP8266::DrawStatus(
 
 void RendererESP8266::DrawSetupInstructions(app::RuntimeContext& ctx, const String& ssid, const String& address) {
 #ifndef CODEXBAR_DISPLAY_PROBE_ONLY
-  (void)address;
   display::AttachContext(ctx);
   display::StopMiniGifPlayback();
 
@@ -167,18 +212,20 @@ void RendererESP8266::DrawSetupInstructions(app::RuntimeContext& ctx, const Stri
   tft.setTextFont(1);
 
   const char* title = "VIBE TV SETUP";
-  const char* action = "Connect to";
-  const char* detail = "this WiFi:";
+  const char* action = "Join WiFi:";
+  const char* detail = "Open:";
   const int titleSize = display::ChooseTextSizeToFit(title, 3, 2, tft.width() - 8);
   const int ssidSize = display::ChooseTextSizeToFit(ssid.c_str(), 3, 2, tft.width() - 8);
   const int actionSize = display::ChooseTextSizeToFit(action, 2, 1, tft.width() - 14);
   const int detailSize = display::ChooseTextSizeToFit(detail, 2, 1, tft.width() - 14);
+  const int addressSize = display::ChooseTextSizeToFit(address.c_str(), 2, 1, tft.width() - 8);
 
   const int totalH =
       display::TextPixelHeight(titleSize) + 14 +
       display::TextPixelHeight(actionSize) + 4 +
-      display::TextPixelHeight(detailSize) + 8 +
-      display::TextPixelHeight(ssidSize);
+      display::TextPixelHeight(ssidSize) + 10 +
+      display::TextPixelHeight(detailSize) + 4 +
+      display::TextPixelHeight(addressSize);
   int y = (tft.height() - totalH) / 2;
   if (y < 6) {
     y = 6;
@@ -196,16 +243,22 @@ void RendererESP8266::DrawSetupInstructions(app::RuntimeContext& ctx, const Stri
   tft.print(action);
 
   y += display::TextPixelHeight(actionSize) + 4;
+  display::SetClassicTextSize(ssidSize);
+  tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+  tft.setCursor(display::CenteredTextX(ssid.c_str(), ssidSize), y);
+  tft.print(ssid);
+
+  y += display::TextPixelHeight(ssidSize) + 10;
   display::SetClassicTextSize(detailSize);
   tft.setTextColor(TFT_WHITE, TFT_BLACK);
   tft.setCursor(display::CenteredTextX(detail, detailSize), y);
   tft.print(detail);
 
-  y += display::TextPixelHeight(detailSize) + 8;
-  display::SetClassicTextSize(ssidSize);
+  y += display::TextPixelHeight(detailSize) + 4;
+  display::SetClassicTextSize(addressSize);
   tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
-  tft.setCursor(display::CenteredTextX(ssid.c_str(), ssidSize), y);
-  tft.print(ssid);
+  tft.setCursor(display::CenteredTextX(address.c_str(), addressSize), y);
+  tft.print(address);
 
   ctx.lastRenderedSecs = -1;
   ctx.lastRenderedMinuteBucket = -1;
@@ -229,10 +282,10 @@ void RendererESP8266::DrawConnectedSetupInstructions(
   tft.setTextWrap(false);
   tft.setTextFont(1);
 
-  const char* title = "VIBE TV";
-  const char* action = "Open this address";
-  const char* detail = "in your browser";
-  const char* fallback = "Fallback IP:";
+  const char* title = "VIBE TV READY";
+  const char* action = "Open Setup";
+  const char* detail = "Browser:";
+  const char* fallback = "IP:";
   const int titleSize = display::ChooseTextSizeToFit(title, 3, 2, tft.width() - 8);
   const int hostSize = display::ChooseTextSizeToFit(host.c_str(), 3, 2, tft.width() - 8);
   const int actionSize = display::ChooseTextSizeToFit(action, 2, 1, tft.width() - 14);
@@ -242,7 +295,7 @@ void RendererESP8266::DrawConnectedSetupInstructions(
 
   const int totalH =
       display::TextPixelHeight(titleSize) + 12 +
-      display::TextPixelHeight(actionSize) + 4 +
+      display::TextPixelHeight(actionSize) + 10 +
       display::TextPixelHeight(detailSize) + 8 +
       display::TextPixelHeight(hostSize) + 10 +
       display::TextPixelHeight(fallbackSize) + 4 +
@@ -263,7 +316,7 @@ void RendererESP8266::DrawConnectedSetupInstructions(
   tft.setCursor(display::CenteredTextX(action, actionSize), y);
   tft.print(action);
 
-  y += display::TextPixelHeight(actionSize) + 4;
+  y += display::TextPixelHeight(actionSize) + 10;
   display::SetClassicTextSize(detailSize);
   tft.setTextColor(TFT_WHITE, TFT_BLACK);
   tft.setCursor(display::CenteredTextX(detail, detailSize), y);

--- a/firmware_esp8266/src/renderer_esp8266.h
+++ b/firmware_esp8266/src/renderer_esp8266.h
@@ -7,10 +7,27 @@
 namespace codexbar_display {
 namespace esp8266 {
 
+struct RendererDebugSnapshot {
+  String activeTheme;
+  String gifActivePath;
+  bool gifFilePresent = false;
+  bool gifFileOpen = false;
+  bool gifDecoderOpen = false;
+  bool gifBlocked = false;
+  uint8_t gifConsecutiveFailures = 0;
+  unsigned long gifBackoffRemainingMs = 0;
+  String gifLastErrorPath;
+  String gifLastErrorStage;
+  unsigned int gifLastErrorFailures = 0;
+  unsigned long gifLastErrorAgeMs = 0;
+};
+
 class RendererESP8266 : public app::Renderer {
  public:
   void Setup(app::RuntimeContext& ctx) override;
   void OnFrameAccepted(app::RuntimeContext& ctx, const core::SerialConsumeEvent& event) override;
+  RendererDebugSnapshot DebugSnapshot() const;
+  void ResetGifStateForAssetUpdate();
 
   void DrawSplash(app::RuntimeContext& ctx) override;
   void TickSplash(app::RuntimeContext& ctx) override;

--- a/firmware_esp8266/src/renderer_esp8266_theme_mini.cpp
+++ b/firmware_esp8266/src/renderer_esp8266_theme_mini.cpp
@@ -200,13 +200,17 @@ void DrawMiniGifPlaceholder() {
     return;
   }
 
-  if (!GifCore().IsCurrentAssetPresent(kMiniGifPath)) {
+  const GifCoreStatusSnapshot status = GifCore().StatusSnapshot();
+  const bool missing = !GifCore().IsCurrentAssetPresent(kMiniGifPath);
+  const bool failed = status.activePath == kMiniGifPath && status.lastErrorStage.length() > 0;
+  if (missing || failed) {
+    const char* label = failed ? "GIF Fehler" : "Theme fehlt";
     PrimitiveFillRect(x, y, boxW, boxH, kMiniPanel);
     tft.setTextFont(1);
     tft.setTextSize(1);
     tft.setTextColor(kMiniMuted, kMiniPanel);
-    tft.setCursor(x + ((boxW - TextPixelWidth("Theme fehlt", 1)) / 2), y + ((boxH - TextPixelHeight(1)) / 2));
-    tft.print("Theme fehlt");
+    tft.setCursor(x + ((boxW - TextPixelWidth(label, 1)) / 2), y + ((boxH - TextPixelHeight(1)) / 2));
+    tft.print(label);
   }
 }
 

--- a/scripts/vibetv-provision.sh
+++ b/scripts/vibetv-provision.sh
@@ -29,11 +29,24 @@ skip_asset_check=0
 skip_smoke=0
 dry_run=0
 assume_yes=0
-allow_reboot_close=0
+allow_reboot_close=1
 poll_timeout_secs=120
 poll_interval_secs=3
 curl_timeout_secs=30
+upload_timeout_secs=90
+filesystem_upload_timeout_secs=300
 required_assets=("/mini.gif")
+current_stage="startup"
+last_upload_result=""
+failure_reported=0
+
+report_unhandled_failure() {
+  local status=$?
+  if [[ "$status" -ne 0 && "${failure_reported:-0}" != "1" ]]; then
+    printf 'provision: FAIL stage=%s exit=%s\n' "$current_stage" "$status" >&2
+  fi
+}
+trap report_unhandled_failure EXIT
 
 usage() {
   cat <<'EOF'
@@ -44,8 +57,8 @@ Usage:
 
 Builds firmware.bin + littlefs.bin, writes an OTA package with SHA-256 checksums,
 uploads firmware to the GeekMagic manufacturer updater, waits for VibeTV firmware,
-uploads LittleFS to the VibeTV updater, checks /health and /hello, then sends
-a mini theme test frame.
+uploads LittleFS to the VibeTV updater, checks /health, /hello, and /assets,
+verifies required theme asset bytes + SHA-256, then sends a mini theme test frame.
 
 Commands:
   build                 Build and package artifacts only.
@@ -94,6 +107,13 @@ Flow toggles:
   --skip-asset-check    Do not require theme assets to be visible through /assets.
   --skip-smoke          Do not send the mini test frame.
   --allow-reboot-close  Treat curl exit 52/56 during OTA as a reboot close.
+                        This is the default; post-upload checks still decide pass/fail.
+  --strict-upload-response
+                        Fail immediately on curl exit 52/56 instead of classifying it
+                        as a reboot-related connection close.
+  --upload-timeout SECS Upload timeout for firmware OTA requests. Default: 90.
+  --filesystem-upload-timeout SECS
+                        Upload timeout for LittleFS OTA requests. Default: 300.
   --require-asset PATH  Require an asset path in /assets after flashing.
                         Repeatable. Default: /mini.gif.
 
@@ -107,6 +127,8 @@ EOF
 }
 
 die() {
+  failure_reported=1
+  printf 'provision: FAIL stage=%s\n' "$current_stage" >&2
   printf 'error: %s\n' "$*" >&2
   exit 1
 }
@@ -119,6 +141,15 @@ require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
     die "missing required command: $1"
   fi
+}
+
+normalize_asset_path() {
+  local path="$1"
+  [[ -n "$path" ]] || die "asset path must not be empty"
+  if [[ "$path" != /* ]]; then
+    path="/${path}"
+  fi
+  printf '%s\n' "$path"
 }
 
 normalize_target() {
@@ -159,6 +190,34 @@ json_escape() {
   sed 's/\\/\\\\/g; s/"/\\"/g'
 }
 
+lower_ascii() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+build_theme_assets_json() {
+  local assets_json="[]"
+  local asset normalized rel src bytes sha
+
+  for asset in "${required_assets[@]}"; do
+    normalized="$(normalize_asset_path "$asset")"
+    rel="${normalized#/}"
+    src="${project_dir}/data/${rel}"
+    [[ -f "$src" ]] || die "required theme asset not found in data dir: ${src}"
+    bytes="$(wc -c <"$src" | tr -d ' ')"
+    [[ "$bytes" -gt 0 ]] || die "required theme asset is empty: ${src}"
+    sha="$(sha256_file "$src")"
+    assets_json="$(jq -c \
+      --arg path "$normalized" \
+      --arg file "data/${rel}" \
+      --arg sha "$sha" \
+      --argjson bytes "$bytes" \
+      '. + [{"path":$path,"file":$file,"bytes":$bytes,"sha256":$sha,"required":true}] | unique_by(.path)' \
+      <<<"$assets_json")"
+  done
+
+  printf '%s\n' "$assets_json"
+}
+
 confirm_destructive() {
   if [[ "$dry_run" == "1" || "$assume_yes" == "1" ]]; then
     return
@@ -184,6 +243,11 @@ run_or_print() {
   "$@"
 }
 
+is_reboot_close_status() {
+  local status="$1"
+  [[ "$status" -eq 52 || "$status" -eq 56 ]]
+}
+
 ensure_package_dir() {
   if [[ -n "$package_dir" ]]; then
     return
@@ -192,8 +256,10 @@ ensure_package_dir() {
 }
 
 build_package() {
+  current_stage="build package"
   require_cmd pio
   require_cmd shasum
+  require_cmd jq
   ensure_package_dir
 
   [[ -d "$project_dir" ]] || die "project dir not found: $project_dir"
@@ -212,16 +278,13 @@ build_package() {
   cp "$firmware_src" "$(artifact_path firmware.bin)"
   cp "$littlefs_src" "$(artifact_path littlefs.bin)"
 
-  local firmware_sha littlefs_sha git_commit created_utc
+  local firmware_sha littlefs_sha manifest_sha git_commit created_utc theme_assets_json required_asset_paths_json
   firmware_sha="$(sha256_file "$(artifact_path firmware.bin)")"
   littlefs_sha="$(sha256_file "$(artifact_path littlefs.bin)")"
   git_commit="$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null || printf 'unknown')"
   created_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
-  {
-    printf '%s  firmware.bin\n' "$firmware_sha"
-    printf '%s  littlefs.bin\n' "$littlefs_sha"
-  } >"$(artifact_path SHA256SUMS)"
+  theme_assets_json="$(build_theme_assets_json)"
+  required_asset_paths_json="$(jq -c '[.[].path]' <<<"$theme_assets_json")"
 
   local escaped_env escaped_commit escaped_created
   escaped_env="$(printf '%s' "$env_name" | json_escape)"
@@ -238,9 +301,20 @@ build_package() {
       "$firmware_sha" "$(wc -c <"$(artifact_path firmware.bin)" | tr -d ' ')"
     printf '    "filesystem": {"file": "littlefs.bin", "sha256": "%s", "bytes": %s}\n' \
       "$littlefs_sha" "$(wc -c <"$(artifact_path littlefs.bin)" | tr -d ' ')"
-    printf '  }\n'
+    printf '  },\n'
+    printf '  "themeAssets": %s,\n' "$theme_assets_json"
+    printf '  "themePacks": [\n'
+    printf '    {"id": "mini", "requiredAssets": %s}\n' "$required_asset_paths_json"
+    printf '  ]\n'
     printf '}\n'
   } >"$(artifact_path manifest.json)"
+
+  manifest_sha="$(sha256_file "$(artifact_path manifest.json)")"
+  {
+    printf '%s  firmware.bin\n' "$firmware_sha"
+    printf '%s  littlefs.bin\n' "$littlefs_sha"
+    printf '%s  manifest.json\n' "$manifest_sha"
+  } >"$(artifact_path SHA256SUMS)"
 
   log "package: ${package_dir}"
   log "checksums:"
@@ -248,12 +322,18 @@ build_package() {
 }
 
 verify_package() {
+  current_stage="verify package"
   require_cmd shasum
+  require_cmd jq
   [[ -n "$package_dir" ]] || die "--package-dir is required with flash or --skip-build"
   [[ -f "$(artifact_path firmware.bin)" ]] || die "missing package artifact: $(artifact_path firmware.bin)"
   [[ -f "$(artifact_path littlefs.bin)" ]] || die "missing package artifact: $(artifact_path littlefs.bin)"
   [[ -f "$(artifact_path SHA256SUMS)" ]] || die "missing package checksum file: $(artifact_path SHA256SUMS)"
+  [[ -f "$(artifact_path manifest.json)" ]] || die "missing package manifest: $(artifact_path manifest.json)"
   (cd "$package_dir" && shasum -a 256 -c SHA256SUMS)
+  jq -e '.kind == "vibetv-ota-package" and (.themeAssets | type == "array") and (.themeAssets | length > 0)' \
+    "$(artifact_path manifest.json)" >/dev/null ||
+    die "package manifest does not contain themeAssets metadata"
 }
 
 curl_get() {
@@ -338,7 +418,10 @@ check_hello() {
     log "dry-run: would read hello ${url}"
     return 0
   fi
-  curl_get "$url" >"$body_file"
+  curl_get "$url" >"$body_file" || {
+    rm -f "$body_file"
+    die "hello check request failed"
+  }
   if [[ -n "$expect_board" ]] && ! grep -F "$expect_board" "$body_file" >/dev/null 2>&1; then
     log "hello response:" >&2
     sed 's/^/  /' "$body_file" >&2
@@ -352,7 +435,10 @@ check_hello() {
 
 check_assets() {
   local url="$1"
+  local require_runtime_assets="${2:-1}"
   local body_file="/tmp/vibetv-provision-assets.$$"
+  local expected_file="/tmp/vibetv-provision-expected-assets.$$"
+  local sorted_expected_file="/tmp/vibetv-provision-expected-assets-sorted.$$"
   if [[ "$skip_asset_check" == "1" ]]; then
     log "skip: asset check"
     return 0
@@ -362,30 +448,83 @@ check_assets() {
     return 0
   fi
 
-  curl_get "$url" >"$body_file"
-  if ! grep -F '"mounted":true' "$body_file" >/dev/null 2>&1; then
+  curl_get "$url" >"$body_file" || {
+    rm -f "$body_file"
+    die "asset verification request failed"
+  }
+  if [[ "$require_runtime_assets" != "1" ]]; then
+    log "assets endpoint:"
+    sed 's/^/  /' "$body_file"
+    rm -f "$body_file"
+    return 0
+  fi
+
+  if ! jq -e '.filesystem.mounted == true' "$body_file" >/dev/null 2>&1; then
     log "assets response:" >&2
     sed 's/^/  /' "$body_file" >&2
     rm -f "$body_file"
     die "filesystem is not mounted according to /assets"
   fi
 
-  local asset
+  : >"$expected_file"
+  jq -r '.themeAssets[] | select(.required != false) | [.path, (.bytes | tostring), (.sha256 // "")] | @tsv' \
+    "$(artifact_path manifest.json)" >>"$expected_file"
+
+  local asset normalized
   for asset in "${required_assets[@]}"; do
     if [[ -z "$asset" ]]; then
       continue
     fi
-    if ! grep -F "\"path\":\"${asset}\"" "$body_file" >/dev/null 2>&1; then
+    normalized="$(normalize_asset_path "$asset")"
+    printf '%s\t\t\n' "$normalized" >>"$expected_file"
+  done
+  sort -u "$expected_file" >"$sorted_expected_file"
+
+  local expected_path expected_bytes expected_sha asset_metadata actual_bytes actual_sha
+  while IFS=$'\t' read -r expected_path expected_bytes expected_sha; do
+    if [[ -z "$expected_path" ]]; then
+      continue
+    fi
+    if ! asset_metadata="$(jq -er --arg path "$expected_path" \
+      'first(.assets[]? | select(.path == $path) | [(.sizeBytes // -1), (.sha256 // "")] | @tsv) // empty' \
+      "$body_file" 2>/dev/null)"; then
       log "assets response:" >&2
       sed 's/^/  /' "$body_file" >&2
-      rm -f "$body_file"
-      die "required asset missing from /assets: ${asset}"
+      rm -f "$body_file" "$expected_file" "$sorted_expected_file"
+      die "required asset missing from /assets: ${expected_path}"
     fi
-  done
+    IFS=$'\t' read -r actual_bytes actual_sha <<<"$asset_metadata"
+    if [[ ! "$actual_bytes" =~ ^[0-9]+$ || "$actual_bytes" -le 0 ]]; then
+      log "assets response:" >&2
+      sed 's/^/  /' "$body_file" >&2
+      rm -f "$body_file" "$expected_file" "$sorted_expected_file"
+      die "required asset has invalid or zero size: ${expected_path}"
+    fi
+    if [[ -n "$expected_bytes" && "$actual_bytes" != "$expected_bytes" ]]; then
+      log "assets response:" >&2
+      sed 's/^/  /' "$body_file" >&2
+      rm -f "$body_file" "$expected_file" "$sorted_expected_file"
+      die "required asset size mismatch: ${expected_path} expected=${expected_bytes} actual=${actual_bytes}"
+    fi
+    if [[ -n "$expected_sha" ]]; then
+      if [[ -z "$actual_sha" || "$actual_sha" == "null" ]]; then
+        log "assets response:" >&2
+        sed 's/^/  /' "$body_file" >&2
+        rm -f "$body_file" "$expected_file" "$sorted_expected_file"
+        die "required asset missing sha256 metadata: ${expected_path}"
+      fi
+      if [[ "$(lower_ascii "$actual_sha")" != "$(lower_ascii "$expected_sha")" ]]; then
+        log "assets response:" >&2
+        sed 's/^/  /' "$body_file" >&2
+        rm -f "$body_file" "$expected_file" "$sorted_expected_file"
+        die "required asset sha256 mismatch: ${expected_path} expected=${expected_sha} actual=${actual_sha}"
+      fi
+    fi
+  done <"$sorted_expected_file"
 
   log "assets:"
   sed 's/^/  /' "$body_file"
-  rm -f "$body_file"
+  rm -f "$body_file" "$expected_file" "$sorted_expected_file"
 }
 
 upload_multipart() {
@@ -393,29 +532,86 @@ upload_multipart() {
   local url="$2"
   local field="$3"
   local file="$4"
+  local timeout_secs="${5:-$upload_timeout_secs}"
+  local response_file="/tmp/vibetv-provision-upload-response.$$"
+  local error_file="/tmp/vibetv-provision-upload-error.$$"
   [[ -f "$file" ]] || die "${label} file not found: $file"
+  current_stage="upload: ${label}"
+  last_upload_result=""
 
   log "upload: ${label} -> ${url} field=${field} file=${file}"
   if [[ "$dry_run" == "1" ]]; then
     printf 'dry-run: curl -fsS --connect-timeout 5 --max-time %q -X POST -F %q %q\n' \
-      "$curl_timeout_secs" "${field}=@${file}" "$url"
+      "$timeout_secs" "${field}=@${file}" "$url"
+    last_upload_result="dry-run"
     return 0
   fi
 
   set +e
-  curl -fsS --connect-timeout 5 --max-time "$curl_timeout_secs" \
-    -X POST -F "${field}=@${file};filename=$(basename "$file")" "$url"
+  curl -fsS --connect-timeout 5 --max-time "$timeout_secs" \
+    -X POST -F "${field}=@${file};filename=$(basename "$file")" "$url" \
+    >"$response_file" 2>"$error_file"
   local status=$?
   set -e
-  printf '\n'
   if [[ "$status" -eq 0 ]]; then
+    last_upload_result="http-response"
+    if [[ -s "$response_file" ]]; then
+      log "upload: ${label} HTTP response:"
+      sed 's/^/  /' "$response_file"
+    fi
+    rm -f "$response_file" "$error_file"
+    log "upload: ${label} HTTP response received; continuing with post-upload checks"
     return 0
   fi
-  if [[ "$allow_reboot_close" == "1" && ( "$status" -eq 52 || "$status" -eq 56 ) ]]; then
-    log "upload: ${label} curl status ${status}; treating as reboot close"
+  if [[ "$allow_reboot_close" == "1" ]] && is_reboot_close_status "$status"; then
+    last_upload_result="reboot-close"
+    log "upload: ${label} curl status ${status}; classified as reboot-related connection close"
+    if [[ -s "$error_file" ]]; then
+      sed 's/^/  /' "$error_file" >&2 || true
+    fi
+    rm -f "$response_file" "$error_file"
+    log "upload: ${label} response was interrupted by reboot; continuing with post-upload checks"
     return 0
   fi
+  if [[ -s "$error_file" ]]; then
+    log "upload error:" >&2
+    sed 's/^/  /' "$error_file" >&2 || true
+  fi
+  rm -f "$response_file" "$error_file"
   die "${label} upload failed with curl status ${status}"
+}
+
+post_upload_checks() {
+  local phase="$1"
+  local health_url="$2"
+  local hello_url="$3"
+  local assets_url="$4"
+  local asset_mode="${5:-required}"
+  local require_runtime_assets=1
+
+  log "verify: ${phase}: post-upload checks start (upload=${last_upload_result:-unknown})"
+  if [[ "$skip_health" != "1" ]]; then
+    current_stage="reboot wait: ${phase} health"
+    wait_for_endpoint "${phase} health check" "$health_url" ||
+      die "reboot wait/health check failed for ${phase}"
+  else
+    log "skip: health check for ${phase}"
+  fi
+
+  current_stage="health check: ${phase} hello"
+  wait_for_endpoint "${phase} hello check" "$hello_url" ||
+    die "hello check failed for ${phase}"
+  check_hello "$hello_url"
+
+  if [[ "$asset_mode" == "endpoint" ]]; then
+    require_runtime_assets=0
+  fi
+  current_stage="asset verification: ${phase}"
+  wait_for_endpoint "${phase} assets check" "$assets_url" ||
+    die "asset verification failed for ${phase}"
+  check_assets "$assets_url" "$require_runtime_assets"
+
+  log "verify: ${phase}: post-upload checks passed"
 }
 
 send_frame() {
@@ -460,7 +656,52 @@ send_smoke_frames() {
     '{"v":2,"provider":"vibetv","label":"Vibe TV","session":23,"weekly":64,"resetSecs":12000,"sessionTokens":203211,"weekTokens":9231002,"totalTokens":1087628607,"theme":"mini"}'
 }
 
+check_post_smoke_gif_state() {
+  local health_url="$1"
+  local body_file="/tmp/vibetv-provision-gif-health.$$"
+  local attempt stage error_path
+
+  if [[ "$skip_health" == "1" ]]; then
+    log "skip: post-smoke GIF state check because health checks are disabled"
+    return 0
+  fi
+  if [[ "$dry_run" == "1" ]]; then
+    log "dry-run: would verify mini GIF state via ${health_url}"
+    return 0
+  fi
+
+  current_stage="post-smoke GIF state"
+  for attempt in 1 2 3 4 5 6 7 8; do
+    if curl_get "$health_url" >"$body_file"; then
+      if jq -e '.display.activeTheme == "mini" and .display.gif.activePath == "/mini.gif" and .display.gif.filePresent == true and .display.gif.decoderOpen == true and .display.gif.lastError == null' "$body_file" >/dev/null 2>&1; then
+        log "smoke: mini GIF decoder healthy"
+        rm -f "$body_file"
+        return 0
+      fi
+      if jq -e '.display.gif.lastError != null' "$body_file" >/dev/null 2>&1; then
+        stage="$(jq -r '.display.gif.lastError.stage // "unknown"' "$body_file")"
+        error_path="$(jq -r '.display.gif.lastError.path // ""' "$body_file")"
+        log "health response:" >&2
+        sed 's/^/  /' "$body_file" >&2
+        rm -f "$body_file"
+        die "mini GIF renderer reported error stage=${stage} path=${error_path}"
+      fi
+    fi
+    if [[ "$attempt" != "8" ]]; then
+      sleep 1
+    fi
+  done
+
+  log "health response:" >&2
+  if [[ -f "$body_file" ]]; then
+    sed 's/^/  /' "$body_file" >&2
+  fi
+  rm -f "$body_file"
+  die "mini GIF decoder did not report healthy state after smoke frame"
+}
+
 flash_package() {
+  current_stage="flash package"
   require_cmd curl
   verify_package
   target="$(normalize_target "$target")"
@@ -478,40 +719,29 @@ flash_package() {
   confirm_destructive
 
   if [[ "$skip_manufacturer_ota" != "1" ]]; then
-    upload_multipart "manufacturer firmware OTA" "$manufacturer_url" "$manufacturer_field" "$(artifact_path firmware.bin)"
-    if [[ "$skip_health" != "1" ]]; then
-      wait_for_endpoint "health" "$health_url"
-    fi
-    wait_for_endpoint "hello" "$hello_url"
-    check_hello "$hello_url"
+    upload_multipart "manufacturer firmware OTA" "$manufacturer_url" "$manufacturer_field" "$(artifact_path firmware.bin)" "$upload_timeout_secs"
+    post_upload_checks "manufacturer firmware OTA" "$health_url" "$hello_url" "$assets_url" "endpoint"
   else
     log "skip: manufacturer firmware OTA"
   fi
 
   if [[ "$skip_firmware_ota" != "1" ]]; then
-    upload_multipart "VibeTV firmware OTA" "$firmware_url" "$firmware_field" "$(artifact_path firmware.bin)"
-    if [[ "$skip_health" != "1" ]]; then
-      wait_for_endpoint "health" "$health_url"
-    fi
-    wait_for_endpoint "hello" "$hello_url"
-    check_hello "$hello_url"
+    upload_multipart "VibeTV firmware OTA" "$firmware_url" "$firmware_field" "$(artifact_path firmware.bin)" "$upload_timeout_secs"
+    post_upload_checks "VibeTV firmware OTA" "$health_url" "$hello_url" "$assets_url" "endpoint"
   fi
 
   if [[ "$skip_filesystem_ota" != "1" ]]; then
-    upload_multipart "VibeTV filesystem OTA" "$filesystem_url" "$filesystem_field" "$(artifact_path littlefs.bin)"
-    if [[ "$skip_health" != "1" ]]; then
-      wait_for_endpoint "health" "$health_url"
-    fi
-    wait_for_endpoint "hello" "$hello_url"
-    check_hello "$hello_url"
+    upload_multipart "VibeTV filesystem OTA" "$filesystem_url" "$filesystem_field" "$(artifact_path littlefs.bin)" "$filesystem_upload_timeout_secs"
+    post_upload_checks "VibeTV filesystem OTA" "$health_url" "$hello_url" "$assets_url" "required"
   else
     log "skip: filesystem OTA"
+    post_upload_checks "final runtime verification" "$health_url" "$hello_url" "$assets_url" "required"
   fi
 
-  check_assets "$assets_url"
-
   if [[ "$skip_smoke" != "1" ]]; then
+    current_stage="smoke frame"
     send_smoke_frames "$frame_url"
+    check_post_smoke_gif_state "$health_url"
   else
     log "skip: smoke frames"
   fi
@@ -608,6 +838,14 @@ while [[ "$#" -gt 0 ]]; do
       curl_timeout_secs="${2:-}"
       shift 2
       ;;
+    --upload-timeout)
+      upload_timeout_secs="${2:-}"
+      shift 2
+      ;;
+    --filesystem-upload-timeout)
+      filesystem_upload_timeout_secs="${2:-}"
+      shift 2
+      ;;
     --skip-build)
       skip_build=1
       shift
@@ -644,6 +882,10 @@ while [[ "$#" -gt 0 ]]; do
       allow_reboot_close=1
       shift
       ;;
+    --strict-upload-response)
+      allow_reboot_close=0
+      shift
+      ;;
     --dry-run)
       dry_run=1
       shift
@@ -675,3 +917,6 @@ case "$command" in
     die "unknown command: $command"
     ;;
 esac
+
+current_stage="complete"
+log "provision: PASS command=${command}"


### PR DESCRIPTION
## Summary
- harden OTA provisioning around long ESP8266 filesystem uploads, reboot-close handling, and post-upload checks
- verify runtime theme assets by bytes and SHA-256 via `/assets` and package `manifest.json`
- expose GIF renderer state in `/health`, reset GIF decoder/backoff state after asset/filesystem updates, and fail provisioning on broken mini GIF playback
- clarify customer-facing setup/status screens with short English VibeTV copy and support docs

## Issues
Closes #59
Closes #60
Closes #61
Closes #53

Refs #52 for the theme-pack planning work.
Refs #63 for the new Theme Library / `vibetv.local` journey issue.

## Tests
- `pio run -d firmware_esp8266 -e esp8266_smalltv_st7789`
- `./scripts/check-gif-core-policy-tests.sh`
- `go test ./...` in `companion`
- `bash -n scripts/vibetv-provision.sh`
- `./scripts/vibetv-provision.sh build --package-dir /tmp/vibetv-final-package`
- `git diff --check`

## Notes
- Not tested on physical ESP8266 hardware.
- `tools/theme-studio/` was already untracked locally and is intentionally not included.