### PR TITLE
[codex] Harden setup dependency preflight

### DIFF
--- a/companion/internal/errcode/errcode.go
+++ b/companion/internal/errcode/errcode.go
@@ -34,6 +34,7 @@ const (
 
 	SetupCodexbarValidate    Code = "setup/codexbar-validate"
 	SetupCodexbarInstall     Code = "setup/codexbar-install"
+	SetupDependencyPreflight Code = "setup/dependency-preflight"
 	SetupListPorts           Code = "setup/list-ports"
 	SetupSelectPort          Code = "setup/select-port"
 	SetupSerialProbe         Code = "setup/serial-probe"
@@ -141,6 +142,8 @@ func DefaultRecovery(code Code) string {
 		return "Install CodexBar CLI (`brew install --cask steipete/tap/codexbar`) and rerun setup."
 	case SetupCodexbarInstall:
 		return "Install CodexBar manually, then rerun setup."
+	case SetupDependencyPreflight:
+		return "Install the missing setup dependency shown above, then rerun setup."
 	case SetupListPorts, SetupSelectPort:
 		return "Reconnect the board and retry port selection."
 	case SetupSerialProbe:

--- a/companion/internal/setup/setup.go
+++ b/companion/internal/setup/setup.go
@@ -177,6 +177,8 @@ func (e *StepError) ErrorCode() errcode.Code {
 		return errcode.SetupCodexbarValidate
 	case "codexbar-install":
 		return errcode.SetupCodexbarInstall
+	case "dependency-preflight":
+		return errcode.SetupDependencyPreflight
 	case "list-ports":
 		return errcode.SetupListPorts
 	case "select-port":
@@ -239,12 +241,7 @@ func runWithDeps(ctx context.Context, opts Options, d deps) error {
 	}
 	fmt.Fprintf(d.stdout, "Mode: %s\n", mode)
 
-	allowInstall := !opts.ValidateOnly && !opts.DryRun
-	codexbarBin, err := ensureCodexbar(ctx, d, allowInstall)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(d.stdout, "CodexBar CLI: %s\n", codexbarBin)
+	var err error
 
 	transportName := normalizeSetupTransport(opts.Transport)
 	if transportName == "" {
@@ -272,6 +269,18 @@ func runWithDeps(ctx context.Context, opts Options, d deps) error {
 	if target != "" {
 		fmt.Fprintf(d.stdout, "Launch agent target: %s\n", target)
 	}
+
+	if err := runDependencyPreflight(opts, transportName, d); err != nil {
+		return err
+	}
+	fmt.Fprintln(d.stdout, "Setup preflight: ok")
+
+	allowInstall := !opts.ValidateOnly && !opts.DryRun
+	codexbarBin, err := ensureCodexbar(ctx, d, allowInstall)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(d.stdout, "CodexBar CLI: %s\n", codexbarBin)
 
 	port := ""
 	if transportName == "usb" {
@@ -569,6 +578,40 @@ func normalizeSetupTarget(value string) string {
 		target = "http://" + target
 	}
 	return target
+}
+
+func runDependencyPreflight(opts Options, transportName string, d deps) error {
+	if !opts.ValidateOnly && !opts.DryRun {
+		if err := requireSetupCommand(d, "launchctl",
+			"starts and restarts the VibeTV background service on macOS",
+			"run setup on macOS as your normal logged-in user, then rerun `codexbar-display setup`",
+		); err != nil {
+			return err
+		}
+	}
+
+	if normalizeSetupTransport(transportName) == "usb" && !opts.SkipFlash {
+		if err := requireSetupCommand(d, "pio",
+			"builds and uploads VibeTV firmware when USB flashing is requested",
+			"install PlatformIO CLI with `python3 -m pip install --user platformio`, ensure `pio` is in PATH, then rerun setup",
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func requireSetupCommand(d deps, name, why, action string) error {
+	if _, err := d.lookPath(name); err != nil {
+		return &StepError{
+			Step: "dependency-preflight",
+			Code: errcode.SetupDependencyPreflight,
+			Err:  fmt.Errorf("missing dependency %q: %s (%w)", name, why, err),
+			Hint: action,
+		}
+	}
+	return nil
 }
 
 func ensureCodexbar(ctx context.Context, d deps, allowInstall bool) (string, error) {

--- a/companion/internal/setup/setup_test.go
+++ b/companion/internal/setup/setup_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/errcode"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/runtimeconfig"
 )
@@ -63,7 +64,7 @@ func TestRunWithDepsInstallsCodexbarAndCompletesSetup(t *testing.T) {
 		},
 		lookPath: func(file string) (string, error) {
 			switch file {
-			case "brew", "pio", "open":
+			case "brew", "pio", "open", "launchctl":
 				return "/usr/bin/" + file, nil
 			default:
 				return "", errors.New("not found")
@@ -577,6 +578,76 @@ func TestRunWithDepsContinuesWhenSkipFlashAndProbeFails(t *testing.T) {
 	}
 }
 
+func TestRunWithDepsFailsPreflightWhenLaunchctlMissing(t *testing.T) {
+	err := runWithDeps(context.Background(), Options{SkipFlash: true, AssumeYes: true}, deps{
+		stdin:  strings.NewReader(""),
+		stdout: &bytes.Buffer{},
+		lookPath: func(file string) (string, error) {
+			if file == "launchctl" {
+				return "", errors.New("not found")
+			}
+			return "/usr/bin/" + file, nil
+		},
+		findCodexbar: func() (string, error) {
+			t.Fatalf("preflight should fail before CodexBar detection")
+			return "", nil
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected setup preflight failure")
+	}
+	if got := errcode.Of(err); got != errcode.SetupDependencyPreflight {
+		t.Fatalf("expected dependency preflight code, got %s", got)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "missing dependency \"launchctl\"") {
+		t.Fatalf("expected launchctl dependency message, got %q", msg)
+	}
+	if !strings.Contains(msg, "starts and restarts the VibeTV background service") {
+		t.Fatalf("expected why-it-is-needed text, got %q", msg)
+	}
+	if !strings.Contains(msg, "rerun `codexbar-display setup`") {
+		t.Fatalf("expected concrete recovery action, got %q", msg)
+	}
+}
+
+func TestRunWithDepsFailsPreflightWhenPlatformIOMissingForUSBFlash(t *testing.T) {
+	err := runWithDeps(context.Background(), Options{Transport: "usb", AssumeYes: true}, deps{
+		stdin:  strings.NewReader(""),
+		stdout: &bytes.Buffer{},
+		lookPath: func(file string) (string, error) {
+			switch file {
+			case "launchctl":
+				return "/bin/launchctl", nil
+			case "pio":
+				return "", errors.New("not found")
+			default:
+				return "/usr/bin/" + file, nil
+			}
+		},
+		findCodexbar: func() (string, error) {
+			t.Fatalf("preflight should fail before CodexBar detection")
+			return "", nil
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected setup preflight failure")
+	}
+	if got := errcode.Of(err); got != errcode.SetupDependencyPreflight {
+		t.Fatalf("expected dependency preflight code, got %s", got)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "missing dependency \"pio\"") {
+		t.Fatalf("expected pio dependency message, got %q", msg)
+	}
+	if !strings.Contains(msg, "USB flashing is requested") {
+		t.Fatalf("expected why-it-is-needed text, got %q", msg)
+	}
+	if !strings.Contains(msg, "python3 -m pip install --user platformio") {
+		t.Fatalf("expected PlatformIO install action, got %q", msg)
+	}
+}
+
 func TestRunWithDepsFailsWithRecoveryWhenCodexbarInstallNotPossible(t *testing.T) {
 	var calls []commandCall
 	err := runWithDeps(context.Background(), Options{SkipFlash: true, AssumeYes: true}, deps{
@@ -596,7 +667,7 @@ func TestRunWithDepsFailsWithRecoveryWhenCodexbarInstallNotPossible(t *testing.T
 			return "", errors.New("missing")
 		},
 		lookPath: func(file string) (string, error) {
-			if file == "open" {
+			if file == "launchctl" || file == "open" {
 				return "/usr/bin/open", nil
 			}
 			return "", errors.New("not found")
@@ -702,7 +773,7 @@ func TestRunWithDepsReportsFlashFailureWithConcreteHint(t *testing.T) {
 		},
 		lookPath: func(file string) (string, error) {
 			switch file {
-			case "pio", "brew", "open":
+			case "pio", "brew", "open", "launchctl":
 				return "/usr/bin/" + file, nil
 			default:
 				return "", errors.New("not found")
@@ -766,7 +837,7 @@ func TestRunWithDepsWaitsForLaunchAgentToBecomeRunning(t *testing.T) {
 		},
 		lookPath: func(file string) (string, error) {
 			switch file {
-			case "pio", "brew", "open":
+			case "pio", "brew", "open", "launchctl":
 				return "/usr/bin/" + file, nil
 			default:
 				return "", errors.New("not found")
@@ -828,7 +899,7 @@ func TestRunWithDepsRetriesLaunchAgentBootstrapRace(t *testing.T) {
 		},
 		lookPath: func(file string) (string, error) {
 			switch file {
-			case "pio", "brew", "open":
+			case "pio", "brew", "open", "launchctl":
 				return "/usr/bin/" + file, nil
 			default:
 				return "", errors.New("not found")
@@ -897,7 +968,7 @@ func TestRunWithDepsFallsBackToKickstartWhenLaunchAgentAlreadyLoaded(t *testing.
 		},
 		lookPath: func(file string) (string, error) {
 			switch file {
-			case "pio", "brew", "open":
+			case "pio", "brew", "open", "launchctl":
 				return "/usr/bin/" + file, nil
 			default:
 				return "", errors.New("not found")

--- a/docs/customer-setup.md
+++ b/docs/customer-setup.md
@@ -91,6 +91,20 @@ The installer handles everything automatically:
 6. It starts the background service that sends frames to the Vibe TV IP.
 7. It runs a health check at the end.
 
+## Setup Dependency Checks
+
+The installer checks required tools before setup changes anything important. If something is missing, it stops with the dependency name, why it is needed, and the next command or action.
+
+| Dependency | Why it is needed | What to do if missing |
+| --- | --- | --- |
+| `curl` | Downloads the VibeTV installer files from GitHub. | Use a standard macOS Terminal with `curl` available, then rerun the installer. |
+| `shasum`, `awk`, `sed`, `grep`, `uname`, `mktemp` | Verifies the release and detects the right Mac binary. | Install the macOS command line tools, then rerun the installer. |
+| `launchctl` | Starts the background service that sends frames to Vibe TV. | Run setup on macOS as your normal logged-in user, then rerun `codexbar-display setup`. |
+| CodexBar CLI | Provides the usage data shown on Vibe TV. | The setup tries Homebrew automatically. If that fails, run `brew install --cask steipete/tap/codexbar`, then rerun setup. |
+| `pio` | Only needed for manual USB firmware flashing. | Standard WiFi setup does not need this. For USB flashing, install PlatformIO with `python3 -m pip install --user platformio`, then rerun setup. |
+
+Setup is safe to rerun after fixing a missing dependency.
+
 ## What Success Looks Like
 
 - Terminal prints a successful setup message.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,9 +54,16 @@ die() {
   exit 1
 }
 
-require_cmd() {
-  if ! command -v "$1" >/dev/null 2>&1; then
-    die "missing required command: $1"
+require_cmd_for() {
+  local cmd="$1"
+  local why="$2"
+  local action="$3"
+
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    printf 'error: missing dependency: %s\n' "$cmd" >&2
+    printf 'needed for: %s\n' "$why" >&2
+    printf 'next step: %s\n' "$action" >&2
+    exit 1
   fi
 }
 
@@ -266,13 +273,13 @@ main() {
     exit 0
   fi
 
-  require_cmd curl
-  require_cmd shasum
-  require_cmd awk
-  require_cmd sed
-  require_cmd grep
-  require_cmd uname
-  require_cmd mktemp
+  require_cmd_for curl "download the VibeTV installer files from GitHub" "install curl or use a standard macOS Terminal, then rerun the installer."
+  require_cmd_for shasum "verify the downloaded VibeTV binary checksum" "install the macOS command line tools, then rerun the installer."
+  require_cmd_for awk "read the expected checksum from the release file" "install the macOS command line tools, then rerun the installer."
+  require_cmd_for sed "read the latest GitHub release version" "install the macOS command line tools, then rerun the installer."
+  require_cmd_for grep "find the matching checksum entry" "install the macOS command line tools, then rerun the installer."
+  require_cmd_for uname "detect your Mac CPU architecture" "use a standard macOS Terminal, then rerun the installer."
+  require_cmd_for mktemp "create a temporary download folder" "use a standard macOS Terminal, then rerun the installer."
 
   if [[ "$(uname -s)" != "Darwin" ]]; then
     die "this installer only supports macOS"


### PR DESCRIPTION
## Summary
- add an explicit setup dependency preflight before setup starts doing install/service work
- report missing `launchctl` and USB-flash `pio` with the dependency name, why it is needed, and the exact recovery action
- make installer bootstrap dependency failures more customer-readable and document the dependency list

## Validation
- `bash -n scripts/install.sh`
- `go test ./internal/setup ./internal/errcode`
- `go test ./...` from `companion`
- `git diff --check`
- read-only VibeTV `/hello` check on `http://192.168.178.163/hello`

## Notes
No CI limits changed. No VibeTV reset or USB flash was performed.
