### PR TITLE
CODEX publish stable firmware manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
           import os
 
           version = os.environ["VERSION"]
+          repo = os.environ.get("GITHUB_REPOSITORY", "DreamyTalesPAN/CodexBar-Display")
           targets = [
               ("esp8266_smalltv_st7789", "esp8266-smalltv-st7789"),
               ("lilygo_t_display_s3", "esp32-lilygo-t-display-s3"),
@@ -103,6 +104,7 @@ jobs:
 
           for env_name, board in targets:
               path = f"dist/firmware/codexbar-display-firmware-{env_name}-v{version}.bin"
+              asset = os.path.basename(path)
               with open(path, "rb") as f:
                   sha = hashlib.sha256(f.read()).hexdigest()
 
@@ -111,15 +113,21 @@ jobs:
                       "firmwareEnv": env_name,
                       "board": board,
                       "firmwareVersion": version,
-                      "asset": os.path.basename(path),
+                      "asset": asset,
                       "sha256": sha,
+                      "severity": "recommended",
+                      "message": "Firmware update available. Open vibetv.local.",
+                      "firmwareUrl": f"https://github.com/{repo}/releases/download/v{version}/{asset}",
                   }
               )
 
-          out_path = f"dist/firmware/firmware-manifest-v{version}.json"
-          with open(out_path, "w", encoding="utf-8") as f:
-              json.dump(manifest, f, indent=2)
-              f.write("\n")
+          for out_path in (
+              f"dist/firmware/firmware-manifest-v{version}.json",
+              "dist/firmware/firmware-manifest.json",
+          ):
+              with open(out_path, "w", encoding="utf-8") as f:
+                  json.dump(manifest, f, indent=2)
+                  f.write("\n")
           PY
 
           (
@@ -135,5 +143,6 @@ jobs:
             dist/install.sh
             dist/companion/*
             dist/firmware/*.bin
+            dist/firmware/firmware-manifest.json
             dist/firmware/firmware-manifest-*.json
             dist/checksums-*.txt

--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -35,7 +35,7 @@ const (
 	defaultReleaseRepo        = "DreamyTalesPAN/CodexBar-Display"
 	githubAPIBaseURL          = "https://api.github.com"
 	githubDownloadBaseURL     = "https://github.com"
-	vibeTVFirmwareManifestURL = "https://vibetv.shop/cdn/shop/t/1/assets/firmware-manifest.json"
+	vibeTVFirmwareManifestURL = "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/firmware-manifest.json"
 )
 
 var (

--- a/companion/internal/daemon/daemon.go
+++ b/companion/internal/daemon/daemon.go
@@ -48,7 +48,7 @@ const (
 	collectorOrderEnvVar    = "CODEXBAR_DISPLAY_PROVIDER_ORDER"
 	providerMaxAgeEnvVar    = "CODEXBAR_DISPLAY_PROVIDER_LAST_GOOD_MAX_AGE"
 	firmwareManifestEnvVar  = "CODEXBAR_DISPLAY_FIRMWARE_MANIFEST_URL"
-	firmwareManifestURL     = "https://vibetv.shop/cdn/shop/t/1/assets/firmware-manifest.json"
+	firmwareManifestURL     = "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/firmware-manifest.json"
 	firmwareUpdateCheckGap  = 6 * time.Hour
 	firmwareManifestTimeout = 5 * time.Second
 )

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -55,7 +55,7 @@ const char kSetupApSsid[] = "VibeTV-Setup";
 const char kSetupHost[] = "vibetv.local";
 const char kMdnsName[] = "vibetv";
 const char kMdnsHost[] = "vibetv.local";
-const char kFirmwareManifestUrl[] = "https://vibetv.shop/cdn/shop/t/1/assets/firmware-manifest.json";
+const char kFirmwareManifestUrl[] = "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/firmware-manifest.json";
 const char* const kFirmwareUpdateNoticeTexts[] = {
     "Update Available:",
     "vibetv.local",


### PR DESCRIPTION
## Summary
- publish a stable firmware-manifest.json asset on every tagged release
- include firmwareUrl/severity/message metadata in generated manifests
- move firmware and companion update checks from the Shopify CDN manifest to GitHub Releases latest/download/firmware-manifest.json

## Why
Shopify theme assets are served with long-lived immutable cache headers. The no-query firmware manifest URL can remain stale after updating the theme asset, so it is not reliable as the update source of truth.

## Tests
- go test ./... (companion)
- pio test -d firmware_esp8266 -e native_theme_spec_renderer
- scripts/check-firmware-size-budget.sh firmware_esp8266 esp8266_smalltv_st7789 45 82 470000