### PR TITLE
[codex] Fix VibeTV update cache and mDNS refresh

### DIFF
--- a/companion/internal/daemon/daemon.go
+++ b/companion/internal/daemon/daemon.go
@@ -199,6 +199,8 @@ type runtimeState struct {
 	firmwareUpdate         protocol.UpdateState
 	hasFirmwareUpdate      bool
 	updateCheckedAt        time.Time
+	updateCheckedBoard     string
+	updateCheckedFirmware  string
 	lastActivityAt         time.Time
 	lastActivityObservedAt time.Time
 	lastIdleEvidenceAt     time.Time
@@ -571,7 +573,13 @@ func attachFirmwareUpdateState(ctx context.Context, state *runtimeState, deps ru
 	}
 
 	now := deps.now()
-	if state.hasFirmwareUpdate && now.Sub(state.updateCheckedAt) >= 0 && now.Sub(state.updateCheckedAt) < firmwareUpdateCheckGap {
+	board := strings.TrimSpace(strings.ToLower(caps.Board))
+	firmware := strings.TrimSpace(caps.Firmware)
+	if state.hasFirmwareUpdate &&
+		state.updateCheckedBoard == board &&
+		state.updateCheckedFirmware == firmware &&
+		now.Sub(state.updateCheckedAt) >= 0 &&
+		now.Sub(state.updateCheckedAt) < firmwareUpdateCheckGap {
 		update := state.firmwareUpdate
 		result.frame.Update = &update
 		return
@@ -588,6 +596,8 @@ func attachFirmwareUpdateState(ctx context.Context, state *runtimeState, deps ru
 	state.firmwareUpdate = update
 	state.hasFirmwareUpdate = true
 	state.updateCheckedAt = now
+	state.updateCheckedBoard = board
+	state.updateCheckedFirmware = firmware
 	result.frame.Update = &update
 }
 

--- a/companion/internal/daemon/daemon_test.go
+++ b/companion/internal/daemon/daemon_test.go
@@ -1108,6 +1108,67 @@ func TestRunCycleWithDepsAttachesFirmwareUpdateState(t *testing.T) {
 	}
 }
 
+func TestRunCycleWithDepsRefreshesFirmwareUpdateCacheWhenFirmwareChanges(t *testing.T) {
+	prepareFastTestEnv(t)
+
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	state := &runtimeState{
+		selector: codexbar.NewProviderSelector(),
+	}
+	firmwareVersion := "1.0.0"
+	var fetchUpdateCalls int
+	var sentLine []byte
+	deps := runtimeDeps{
+		now:         func() time.Time { return now },
+		resolvePort: func(string) (string, error) { return "http://vibetv.local", nil },
+		deviceCaps: func(string) (protocol.DeviceCapabilities, error) {
+			return protocol.DeviceCapabilities{
+				Known:                     true,
+				Board:                     "esp8266-smalltv-st7789",
+				Firmware:                  firmwareVersion,
+				NegotiatedProtocolVersion: 2,
+				MaxFrameBytes:             1024,
+			}, nil
+		},
+		fetchProviders: func(context.Context) ([]codexbar.ParsedFrame, error) {
+			return []codexbar.ParsedFrame{testParsedFrame("codex", 12, 30, 3600)}, nil
+		},
+		fetchUpdateState: func(_ context.Context, caps protocol.DeviceCapabilities) (protocol.UpdateState, error) {
+			fetchUpdateCalls++
+			if caps.Firmware == "1.0.0" {
+				return protocol.UpdateState{Available: true, LatestVersion: "1.0.1", Status: "update_available"}, nil
+			}
+			return protocol.UpdateState{Available: false, LatestVersion: "1.0.1", Status: "current"}, nil
+		},
+		logf: func(string, ...any) {},
+		sendLine: func(_ string, line []byte) error {
+			sentLine = append([]byte(nil), line...)
+			return nil
+		},
+	}
+
+	if err := runCycleWithDeps(context.Background(), "", state, deps); err != nil {
+		t.Fatalf("first cycle: %v", err)
+	}
+	firstFrame := decodeFrameLine(t, sentLine)
+	if firstFrame.Update == nil || !firstFrame.Update.Available {
+		t.Fatalf("expected first cycle update available, got %+v", firstFrame.Update)
+	}
+
+	firmwareVersion = "1.0.1"
+	now = now.Add(time.Minute)
+	if err := runCycleWithDeps(context.Background(), "", state, deps); err != nil {
+		t.Fatalf("second cycle: %v", err)
+	}
+	secondFrame := decodeFrameLine(t, sentLine)
+	if secondFrame.Update == nil || secondFrame.Update.Available || secondFrame.Update.Status != "current" {
+		t.Fatalf("expected second cycle current update state, got %+v", secondFrame.Update)
+	}
+	if fetchUpdateCalls != 2 {
+		t.Fatalf("expected update state to refresh after firmware change, got %d calls", fetchUpdateCalls)
+	}
+}
+
 func TestRunCycleWithDepsPreservesFirmwareUpdateNoticeForLegacyDevice(t *testing.T) {
 	prepareFastTestEnv(t)
 

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -159,6 +159,7 @@ unsigned long lastFrameAcceptedAtMs = 0;
 bool frameStaleStatusRendered = false;
 bool captiveDnsStarted = false;
 bool mdnsStarted = false;
+IPAddress mdnsAddress;
 unsigned long wifiDisconnectedAtMs = 0;
 unsigned long wifiReconnectAttemptAtMs = 0;
 bool wifiReconnectStatusRendered = false;
@@ -400,8 +401,16 @@ void resetWifiReconnectState() {
 }
 
 void startMdnsResponder(const IPAddress& address) {
-  if (mdnsStarted) {
+  if (mdnsStarted && mdnsAddress == address) {
     return;
+  }
+  if (mdnsStarted) {
+    MDNS.close();
+    mdnsStarted = false;
+    Serial.printf("mdns_restarting host=%s old_ip=%s new_ip=%s\n",
+                  kMdnsHost,
+                  mdnsAddress.toString().c_str(),
+                  address.toString().c_str());
   }
   if (!MDNS.begin(kMdnsName, address)) {
     Serial.printf("mdns_start_failed host=%s ip=%s\n", kMdnsHost, address.toString().c_str());
@@ -409,7 +418,18 @@ void startMdnsResponder(const IPAddress& address) {
   }
   MDNS.addService("http", "tcp", 80);
   mdnsStarted = true;
+  mdnsAddress = address;
   Serial.printf("mdns_started host=%s ip=%s service=http\n", kMdnsHost, address.toString().c_str());
+}
+
+void stopMdnsResponder(const char* reason) {
+  if (!mdnsStarted) {
+    return;
+  }
+  MDNS.close();
+  mdnsStarted = false;
+  mdnsAddress = IPAddress();
+  Serial.printf("mdns_stopped host=%s reason=%s\n", kMdnsHost, reason == nullptr ? "unknown" : reason);
 }
 
 String displayErrorMessage(const String& message) {
@@ -2027,6 +2047,7 @@ void maintainWifiConnection() {
       Serial.printf("wifi_reconnected ip=%s\n", WiFi.localIP().toString().c_str());
       drawWaitingForCompanionStatus();
     }
+    startMdnsResponder(WiFi.localIP());
     resetWifiReconnectState();
     return;
   }
@@ -2038,6 +2059,7 @@ void maintainWifiConnection() {
     Serial.printf("wifi_disconnected status=%d fallback_ms=%lu\n",
                   static_cast<int>(WiFi.status()),
                   kWifiReconnectFallbackMs);
+    stopMdnsResponder("wifi_disconnected");
   }
 
   if (!wifiReconnectStatusRendered) {


### PR DESCRIPTION
## What changed

- Cache firmware update checks per device board and firmware version instead of only by time.
- Restart ESP8266 mDNS when the advertised IP changes and stop it when WiFi disconnects.
- Add a daemon regression test covering firmware version changes after OTA.

## Why

After OTA, the daemon could keep sending a cached `update_available` state for up to six hours even though the device already reported the target firmware. Separately, `vibetv.local` could keep pointing at an old address after reconnect/IP change.

## Validation

- `go test ./...` in `companion`
- `pio run -d firmware_esp8266 -e esp8266_smalltv_st7789`
