### PR TITLE
CODEX clear SDK WiFi credentials on reset

### DIFF
--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -490,6 +490,15 @@ void clearWifiCredentials() {
   Serial.println("wifi_credentials_cleared");
 }
 
+void clearSdkWifiCredentials() {
+  WiFi.persistent(true);
+  WiFi.mode(WIFI_STA);
+  WiFi.disconnect(true);
+  delay(150);
+  WiFi.persistent(false);
+  Serial.println("wifi_sdk_credentials_cleared");
+}
+
 uint8_t readBootRecoveryCounter() {
   EEPROM.begin(kEepromBytes);
   uint32_t magic = 0;
@@ -527,6 +536,7 @@ bool consumeBootRecoveryTrigger() {
 
   if (counter >= kBootRecoveryThreshold) {
     clearWifiCredentials();
+    clearSdkWifiCredentials();
     clearBootRecoveryCounter();
     Serial.println("boot_recovery_triggered action=wifi_setup");
     drawWifiResetStatus("Starting setup");
@@ -731,6 +741,7 @@ void handleResetWifi() {
   }
 
   clearWifiCredentials();
+  clearSdkWifiCredentials();
   clearBootRecoveryCounter();
   webServer.send(200, "text/html; charset=utf-8", "<!doctype html><p>WiFi settings cleared. Vibe TV is restarting setup.</p>");
   drawWifiResetStatus("Restarting");


### PR DESCRIPTION
## Summary
- clear ESP8266 SDK-persisted WiFi credentials during Reset WiFi
- also clear SDK credentials when boot recovery enters setup mode

## Why
Reset WiFi cleared our EEPROM credentials, but ESP8266 SDK credentials could still reconnect the device to the provisioning WiFi. That leaves a shipped device in ready mode instead of VibeTV-Setup.

## Tests
- go test ./... (companion)
- pio test -d firmware_esp8266 -e native_theme_spec_renderer
- CODEXBAR_DISPLAY_FW_VERSION=1.0.16 scripts/check-firmware-size-budget.sh firmware_esp8266 esp8266_smalltv_st7789 45 82 470000