### PR TITLE
[codex] Make theme install logs readable

### DIFF
--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -90,14 +90,14 @@ func printUsage() {
 	fmt.Println("  codexbar-display service <start|stop|status>")
 	fmt.Println("  codexbar-display version [--short] [--json]")
 	fmt.Println("  codexbar-display upgrade [--port /dev/cu.usbserial-10] [--firmware-env env] [--target-firmware-version x.y.z] [--repo owner/name] [--skip-version-guard]")
-	fmt.Println("  codexbar-display install-update [--target http://vibetv.local] [--manifest-url url] [--confirm-live-update] [--force]")
+	fmt.Println("  codexbar-display install-update [--target http://vibetv.local] [--manifest-url url] [--confirm-live-update] [--force] [--verbose]")
 	fmt.Println("  codexbar-display rollback [--port /dev/cu.usbserial-10] [--skip-companion] [--skip-firmware] [--image path/to/backup.bin] [--manifest path/to/backup.manifest] [--backup-dir <dir>] [--script-path <path>] [--skip-verify]")
 	fmt.Println("  codexbar-display restore-known-good [--port /dev/cu.usbserial-10] [--image path/to/backup.bin] [--backup-dir <dir>] [--script-path <path>] [--manifest <path>] [--skip-verify]")
 	fmt.Println("  codexbar-display theme-validate --spec path/to/theme-spec.json [--transport wifi|usb] [--target http://vibetv.local] [--port /dev/cu.usbserial-10] [--allow-unknown-capabilities]")
 	fmt.Println("  codexbar-display theme-apply --spec path/to/theme-spec.json [--transport wifi|usb] [--target http://vibetv.local] [--port /dev/cu.usbserial-10] [--allow-unknown-capabilities]")
 	fmt.Println("  codexbar-display theme-pack catalog [--catalog https://raw.githubusercontent.com/DreamyTalesPAN/CodexBar-Display/main/dist/theme-packs/vibetv-theme-packs.json]")
 	fmt.Println("  codexbar-display theme-pack validate --pack path/to/theme-pack-dir-or.zip-or-url")
-	fmt.Println("  codexbar-display theme-pack install (--pack path/to/theme-pack-dir-or.zip-or-url | --catalog url --theme theme-id) [--target http://vibetv.local] [--firmware-manifest-url url] [--skip-firmware-update] [--allow-unknown-capabilities]")
+	fmt.Println("  codexbar-display theme-pack install (--pack path/to/theme-pack-dir-or.zip-or-url | --catalog url --theme theme-id) [--target http://vibetv.local] [--firmware-manifest-url url] [--skip-firmware-update] [--allow-unknown-capabilities] [--verbose]")
 	fmt.Println("  codexbar-display setup [--transport wifi|usb] [--target http://vibetv.local] [--port /dev/cu.usbserial-10] [--yes] [--skip-flash] [--pin-port] [--firmware-env env] [--theme classic|crt|mini|none] [--validate-only] [--dry-run]")
 }
 
@@ -566,6 +566,7 @@ func runThemePackInstall(args []string) error {
 	target := fs.String("target", setup.DefaultWiFiTarget(), "WiFi target base URL, for example http://vibetv.local")
 	firmwareManifestURL := fs.String("firmware-manifest-url", vibeTVFirmwareManifestURL, "firmware manifest URL checked before installing the theme pack")
 	skipFirmwareUpdate := fs.Bool("skip-firmware-update", false, "skip the firmware update preflight before installing the theme pack")
+	verbose := fs.Bool("verbose", false, "show detailed theme install paths and byte counts")
 	allowUnknown := fs.Bool(
 		"allow-unknown-capabilities",
 		false,
@@ -582,30 +583,62 @@ func runThemePackInstall(args []string) error {
 	if err != nil {
 		return err
 	}
+	themeName := strings.TrimSpace(pack.Manifest.Name)
+	if themeName == "" {
+		themeName = pack.Manifest.ID
+	}
+	fmt.Printf("Preparing theme: %s\n", themeName)
+	if *verbose {
+		fmt.Printf("Theme source: %s\n", resolvedPack)
+	}
 
 	wifi := transportlayer.NewWiFiTransportWithClient(&http.Client{Timeout: themePackWiFiTimeout})
 	resolvedTarget, err := wifi.ResolvePort(strings.TrimSpace(*target))
 	if err != nil {
-		return err
+		return &commandError{
+			Op:   "theme-pack/resolve-target",
+			Code: errcode.UpgradeFlashFirmware,
+			Err:  err,
+			Hint: "use --target http://vibetv.local or the IP shown on Vibe TV",
+		}
 	}
 	if !*skipFirmwareUpdate {
 		if err := themePackInstallFirmwareUpdateFn(resolvedTarget, strings.TrimSpace(*firmwareManifestURL)); err != nil {
-			return fmt.Errorf("firmware update before theme install: %w", err)
+			return &commandError{
+				Op:   "theme-pack/check-firmware",
+				Code: errcode.UpgradeFlashFirmware,
+				Err:  err,
+				Hint: "keep VibeTV powered and on the same WiFi, then retry theme install",
+			}
 		}
+	} else if *verbose {
+		fmt.Println("Firmware check: skipped")
 	}
+	fmt.Println("Checking device...")
 	caps, err := wifi.DeviceCapabilities(resolvedTarget)
 	if err != nil {
 		if !*allowUnknown {
-			return err
+			return &commandError{
+				Op:   "theme-pack/check-device",
+				Code: errcode.UpgradeFlashFirmware,
+				Err:  fmt.Errorf("VibeTV is not reachable at %s: %w", resolvedTarget, err),
+				Hint: "check VibeTV power/WiFi or pass --target http://<device-ip>",
+			}
 		}
 		caps = fallbackThemeSpecCapabilities()
 		caps.ActiveTransport = "wifi"
-		fmt.Printf("warning: device hello unavailable; using local fallback capabilities for validation on %s\n", resolvedTarget)
+		fmt.Println("Checking device: using local fallback profile")
+		if *verbose {
+			fmt.Printf("Device warning: hello unavailable for %s: %v\n", resolvedTarget, err)
+		}
 	}
 	if *allowUnknown && !caps.Known {
 		caps = fallbackThemeSpecCapabilities()
 		caps.ActiveTransport = "wifi"
-		fmt.Printf("warning: capabilities unknown; using local fallback profile on %s\n", resolvedTarget)
+		fmt.Println("Checking device: using local fallback profile")
+		if *verbose {
+			fmt.Printf("Device warning: capabilities unknown on %s\n", resolvedTarget)
+		}
 	}
 	if !*allowUnknown && !caps.Known {
 		return &commandError{
@@ -613,6 +646,9 @@ func runThemePackInstall(args []string) error {
 			Code: errcode.ProtocolThemeSpecIncompatible,
 			Err:  errors.New("device capabilities unavailable; connect device and retry"),
 		}
+	}
+	if *verbose {
+		fmt.Printf("Device: board=%s protocol=%d target=%s\n", caps.Board, caps.NegotiatedProtocolVersion, resolvedTarget)
 	}
 	if err := themespec.ValidateAgainstCapabilities(pack.ThemeSpec, pack.ThemeSpecRaw, caps); err != nil {
 		return &commandError{
@@ -622,19 +658,57 @@ func runThemePackInstall(args []string) error {
 		}
 	}
 
+	retryNoted := false
+	wifi = wifi.WithAssetUploadRetryObserver(func(retry transportlayer.AssetUploadRetry) {
+		if !retryNoted {
+			fmt.Println("Upload interrupted, retrying...")
+			retryNoted = true
+		}
+		if *verbose {
+			reason := ""
+			if retry.Err != nil {
+				reason = retry.Err.Error()
+			} else if retry.StatusCode > 0 {
+				reason = fmt.Sprintf("status=%d", retry.StatusCode)
+			}
+			fmt.Printf("Retrying upload: path=%s attempt=%d/%d %s\n", retry.DevicePath, retry.Attempt+1, retry.MaxAttempts, strings.TrimSpace(reason))
+		}
+	})
+
+	fmt.Println("Uploading theme files...")
 	for _, asset := range pack.Assets {
 		if err := wifi.UploadAsset(resolvedTarget, asset.Entry.Path, filepath.Base(asset.Entry.File), asset.Data); err != nil {
-			return err
+			return &commandError{
+				Op:   "theme-pack/upload",
+				Code: errcode.UpgradeFlashFirmware,
+				Err:  themePackUploadError(asset.Entry.Path, err, *verbose),
+				Hint: "keep VibeTV powered and on the same WiFi, then retry theme install",
+			}
 		}
-		fmt.Printf("uploaded asset: %s bytes=%d\n", asset.Entry.Path, len(asset.Data))
+		if *verbose {
+			fmt.Printf("Uploaded asset: %s bytes=%d\n", asset.Entry.Path, len(asset.Data))
+		}
 	}
 	if err := wifi.UploadAsset(resolvedTarget, pack.ThemeSpecFile.Entry.Path, filepath.Base(pack.ThemeSpecFile.Entry.File), pack.ThemeSpecRaw); err != nil {
-		return err
+		return &commandError{
+			Op:   "theme-pack/upload",
+			Code: errcode.UpgradeFlashFirmware,
+			Err:  themePackUploadError(pack.ThemeSpecFile.Entry.Path, err, *verbose),
+			Hint: "keep VibeTV powered and on the same WiFi, then retry theme install",
+		}
 	}
-	fmt.Printf("uploaded theme spec: %s bytes=%d\n", pack.ThemeSpecFile.Entry.Path, len(pack.ThemeSpecRaw))
+	if *verbose {
+		fmt.Printf("Uploaded theme spec: %s bytes=%d\n", pack.ThemeSpecFile.Entry.Path, len(pack.ThemeSpecRaw))
+	}
 
+	fmt.Println("Activating theme...")
 	if err := wifi.ActivateStoredTheme(resolvedTarget, pack.ThemeSpecFile.Entry.Path); err != nil {
-		return err
+		return &commandError{
+			Op:   "theme-pack/activate",
+			Code: errcode.UpgradeFlashFirmware,
+			Err:  err,
+			Hint: "keep VibeTV powered and on the same WiFi, then retry theme install",
+		}
 	}
 
 	frame := protocol.Frame{
@@ -653,18 +727,26 @@ func runThemePackInstall(args []string) error {
 		return err
 	}
 	if err := wifi.SendLine(resolvedTarget, line); err != nil {
-		return err
+		return &commandError{
+			Op:   "theme-pack/send-frame",
+			Code: errcode.UpgradeFlashFirmware,
+			Err:  err,
+			Hint: "theme is installed; wait a moment or retry if the display did not update",
+		}
 	}
 
-	fmt.Printf(
-		"theme-pack installed: id=%s themeId=%s rev=%d target=%s activePath=%s\n",
-		pack.Manifest.ID,
-		pack.ThemeSpec.ThemeID,
-		pack.ThemeSpec.ThemeRev,
-		resolvedTarget,
-		pack.ThemeSpecFile.Entry.Path,
-	)
+	fmt.Printf("Done: theme %s installed on %s\n", pack.Manifest.ID, resolvedTarget)
+	if *verbose {
+		fmt.Printf("Active theme path: %s themeId=%s rev=%d\n", pack.ThemeSpecFile.Entry.Path, pack.ThemeSpec.ThemeID, pack.ThemeSpec.ThemeRev)
+	}
 	return nil
+}
+
+func themePackUploadError(devicePath string, err error, verbose bool) error {
+	if verbose {
+		return fmt.Errorf("upload failed for %s: %w", devicePath, err)
+	}
+	return fmt.Errorf("theme upload did not finish for %s", devicePath)
 }
 
 func resolveThemePackInstallSource(packPath, catalogRef, themeID string) (string, error) {

--- a/companion/cmd/codexbar-display/main_test.go
+++ b/companion/cmd/codexbar-display/main_test.go
@@ -187,13 +187,32 @@ func TestThemePackInstallSupportsPackURL(t *testing.T) {
 	}))
 	defer server.Close()
 
-	err := runThemePackInstall([]string{
-		"--pack", server.URL + "/cozy-meadow.zip",
-		"--target", server.URL,
+	output, err := captureStdout(t, func() error {
+		return runThemePackInstall([]string{
+			"--pack", server.URL + "/cozy-meadow.zip",
+			"--target", server.URL,
+		})
 	})
 	if err != nil {
 		t.Fatalf("runThemePackInstall returned error: %v", err)
 	}
+	for _, want := range []string{
+		"Preparing theme: Cozy Meadow",
+		"Checking device...",
+		"Uploading theme files...",
+		"Activating theme...",
+		"Done: theme cozy-meadow installed on " + server.URL,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, output)
+		}
+	}
+	for _, noisy := range []string{"uploaded asset:", "uploaded theme spec:", "activePath="} {
+		if strings.Contains(output, noisy) {
+			t.Fatalf("expected quiet install output not to contain %q, got:\n%s", noisy, output)
+		}
+	}
+
 	if !downloadedPack {
 		t.Fatalf("expected theme pack URL to be downloaded")
 	}
@@ -208,6 +227,148 @@ func TestThemePackInstallSupportsPackURL(t *testing.T) {
 	}
 	if !sentFrame {
 		t.Fatalf("expected live frame after activation")
+	}
+}
+
+func TestThemePackInstallLogsConciseRetry(t *testing.T) {
+	packZip := buildTestThemePackZip(t)
+	assetAttempts := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/cozy-meadow.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(packZip)
+		case "/hello":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","features":["theme","theme-spec-v1"],"maxFrameBytes":2048,"capabilities":{"theme":{"supportsThemeSpecV1":true,"maxThemeSpecBytes":1200,"maxThemePrimitives":8,"builtinThemes":["mini","classic"]},"transport":{"active":"wifi","supported":["wifi","usb"]}}}`))
+		case "/assets":
+			if r.URL.Query().Get("path") == "/themes/u/cm.cbi" {
+				assetAttempts++
+				if assetAttempts == 1 {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = w.Write([]byte("upload busy"))
+					return
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+		case "/theme/active", "/frame":
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	output, err := captureStdout(t, func() error {
+		return runThemePackInstall([]string{
+			"--pack", server.URL + "/cozy-meadow.zip",
+			"--target", server.URL,
+			"--skip-firmware-update",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runThemePackInstall returned error: %v", err)
+	}
+	if assetAttempts != 2 {
+		t.Fatalf("expected one retry for asset upload, got %d attempts", assetAttempts)
+	}
+	if got := strings.Count(output, "Upload interrupted, retrying..."); got != 1 {
+		t.Fatalf("expected one concise retry line, got %d in:\n%s", got, output)
+	}
+	if strings.Contains(output, "status=503") || strings.Contains(output, "upload busy") {
+		t.Fatalf("expected quiet retry output to hide raw server details, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Done: theme cozy-meadow installed on "+server.URL) {
+		t.Fatalf("expected done line, got:\n%s", output)
+	}
+}
+
+func TestThemePackInstallWrapsUploadFailureForCustomers(t *testing.T) {
+	packZip := buildTestThemePackZip(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/cozy-meadow.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(packZip)
+		case "/hello":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","features":["theme","theme-spec-v1"],"maxFrameBytes":2048,"capabilities":{"theme":{"supportsThemeSpecV1":true,"maxThemeSpecBytes":1200,"maxThemePrimitives":8,"builtinThemes":["mini","classic"]},"transport":{"active":"wifi","supported":["wifi","usb"]}}}`))
+		case "/assets":
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("raw device failure"))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	output, err := captureStdout(t, func() error {
+		return runThemePackInstall([]string{
+			"--pack", server.URL + "/cozy-meadow.zip",
+			"--target", server.URL,
+			"--skip-firmware-update",
+		})
+	})
+	if err == nil {
+		t.Fatalf("expected upload failure")
+	}
+	if !strings.Contains(output, "Upload interrupted, retrying...") {
+		t.Fatalf("expected concise retry output, got:\n%s", output)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "theme-pack/upload: theme upload did not finish for /themes/u/cm.cbi") {
+		t.Fatalf("expected customer-friendly upload error, got %q", msg)
+	}
+	for _, raw := range []string{"status=503", "raw device failure", "post asset"} {
+		if strings.Contains(msg, raw) {
+			t.Fatalf("expected non-verbose error to hide raw %q detail, got %q", raw, msg)
+		}
+	}
+}
+
+func TestThemePackInstallVerboseShowsDetails(t *testing.T) {
+	packZip := buildTestThemePackZip(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/cozy-meadow.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(packZip)
+		case "/hello":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","features":["theme","theme-spec-v1"],"maxFrameBytes":2048,"capabilities":{"theme":{"supportsThemeSpecV1":true,"maxThemeSpecBytes":1200,"maxThemePrimitives":8,"builtinThemes":["mini","classic"]},"transport":{"active":"wifi","supported":["wifi","usb"]}}}`))
+		case "/assets", "/theme/active", "/frame":
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	output, err := captureStdout(t, func() error {
+		return runThemePackInstall([]string{
+			"--pack", server.URL + "/cozy-meadow.zip",
+			"--target", server.URL,
+			"--skip-firmware-update",
+			"--verbose",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runThemePackInstall returned error: %v", err)
+	}
+	for _, want := range []string{
+		"Theme source:",
+		"Firmware check: skipped",
+		"Device: board=esp8266-smalltv-st7789",
+		"Uploaded asset: /themes/u/cm.cbi",
+		"Uploaded theme spec: /themes/u/cm.json",
+		"Active theme path: /themes/u/cm.json themeId=cozy-meadow rev=1",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected verbose output to contain %q, got:\n%s", want, output)
+		}
 	}
 }
 
@@ -328,4 +489,27 @@ func buildTestThemePackZip(t *testing.T) []byte {
 		t.Fatal(err)
 	}
 	return buf.Bytes()
+}
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = old
+	}()
+
+	runErr := fn()
+	if closeErr := writer.Close(); closeErr != nil {
+		t.Fatalf("close stdout pipe: %v", closeErr)
+	}
+	out, readErr := io.ReadAll(reader)
+	if readErr != nil {
+		t.Fatalf("read stdout pipe: %v", readErr)
+	}
+	return string(out), runErr
 }

--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -428,6 +428,7 @@ func runInstallUpdate(args []string) error {
 	manifestURL := fs.String("manifest-url", vibeTVFirmwareManifestURL, "firmware manifest URL")
 	force := fs.Bool("force", false, "install even when the device already reports the latest firmware")
 	confirmLiveUpdate := fs.Bool("confirm-live-update", false, "allow installing from the default live Shopify firmware manifest")
+	verbose := fs.Bool("verbose", false, "show manifest, asset, and local firmware file details")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -457,8 +458,10 @@ func runInstallUpdate(args []string) error {
 		}
 	}
 	caps := protocol.CapabilitiesFromHello(hello)
-	fmt.Printf("device: target=%s board=%s firmware=%s\n", base, caps.Board, caps.Firmware)
+	fmt.Println("Checking device...")
+	fmt.Printf("Device: %s firmware %s\n", caps.Board, caps.Firmware)
 
+	fmt.Println("Checking firmware...")
 	manifest, err := fetchReleaseFirmwareManifestURL(ctx, strings.TrimSpace(*manifestURL))
 	if err != nil {
 		return &commandError{Op: "fetch-firmware-manifest", Code: errcode.UpgradeFlashFirmware, Err: err}
@@ -478,17 +481,14 @@ func runInstallUpdate(args []string) error {
 		return &commandError{Op: "parse-target-firmware", Code: errcode.UpgradeVersionGuard, Err: nextErr}
 	}
 	if current.Compare(next) >= 0 && !*force {
-		fmt.Printf("firmware already current: installed=%s latest=%s\n", caps.Firmware, targetVersion)
+		fmt.Printf("Firmware: already current (%s)\n", caps.Firmware)
 		return nil
 	}
-	fmt.Printf(
-		"update plan: manifest=%s installed=%s target=%s board=%s asset=%s\n",
-		strings.TrimSpace(*manifestURL),
-		caps.Firmware,
-		targetVersion,
-		caps.Board,
-		strings.TrimSpace(artifact.Asset),
-	)
+	fmt.Printf("Updating firmware: %s -> %s\n", caps.Firmware, targetVersion)
+	if *verbose {
+		fmt.Printf("Firmware manifest: %s\n", strings.TrimSpace(*manifestURL))
+		fmt.Printf("Firmware asset: %s\n", strings.TrimSpace(artifact.Asset))
+	}
 
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -503,7 +503,9 @@ func runInstallUpdate(args []string) error {
 			Hint: "check network access and the manifest firmwareUrl/sha256 fields",
 		}
 	}
-	fmt.Printf("firmware downloaded: %s sha256=%s\n", imagePath, strings.TrimSpace(artifact.SHA256))
+	if *verbose {
+		fmt.Printf("Firmware downloaded: %s sha256=%s\n", imagePath, strings.TrimSpace(artifact.SHA256))
+	}
 
 	if err := uploadFirmwareOTAFn(ctx, base, imagePath); err != nil {
 		return &commandError{
@@ -513,7 +515,7 @@ func runInstallUpdate(args []string) error {
 			Hint: "keep VibeTV powered and on the same WiFi, then retry",
 		}
 	}
-	fmt.Println("firmware upload: ok; waiting for VibeTV to restart")
+	fmt.Println("Restarting VibeTV...")
 
 	if err := waitForHTTPFirmwareVersion(ctx, base, targetVersion, 90*time.Second); err != nil {
 		return &commandError{
@@ -523,7 +525,7 @@ func runInstallUpdate(args []string) error {
 			Hint: "wait one minute, then open http://vibetv.local/health",
 		}
 	}
-	fmt.Printf("update complete: firmware=%s\n", targetVersion)
+	fmt.Printf("Done: firmware %s installed\n", targetVersion)
 	return nil
 }
 

--- a/companion/cmd/codexbar-display/release_commands_test.go
+++ b/companion/cmd/codexbar-display/release_commands_test.go
@@ -477,12 +477,31 @@ func TestRunInstallUpdateDownloadsVerifiesAndUploadsOTA(t *testing.T) {
 	serverURL = server.URL
 	releaseHTTPClient = server.Client()
 
-	err := runInstallUpdate([]string{"--target", server.URL, "--manifest-url", server.URL + "/manifest.json"})
+	output, err := captureStdout(t, func() error {
+		return runInstallUpdate([]string{"--target", server.URL, "--manifest-url", server.URL + "/manifest.json"})
+	})
 	if err != nil {
 		t.Fatalf("install update: %v", err)
 	}
 	if !uploaded {
 		t.Fatal("expected OTA upload")
+	}
+	for _, want := range []string{
+		"Checking device...",
+		"Device: esp8266-smalltv-st7789 firmware 1.0.0",
+		"Checking firmware...",
+		"Updating firmware: 1.0.0 -> 1.0.1",
+		"Restarting VibeTV...",
+		"Done: firmware 1.0.1 installed",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, output)
+		}
+	}
+	for _, noisy := range []string{"update plan:", "firmware downloaded:", "sha256="} {
+		if strings.Contains(output, noisy) {
+			t.Fatalf("expected quiet update output not to contain %q, got:\n%s", noisy, output)
+		}
 	}
 }
 

--- a/companion/internal/transport/wifi_transport.go
+++ b/companion/internal/transport/wifi_transport.go
@@ -26,8 +26,19 @@ const (
 var assetUploadRetryDelay = 1500 * time.Millisecond
 
 type WiFiTransport struct {
-	client *http.Client
+	client                   *http.Client
+	assetUploadRetryObserver AssetUploadRetryObserver
 }
+
+type AssetUploadRetry struct {
+	DevicePath  string
+	Attempt     int
+	MaxAttempts int
+	Err         error
+	StatusCode  int
+}
+
+type AssetUploadRetryObserver func(AssetUploadRetry)
 
 func NewWiFiTransport() DeviceTransport {
 	return WiFiTransport{
@@ -40,6 +51,11 @@ func NewWiFiTransportWithClient(client *http.Client) WiFiTransport {
 		client = &http.Client{Timeout: defaultWiFiTimeout}
 	}
 	return WiFiTransport{client: client}
+}
+
+func (t WiFiTransport) WithAssetUploadRetryObserver(observer AssetUploadRetryObserver) WiFiTransport {
+	t.assetUploadRetryObserver = observer
+	return t
 }
 
 func (WiFiTransport) Name() string {
@@ -123,6 +139,12 @@ func (t WiFiTransport) UploadAsset(target, devicePath, filename string, data []b
 		if err != nil {
 			lastErr = fmt.Errorf("post asset %s: %w", devicePath, err)
 			if shouldRetryAssetUpload(err) && attempt < assetUploadAttempts {
+				t.noteAssetUploadRetry(AssetUploadRetry{
+					DevicePath:  devicePath,
+					Attempt:     attempt,
+					MaxAttempts: assetUploadAttempts,
+					Err:         err,
+				})
 				time.Sleep(assetUploadRetryDelay)
 				continue
 			}
@@ -138,9 +160,21 @@ func (t WiFiTransport) UploadAsset(target, devicePath, filename string, data []b
 		if !retryableAssetStatus(resp.StatusCode) || attempt >= assetUploadAttempts {
 			return lastErr
 		}
+		t.noteAssetUploadRetry(AssetUploadRetry{
+			DevicePath:  devicePath,
+			Attempt:     attempt,
+			MaxAttempts: assetUploadAttempts,
+			StatusCode:  resp.StatusCode,
+		})
 		time.Sleep(assetUploadRetryDelay)
 	}
 	return lastErr
+}
+
+func (t WiFiTransport) noteAssetUploadRetry(retry AssetUploadRetry) {
+	if t.assetUploadRetryObserver != nil {
+		t.assetUploadRetryObserver(retry)
+	}
 }
 
 func shouldRetryAssetUpload(err error) bool {


### PR DESCRIPTION
## Summary
- make `theme-pack install` output step-based and customer-readable by default
- add `--verbose` for detailed paths, byte counts, manifest and asset details
- show concise asset upload retry output and wrap non-verbose upload failures with a clear recovery path
- make `install-update` output shorter for already-current and update flows

## Validation
- `go test ./cmd/codexbar-display ./internal/transport`
- `go test ./...` from `companion`
- `git diff --check`
- Read/write hardware check before PR: `install-update` confirmed firmware already current on `192.168.178.163`; `theme-pack install` showed the new concise retry line during a real transient upload failure. Further VibeTV write testing stopped after the device needed manual WiFi rejoin.

## Notes
No CI limits changed. Future hardware write tests should be coordinated before running because theme/asset writes can force the device back into setup mode.
