### PR TITLE
CODEX retry transient theme asset uploads

### DIFF
--- a/companion/internal/transport/wifi_transport.go
+++ b/companion/internal/transport/wifi_transport.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -15,7 +17,13 @@ import (
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
 )
 
-const defaultWiFiTimeout = 5 * time.Second
+const (
+	defaultWiFiTimeout      = 5 * time.Second
+	assetUploadAttempts     = 3
+	assetUploadRetryMaxBody = 512
+)
+
+var assetUploadRetryDelay = 1500 * time.Millisecond
 
 type WiFiTransport struct {
 	client *http.Client
@@ -108,16 +116,65 @@ func (t WiFiTransport) UploadAsset(target, devicePath, filename string, data []b
 	}
 
 	endpoint := base + "/assets?path=" + url.QueryEscape(devicePath)
-	resp, err := t.client.Post(endpoint, writer.FormDataContentType(), &body)
-	if err != nil {
-		return fmt.Errorf("post asset %s: %w", devicePath, err)
+	contentType := writer.FormDataContentType()
+	var lastErr error
+	for attempt := 1; attempt <= assetUploadAttempts; attempt++ {
+		resp, err := t.client.Post(endpoint, contentType, bytes.NewReader(body.Bytes()))
+		if err != nil {
+			lastErr = fmt.Errorf("post asset %s: %w", devicePath, err)
+			if shouldRetryAssetUpload(err) && attempt < assetUploadAttempts {
+				time.Sleep(assetUploadRetryDelay)
+				continue
+			}
+			return lastErr
+		}
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			_ = resp.Body.Close()
+			return nil
+		}
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, assetUploadRetryMaxBody))
+		_ = resp.Body.Close()
+		lastErr = fmt.Errorf("post asset %s: status=%d body=%q", devicePath, resp.StatusCode, strings.TrimSpace(string(respBody)))
+		if !retryableAssetStatus(resp.StatusCode) || attempt >= assetUploadAttempts {
+			return lastErr
+		}
+		time.Sleep(assetUploadRetryDelay)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return fmt.Errorf("post asset %s: status=%d body=%q", devicePath, resp.StatusCode, strings.TrimSpace(string(body)))
+	return lastErr
+}
+
+func shouldRetryAssetUpload(err error) bool {
+	if err == nil {
+		return false
 	}
-	return nil
+	if errorsIsTimeout(err) {
+		return true
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "connection reset by peer") ||
+		strings.Contains(text, "broken pipe") ||
+		strings.Contains(text, "eof") ||
+		strings.Contains(text, "server closed idle connection")
+}
+
+func errorsIsTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		return true
+	}
+	if os.IsTimeout(err) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "client.timeout exceeded") ||
+		strings.Contains(strings.ToLower(err.Error()), "context deadline exceeded")
+}
+
+func retryableAssetStatus(statusCode int) bool {
+	return statusCode == http.StatusRequestTimeout ||
+		statusCode == http.StatusTooManyRequests ||
+		(statusCode >= 500 && statusCode <= 599)
 }
 
 func (t WiFiTransport) ActivateStoredTheme(target, devicePath string) error {

--- a/companion/internal/transport/wifi_transport_test.go
+++ b/companion/internal/transport/wifi_transport_test.go
@@ -1,10 +1,13 @@
 package transport
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestWiFiTransportDeviceCapabilitiesReadsHello(t *testing.T) {
@@ -105,6 +108,52 @@ func TestWiFiTransportUploadAssetPostsMultipart(t *testing.T) {
 	}
 }
 
+func TestWiFiTransportUploadAssetRetriesConnectionReset(t *testing.T) {
+	previousDelay := assetUploadRetryDelay
+	assetUploadRetryDelay = time.Millisecond
+	t.Cleanup(func() {
+		assetUploadRetryDelay = previousDelay
+	})
+
+	var attempts int
+	var gotPath string
+	transport := NewWiFiTransportWithClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, errors.New("read tcp 192.168.178.172:55149->192.168.178.163:80: read: connection reset by peer")
+			}
+			if req.URL.Path != "/assets" {
+				t.Fatalf("unexpected path %s", req.URL.Path)
+			}
+			gotPath = req.URL.Query().Get("path")
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			if !strings.Contains(string(body), "CBI1") {
+				t.Fatalf("expected retry body to contain asset data, got %q", string(body))
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}),
+	})
+
+	if err := transport.UploadAsset("http://vibetv.local", "/themes/u/cm.cbi", "cm.cbi", []byte("CBI1\n")); err != nil {
+		t.Fatalf("UploadAsset returned error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected one retry, got attempts=%d", attempts)
+	}
+	if gotPath != "/themes/u/cm.cbi" {
+		t.Fatalf("unexpected path %q", gotPath)
+	}
+}
+
 func TestWiFiTransportActivateStoredThemePostsPath(t *testing.T) {
 	var gotBody string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -127,4 +176,10 @@ func TestWiFiTransportActivateStoredThemePostsPath(t *testing.T) {
 	if gotBody != `{"path":"/themes/u/cm.json"}` {
 		t.Fatalf("unexpected body %q", gotBody)
 	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }


### PR DESCRIPTION
## Summary
- retry transient WiFi `/assets` upload failures during theme-pack install
- handle connection reset, EOF, broken pipe, timeout, 408/429, and 5xx responses
- keep the multipart asset body reusable so retries resend the full file
- add a regression test for retrying a reset upload connection

## Validation
- `git diff --check`
- `go test ./internal/transport ./cmd/codexbar-display`
- `go test ./...` from `companion`
- live smoke: `go run ./cmd/codexbar-display theme-pack install --theme claude-creature --target http://vibetv.local` uploaded all Claude assets and rendered on firmware 1.0.20
