### PR TITLE
CODEX delay WiFi disconnect until reset response

### DIFF
--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -740,13 +740,14 @@ void handleResetWifi() {
     return;
   }
 
-  clearWifiCredentials();
-  clearSdkWifiCredentials();
-  clearBootRecoveryCounter();
   webServer.send(200, "text/html; charset=utf-8", "<!doctype html><p>WiFi settings cleared. Vibe TV is restarting setup.</p>");
   drawWifiResetStatus("Restarting");
   waitStatusRendered = true;
   delay(500);
+  clearWifiCredentials();
+  clearSdkWifiCredentials();
+  clearBootRecoveryCounter();
+  delay(250);
   ESP.restart();
 }
 


### PR DESCRIPTION
## Summary
- send the Reset WiFi HTTP response before clearing SDK WiFi credentials
- keep the SDK credential wipe and reboot, but avoid cutting the socket before the response leaves

## Why
v1.0.16 clears SDK WiFi credentials correctly, but can disconnect the device before the reset response/restart path completes. This can leave the display on the previous mini frame until a power cycle.

## Tests
- go test ./... (companion)
- pio test -d firmware_esp8266 -e native_theme_spec_renderer
- CODEXBAR_DISPLAY_FW_VERSION=1.0.17 scripts/check-firmware-size-budget.sh firmware_esp8266 esp8266_smalltv_st7789 45 82 470000