### PR TITLE
CODEX: Add customer display brightness settings

### DIFF
--- a/companion/internal/protocol/device.go
+++ b/companion/internal/protocol/device.go
@@ -6,12 +6,21 @@ const (
 	FeatureTheme         = "theme"
 	FeatureThemeSpecV1   = "theme-spec-v1"
 	DefaultMaxFrameBytes = 512
+	DefaultMinBrightness = 10
+	DefaultMaxBrightness = 100
 )
 
+type DisplayBrightnessCapabilities struct {
+	Supported  bool `json:"supported,omitempty"`
+	MinPercent int  `json:"minPercent,omitempty"`
+	MaxPercent int  `json:"maxPercent,omitempty"`
+}
+
 type DisplayCapabilities struct {
-	WidthPx        int `json:"widthPx,omitempty"`
-	HeightPx       int `json:"heightPx,omitempty"`
-	ColorDepthBits int `json:"colorDepthBits,omitempty"`
+	WidthPx        int                           `json:"widthPx,omitempty"`
+	HeightPx       int                           `json:"heightPx,omitempty"`
+	ColorDepthBits int                           `json:"colorDepthBits,omitempty"`
+	Brightness     DisplayBrightnessCapabilities `json:"brightness,omitempty"`
 }
 
 type ThemeCapabilities struct {
@@ -111,6 +120,9 @@ type DeviceCapabilities struct {
 	DisplayWidthPx             int
 	DisplayHeightPx            int
 	DisplayColorDepthBits      int
+	SupportsBrightness         bool
+	MinBrightnessPercent       int
+	MaxBrightnessPercent       int
 	ActiveTransport            string
 	SupportedTransportChannels []string
 }
@@ -159,8 +171,19 @@ func CapabilitiesFromHello(raw DeviceHello) DeviceCapabilities {
 		DisplayWidthPx:             h.Capabilities.Display.WidthPx,
 		DisplayHeightPx:            h.Capabilities.Display.HeightPx,
 		DisplayColorDepthBits:      h.Capabilities.Display.ColorDepthBits,
+		SupportsBrightness:         h.Capabilities.Display.Brightness.Supported,
+		MinBrightnessPercent:       h.Capabilities.Display.Brightness.MinPercent,
+		MaxBrightnessPercent:       h.Capabilities.Display.Brightness.MaxPercent,
 		ActiveTransport:            h.Capabilities.Transport.Active,
 		SupportedTransportChannels: append([]string(nil), h.Capabilities.Transport.Supported...),
+	}
+	if caps.SupportsBrightness {
+		if caps.MinBrightnessPercent == 0 {
+			caps.MinBrightnessPercent = DefaultMinBrightness
+		}
+		if caps.MaxBrightnessPercent == 0 {
+			caps.MaxBrightnessPercent = DefaultMaxBrightness
+		}
 	}
 	if h.Kind == "hello" && (h.Board != "" ||
 		h.ProtocolVersion > 0 ||

--- a/companion/internal/protocol/device_test.go
+++ b/companion/internal/protocol/device_test.go
@@ -17,6 +17,9 @@ func TestCapabilitiesFromHelloKnownAndTheme(t *testing.T) {
 				WidthPx:        240,
 				HeightPx:       240,
 				ColorDepthBits: 16,
+				Brightness: DisplayBrightnessCapabilities{
+					Supported: true,
+				},
 			},
 			Theme: ThemeCapabilities{
 				SupportsThemeSpecV1: true,
@@ -64,6 +67,9 @@ func TestCapabilitiesFromHelloKnownAndTheme(t *testing.T) {
 	}
 	if caps.ActiveTransport != "usb" {
 		t.Fatalf("unexpected transport: %q", caps.ActiveTransport)
+	}
+	if !caps.SupportsBrightness || caps.MinBrightnessPercent != 10 || caps.MaxBrightnessPercent != 100 {
+		t.Fatalf("unexpected brightness capabilities: supported=%t min=%d max=%d", caps.SupportsBrightness, caps.MinBrightnessPercent, caps.MaxBrightnessPercent)
 	}
 	if caps.CachedThemeID != "mini-transport" || caps.CachedThemeRev != 3 {
 		t.Fatalf("unexpected theme cache descriptor: id=%q rev=%d", caps.CachedThemeID, caps.CachedThemeRev)

--- a/docs/firmware-provisioning.md
+++ b/docs/firmware-provisioning.md
@@ -70,7 +70,7 @@ What this does:
 7. Compares the runtime theme asset metadata from `/assets` against the package `manifest.json`.
 8. Sends one `mini` frame to `/frame` and requires `ok`.
 
-`/health` reports generic filesystem status plus display debug state. `display.activeTheme` names the active built-in theme, and `display.gif` reports the active GIF path, file/decoder open state, backoff state, and `lastError` when GIF open or decode fails. `/assets` is the generic inspection path for future theme-pack tooling. Each asset entry must include `path` and `sizeBytes`; `sha256` is optional. Required assets must be present, non-empty, byte-exact, and hash-exact compared with the package manifest when the device exposes hashes.
+`/health` reports generic filesystem status plus compact display debug state. `display.activeTheme` names the active built-in theme, `display.themeSpec` reports render health, and `display.gif` reports the active GIF path, file presence, decoder state, blocked state, and `lastError` when GIF open or decode fails. `/assets` is the generic inspection path for future theme-pack tooling. Each asset entry must include `path` and `sizeBytes`; `sha256` is optional. Required assets must be present, non-empty, byte-exact, and hash-exact compared with the package manifest when the device exposes hashes.
 
 The filesystem upload timeout defaults to 300 seconds because slow ESP8266 LittleFS writes can outlive a normal short HTTP timeout. Firmware uploads default to 90 seconds.
 

--- a/docs/hardware-contract.md
+++ b/docs/hardware-contract.md
@@ -30,6 +30,7 @@ Companion setup enforces this mapping when a device hello is available.
   - `protocolVersion` (legacy single-value signal)
   - `board`, `firmware`, `features`, `maxFrameBytes`
   - `capabilities` block (`display`, `theme`, `transport`)
+  - `capabilities.display.brightness` when browser-adjustable backlight control is supported
 
 Companion negotiation:
 - prefers v2 when available.
@@ -41,13 +42,16 @@ Companion negotiation:
 - Setup UI is served at `http://vibetv.local`. In setup mode this is backed by AP mDNS plus captive DNS; `http://192.168.4.1` remains the fallback address.
 - The setup flow stores home WiFi credentials and restarts the device.
 - Connected devices expose `http://vibetv.local` with mDNS, show/log the fallback IP, serve a local setup hub with a copyable Mac setup command, and wait for the Mac Companion.
+- Connected devices expose customer-facing display settings directly on `http://vibetv.local`. The MVP setting is brightness on supported hardware.
+- `POST /api/settings` accepts form field `b` as a brightness percentage and updates supported settings without reflashing firmware. `GET /health` is the readback and support-diagnostics path.
 - Companion runtime defaults to WiFi with `http://vibetv.local`; explicit device IPs remain supported when `.local` does not resolve.
 - Saved WiFi credentials can be cleared from the local web UI with `POST /reset-wifi`.
 - If a connected device loses WiFi, it retries in station mode first. After a persistent outage it starts `VibeTV-Setup` again so the user can choose a different network.
 - If the device is not reachable on WiFi, three interrupted early boots clear saved WiFi credentials and return the device to `VibeTV-Setup`.
 - Generic theme assets can be managed over WiFi with `GET /assets`, `POST /assets?path=...`, and `DELETE /assets?path=...`.
 - `GET /assets` returns `filesystem.mounted` plus an `assets` array. Every asset entry includes `path` and `sizeBytes`; `sha256` is optional so small ESP8266 builds do not need to carry hashing code.
-- `GET /health` returns `display.activeTheme` and `display.gif` so provisioning can see the active GIF path, file/decoder open state, backoff state, and the last GIF open/decode error.
+- `GET /health` returns `display.activeTheme`, compact `display.themeSpec` render health, and `display.gif` so provisioning can see the active GIF path, file presence, decoder state, blocked state, and the last GIF open/decode error.
+- `GET /health` returns `settings.display.brightnessPercent` for support diagnostics.
 
 ## Theme Contract
 - Built-in runtime themes: `classic`, `crt`, `mini`.
@@ -78,6 +82,8 @@ cd companion
 - `TFT_DC=0`
 - `TFT_RST=2`
 - `TFT_BL=5`
+
+Current release-gated hardware treats `TFT_BL` as PWM-capable and active-low (`TFT_BACKLIGHT_ON=0`), so brightness percentages are inverted before writing PWM duty.
 
 Common display assumptions:
 - ST7789 driver

--- a/docs/theme-dev-guide.md
+++ b/docs/theme-dev-guide.md
@@ -105,5 +105,5 @@ Before a theme is published:
 - `renderFailures` does not increase while the theme is running.
 - The Mac Companion can keep sending live frames without clearing or destabilizing the theme.
 - `/health.display.themeSpec.active` stays `true` after normal live frames that do not contain `themeSpec`.
-- `/health.display.themeSpec.compiled` is `true` after the first successful render. `stringBytes` should be comfortably below `stringCapacity`, and `keepsJsonDocument` should usually be `false` for launch themes.
+- `/health.display.themeSpec.compiled` is `true` after the first successful render. Use local ThemeSpec validation and device heap health for deeper capacity checks.
 - `/health.render.partialCount` should rise for normal usage/activity updates. `/health.render.fullCount` should stay stable during steady updates unless the theme is explicitly reactivated or recovered.

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -56,10 +56,14 @@ constexpr uint8_t kBootRecoveryThreshold = 3;
 constexpr size_t kMaxAssetPathBytes = 32;
 constexpr size_t kMaxStoredThemeSpecBytes = 4096;
 constexpr size_t kMaxThemeGifAssetBytes = codexbar_display::themespec::kMaxThemeSpecGifAssetBytes;
+constexpr uint8_t kDefaultBrightnessPercent = 100;
+constexpr uint8_t kMinBrightnessPercent = 10;
+constexpr uint8_t kMaxBrightnessPercent = 100;
 const char kSetupApSsid[] = "VibeTV-Setup";
 const char kSetupHost[] = "vibetv.local";
 const char kMdnsName[] = "vibetv";
 const char kMdnsHost[] = "vibetv.local";
+const char kDeviceSettingsPath[] = "/s";
 const char kFirmwareManifestUrl[] = "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/firmware-manifest.json";
 const char* const kFirmwareUpdateNoticeTexts[] = {
     "Update Available:",
@@ -137,6 +141,10 @@ struct RuntimeRenderDiagnostics {
   unsigned long lastAtMs = 0;
 };
 
+struct DeviceSettings {
+  uint8_t brightnessPercent = kDefaultBrightnessPercent;
+};
+
 bool httpServerStarted = false;
 bool rawOtaServerStarted = false;
 bool setupMode = false;
@@ -167,6 +175,7 @@ FirmwareUpdateState firmwareUpdate;
 bool firmwareUpdateNoticeDirty = false;
 OtaUploadDiagnostics otaDiagnostics;
 RuntimeRenderDiagnostics renderDiagnostics;
+DeviceSettings deviceSettings;
 
 #if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
 constexpr const char* kDefaultThemeSpecPath = "/themes/u/mini-cl-1-410a37.json";
@@ -248,6 +257,69 @@ void appendJSONNullableString(String& out, const String& value) {
   out += "\"";
   out += jsonEscape(value);
   out += "\"";
+}
+
+uint8_t clampBrightnessPercent(int value) {
+  if (value < kMinBrightnessPercent) {
+    return kMinBrightnessPercent;
+  }
+  if (value > kMaxBrightnessPercent) {
+    return kMaxBrightnessPercent;
+  }
+  return static_cast<uint8_t>(value);
+}
+
+void applyDeviceSettings() {
+  if (renderer.SupportsBrightnessControl()) {
+    renderer.ApplyBrightnessPercent(deviceSettings.brightnessPercent);
+  }
+}
+
+bool loadDeviceSettings() {
+  deviceSettings = DeviceSettings{};
+  if (!LittleFS.begin() || !LittleFS.exists(kDeviceSettingsPath)) {
+    applyDeviceSettings();
+    return false;
+  }
+  File file = LittleFS.open(kDeviceSettingsPath, "r");
+  if (!file) {
+    applyDeviceSettings();
+    return false;
+  }
+  const int brightness = file.read();
+  file.close();
+  if (brightness <= 0) {
+    applyDeviceSettings();
+    return false;
+  }
+  deviceSettings.brightnessPercent = clampBrightnessPercent(brightness);
+  applyDeviceSettings();
+  return true;
+}
+
+bool saveDeviceSettings() {
+  if (!LittleFS.begin()) {
+    return false;
+  }
+  File file = LittleFS.open(kDeviceSettingsPath, "w");
+  if (!file) {
+    return false;
+  }
+  const size_t written = file.write(&deviceSettings.brightnessPercent, 1);
+  file.close();
+  return written > 0;
+}
+
+void appendBrightnessCapabilityJSON(String& out) {
+  out += "{\"supported\":";
+  out += renderer.SupportsBrightnessControl() ? "true" : "false";
+  out += "}";
+}
+
+void appendSettingsJSON(String& out) {
+  out += "\"settings\":{\"display\":{\"brightnessPercent\":";
+  out += String(deviceSettings.brightnessPercent);
+  out += "}}";
 }
 
 void markFirmwareUpdateNoticeDirty() {
@@ -499,7 +571,9 @@ void markFrameAccepted(const codexbar_display::core::SerialConsumeEvent& event, 
 const char* transportCapabilitiesJSON(const char* activeTransport) {
   const bool isUsb = activeTransport != nullptr && strcmp(activeTransport, "usb") == 0;
   static String json;
-  json = "{\"display\":{\"widthPx\":240,\"heightPx\":240,\"colorDepthBits\":16},\"theme\":";
+  json = "{\"display\":{\"widthPx\":240,\"heightPx\":240,\"colorDepthBits\":16,\"brightness\":";
+  appendBrightnessCapabilityJSON(json);
+  json += "},\"theme\":";
 #ifdef CODEXBAR_DISPLAY_PROBE_ONLY
   json += themeCapabilitiesJSON(false);
 #else
@@ -817,36 +891,34 @@ String setupPageHTML() {
 String connectedPageHTML() {
   const String ip = WiFi.localIP().toString();
   const bool hasFrame = codexbar_display::app::HasFrame(runtimeCtx);
-  const String setupCommand = macInstallerCommand();
+  const String setupCommand = hasFrame ? String() : macInstallerCommand();
 
   String html;
-  html.reserve(3600);
-  html += F("<!doctype html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'>");
-  html += F("<title>VibeTV Setup</title><style>");
-  html += F(":root{color-scheme:dark;--bg:#0b0c0d;--panel:#15171a;--line:#2b2f35;--text:#f6f4ed;--muted:#a9adb3;--signal:#c7ff00}");
-  html += F("*{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;margin:0;background:var(--bg);color:var(--text)}");
-  html += F("main{max-width:620px;margin:0 auto;padding:28px 20px 34px}.device,.step{border-top:1px solid var(--line);padding-top:14px;margin-top:14px}");
-  html += F(".brand,.pill,.step-title{font-weight:900}.pill,.update strong,a{color:var(--signal)}h1{font-size:36px;line-height:1.05;margin:22px 0 10px}.lead,.muted,.step{color:var(--muted);line-height:1.45}");
-  html += F(".update{border:1px solid #6f8f00;background:#1b2400;border-radius:8px;padding:12px;margin-top:12px;color:#f1ffd0}.update-link{display:inline-block;margin-top:8px}");
-  html += F("code,pre{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}pre{white-space:pre-wrap;word-break:break-word;background:#08090a;border:1px solid #30343a;border-radius:8px;padding:14px;color:#fff}");
-  html += F("button{width:100%;min-height:46px;border:0;border-radius:8px;background:var(--signal);color:#111;font:inherit;font-weight:900}.tools{display:flex;flex-wrap:wrap;gap:12px;margin-top:18px}.reset{color:var(--muted);background:transparent;border:0;padding:0;text-decoration:underline;width:auto;min-height:0}</style></head><body><main>");
-  html += F("<div class='brand'>Vibe TV</div><section class='device'><div class='pill'>Connected</div><p class='muted'>Address: <code>http://");
+  html.reserve(1500);
+  html += F("<!doctype html><meta name=viewport content='width=device-width,initial-scale=1'><title>VibeTV</title><style>");
+  html += F("body{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;margin:24px;background:#0b0c0d;color:#f6f4ed}a{color:#c7ff00;font-weight:800}code,pre{background:#08090a;border:1px solid #30343a;padding:8px;display:block;white-space:pre-wrap;word-break:break-word}button,input{width:100%;font:inherit;margin-top:8px}button{padding:12px;background:#c7ff00;border:0;font-weight:900}section{border-top:1px solid #2b2f35;margin-top:16px;padding-top:12px}</style><h1>Vibe TV</h1>");
+  html += F("<p>Connected<br><code>http://");
   html += kMdnsHost;
-  html += F("</code><br>Fallback IP: <code>http://");
+  html += F("</code><code>http://");
   html += ip;
   html += F("</code></p>");
-  html += updateStatusHTML(true);
-  html += F("</section>");
-  if (hasFrame) {
-    html += F("<h1>Vibe TV is live.</h1><p class='lead'>Your Mac is sending workflow signals.</p>");
-  } else {
-    html += F("<h1>Finish Mac setup.</h1><p class='lead'>Copy the command, paste it in Terminal, then wait for live signals.</p><section><div class='step'><span class='step-title'>1. Copy command</span><pre id='cmd'>");
-    html += htmlEscape(setupCommand);
-    html += F("</pre><textarea id='cmdFallback' readonly style='position:absolute;left:-9999px'></textarea><button type='button' onclick='copyCmd()' id='copyBtn'>Copy setup command</button></div>");
-    html += F("<div class='step'><span class='step-title'>2. Paste in Terminal</span>Open Terminal, paste, press Enter.</div><div class='step'><span class='step-title'>3. Wait</span>This page changes when frames arrive.</div></section>");
+  if (firmwareUpdate.available) {
+    html += updateStatusHTML(true);
   }
-  html += F("<div class='tools'><a href='/health'>Device status</a><a href='/update'>Firmware update</a><form method='post' action='/reset-wifi' onsubmit=\"return confirm('Clear WiFi settings and restart setup?')\"><button class='reset' type='submit'>Reset WiFi</button></form></div>");
-  html += F("<script>function copied(){document.getElementById('copyBtn').textContent='Copied';}function fallbackCopy(t){var a=document.getElementById('cmdFallback');a.value=t;a.focus();a.select();try{document.execCommand('copy');copied();}catch(e){window.prompt('Copy this command',t);}}function copyCmd(){var t=document.getElementById('cmd').textContent.trim();if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(t).then(copied,function(){fallbackCopy(t);});}else{fallbackCopy(t);}}</script></body></html>");
+  if (hasFrame) {
+    html += F("<p>Live.</p>");
+  } else {
+    html += F("<section><h2>Mac setup</h2><pre>");
+    html += htmlEscape(setupCommand);
+    html += F("</pre></section>");
+  }
+  html += F("<p><a href='/health'>Status</a> <a href='/update'>Update</a></p>");
+  if (renderer.SupportsBrightnessControl()) {
+    html += F("<section><form method='post' action='/api/settings'><label>Bright</label><input name='b' type='range' min='10' max='100' value='");
+    html += String(deviceSettings.brightnessPercent);
+    html += F("'><button>OK</button></form></section>");
+  }
+  html += F("<form method='post' action='/reset-wifi' onsubmit=\"return confirm('Clear WiFi settings and restart setup?')\"><button>Reset WiFi</button></form>");
   return html;
 }
 
@@ -916,7 +988,6 @@ void addCorsHeaders() {
   webServer.sendHeader("Access-Control-Allow-Origin", "*");
   webServer.sendHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,OPTIONS");
   webServer.sendHeader("Access-Control-Allow-Headers", "Content-Type");
-  webServer.sendHeader("Access-Control-Max-Age", "86400");
 }
 
 void handleHello() {
@@ -986,167 +1057,6 @@ bool filesystemInfoJSON(String& out) {
   return mounted;
 }
 
-void appendThemeSpecDebugJSON(String& out, const codexbar_display::esp8266::RendererDebugSnapshot& snapshot) {
-  out += "\"themeSpec\":{\"active\":";
-  out += snapshot.themeSpecActive ? "true" : "false";
-  out += ",\"id\":";
-  appendJSONNullableString(out, snapshot.themeSpecId);
-  out += ",\"rev\":";
-  out += String(snapshot.themeSpecRev);
-  out += ",\"path\":";
-  appendJSONNullableString(out, activeThemeSpecPath);
-  out += ",\"hash\":";
-  appendJSONNullableString(out, activeThemeSpecHash);
-  out += ",\"renderOk\":";
-  out += snapshot.themeSpecRenderOk ? "true" : "false";
-  out += ",\"renderError\":";
-  appendJSONNullableString(out, snapshot.themeSpecRenderError);
-  out += ",\"renderFailures\":";
-  out += String(snapshot.themeSpecRenderFailures);
-  out += ",\"partialSuccesses\":";
-  out += String(snapshot.themeSpecPartialSuccesses);
-  out += ",\"partialFailures\":";
-  out += String(snapshot.themeSpecPartialFailures);
-  out += ",\"lastPartialChangedFields\":";
-  out += String(snapshot.themeSpecLastPartialChangedFields);
-  out += ",\"lastPartialChangedFieldsHex\":\"0x";
-  out += String(snapshot.themeSpecLastPartialChangedFields, HEX);
-  out += "\",\"lastPartialError\":";
-  appendJSONNullableString(out, snapshot.themeSpecLastPartialError);
-  out += ",\"compiled\":";
-  out += snapshot.themeSpecCompiled ? "true" : "false";
-  out += ",\"primitiveCount\":";
-  out += String(snapshot.themeSpecPrimitiveCount);
-  out += ",\"primitiveCapacity\":";
-  out += String(snapshot.themeSpecPrimitiveCapacity);
-  out += ",\"stringBytes\":";
-  out += String(snapshot.themeSpecStringBytes);
-  out += ",\"stringCapacity\":";
-  out += String(snapshot.themeSpecStringCapacity);
-  out += ",\"keepsJsonDocument\":";
-  out += snapshot.themeSpecKeepsJsonDocument ? "true" : "false";
-  out += ",\"hasAnimatedAssets\":";
-  out += snapshot.themeSpecHasAnimatedAssets ? "true" : "false";
-  out += "}";
-}
-
-void appendGifDebugJSON(String& out, const codexbar_display::esp8266::RendererDebugSnapshot& snapshot) {
-  out += "\"gif\":{\"activePath\":\"";
-  out += jsonEscape(snapshot.gifActivePath);
-  out += "\",\"filePresent\":";
-  out += snapshot.gifFilePresent ? "true" : "false";
-  out += ",\"fileOpen\":";
-  out += snapshot.gifFileOpen ? "true" : "false";
-  out += ",\"decoderOpen\":";
-  out += snapshot.gifDecoderOpen ? "true" : "false";
-  out += ",\"blocked\":";
-  out += snapshot.gifBlocked ? "true" : "false";
-  out += ",\"consecutiveFailures\":";
-  out += String(snapshot.gifConsecutiveFailures);
-  out += ",\"backoffRemainingMs\":";
-  out += String(snapshot.gifBackoffRemainingMs);
-  out += ",\"lastError\":";
-  if (snapshot.gifLastErrorStage.length() == 0) {
-    out += "null";
-  } else {
-    out += "{\"path\":\"";
-    out += jsonEscape(snapshot.gifLastErrorPath);
-    out += "\",\"stage\":\"";
-    out += jsonEscape(snapshot.gifLastErrorStage);
-    out += "\",\"failures\":";
-    out += String(snapshot.gifLastErrorFailures);
-    out += ",\"ageMs\":";
-    out += String(snapshot.gifLastErrorAgeMs);
-    out += "}";
-  }
-  out += "}";
-}
-
-void appendRendererDebugJSON(String& out) {
-  const codexbar_display::esp8266::RendererDebugSnapshot snapshot = renderer.DebugSnapshot();
-  String activeTheme = snapshot.activeTheme;
-  if (snapshot.themeSpecActive && snapshot.themeSpecId.length() > 0) {
-    activeTheme = snapshot.themeSpecId;
-  }
-  out += "\"display\":{\"activeTheme\":\"";
-  out += jsonEscape(activeTheme);
-  out += "\",";
-  appendThemeSpecDebugJSON(out, snapshot);
-  out += ",";
-  appendGifDebugJSON(out, snapshot);
-  out += "}";
-}
-
-void appendFirmwareUpdateJSON(String& out) {
-  out += "\"update\":{\"available\":";
-  out += firmwareUpdate.available ? "true" : "false";
-  out += ",\"latestVersion\":";
-  appendJSONNullableString(out, firmwareUpdate.latestVersion);
-  out += ",\"manifestUrl\":\"";
-  out += jsonEscape(kFirmwareManifestUrl);
-  out += "\",\"rawFirmwareUrl\":\"http://";
-  out += WiFi.localIP().toString();
-  out += ":8081/update/firmware.raw";
-  out += "\",\"lastCheckedAtMs\":";
-  out += String(firmwareUpdate.lastCheckedAtMs);
-  out += ",\"nextCheckAtMs\":";
-  out += String(firmwareUpdate.nextCheckAtMs);
-  out += ",\"status\":\"";
-  out += jsonEscape(firmwareUpdate.lastStatus);
-  out += "\",\"lastError\":";
-  appendJSONNullableString(out, firmwareUpdate.lastError);
-  out += ",\"upload\":{\"target\":\"";
-  out += otaDiagnostics.target;
-  out += "\",\"status\":\"";
-  out += otaDiagnostics.status;
-  out += "\",\"filename\":";
-  appendJSONNullableString(out, otaDiagnostics.filename);
-  out += ",\"command\":";
-  out += String(otaDiagnostics.command);
-  out += ",\"contentLength\":";
-  out += String(otaDiagnostics.contentLength);
-  out += ",\"totalSize\":";
-  out += String(otaDiagnostics.totalSize);
-  out += ",\"maxSize\":";
-  out += String(otaDiagnostics.maxSize);
-  out += ",\"freeSketchSpace\":";
-  out += String(otaDiagnostics.freeSketchSpace);
-  out += ",\"updateError\":";
-  out += String(otaDiagnostics.updateError);
-  out += ",\"lastError\":";
-  appendJSONNullableString(out, otaDiagnostics.lastError);
-  out += ",\"startedAtMs\":";
-  out += String(otaDiagnostics.startedAtMs);
-  out += ",\"endedAtMs\":";
-  out += String(otaDiagnostics.endedAtMs);
-  out += ",\"successCount\":";
-  out += String(otaDiagnostics.successCount);
-  out += ",\"failureCount\":";
-  out += String(otaDiagnostics.failureCount);
-  out += "}";
-  out += "}";
-}
-
-void appendRenderDiagnosticsJSON(String& out) {
-  out += "\"render\":{\"fullCount\":";
-  out += String(renderDiagnostics.fullCount);
-  out += ",\"partialCount\":";
-  out += String(renderDiagnostics.partialCount);
-  out += ",\"animatedTickAttempts\":";
-  out += String(renderDiagnostics.animatedTickAttempts);
-  out += ",\"lastKind\":\"";
-  out += renderDiagnostics.lastKind;
-  out += "\",\"lastFullKind\":\"";
-  out += renderDiagnostics.lastFullKind;
-  out += "\",\"lastPartialKind\":\"";
-  out += renderDiagnostics.lastPartialKind;
-  out += "\",\"lastDurationUs\":";
-  out += String(renderDiagnostics.lastDurationUs);
-  out += ",\"lastAtMs\":";
-  out += String(renderDiagnostics.lastAtMs);
-  out += "}";
-}
-
 String normalizedAssetListPath(const String& dirPath, const String& fileName) {
   if (fileName.startsWith("/")) {
     if (dirPath.length() > 1 && !fileName.startsWith(dirPath + "/")) {
@@ -1203,9 +1113,10 @@ void appendAssetListJSON(String& out) {
 
 void handleHealth() {
   const bool wifiConnected = WiFi.status() == WL_CONNECTED;
+  const codexbar_display::esp8266::RendererDebugSnapshot snapshot = renderer.DebugSnapshot();
 
   String out;
-  out.reserve(1500);
+  out.reserve(1200);
   out += "{\"ok\":true";
   out += ",\"firmware\":\"";
   out += jsonEscape(CODEXBAR_DISPLAY_FW_VERSION);
@@ -1221,12 +1132,6 @@ void handleHealth() {
   out += String(ESP.getSketchSize());
   out += ",\"freeSketchSpace\":";
   out += String(ESP.getFreeSketchSpace());
-  out += ",\"sketchMD5\":\"";
-  out += jsonEscape(ESP.getSketchMD5());
-  out += "\",\"flashChipSize\":";
-  out += String(ESP.getFlashChipSize());
-  out += ",\"flashChipRealSize\":";
-  out += String(ESP.getFlashChipRealSize());
   out += ",\"resetReason\":\"";
   out += jsonEscape(ESP.getResetReason());
   out += "\"";
@@ -1243,11 +1148,53 @@ void handleHealth() {
   out += "},";
   const bool filesystemMounted = filesystemInfoJSON(out);
   out += ",";
-  appendRendererDebugJSON(out);
+  out += "\"display\":{\"activeTheme\":\"";
+  out += jsonEscape(snapshot.activeTheme);
+  out += "\",\"themeSpec\":{\"active\":";
+  out += snapshot.themeSpecActive ? "true" : "false";
+  out += ",\"renderOk\":";
+  out += snapshot.themeSpecRenderOk ? "true" : "false";
+  out += ",\"renderFailures\":";
+  out += String(snapshot.themeSpecRenderFailures);
+  out += ",\"compiled\":";
+  out += snapshot.themeSpecCompiled ? "true" : "false";
+  out += "},\"gif\":{\"activePath\":\"";
+  out += jsonEscape(snapshot.gifActivePath);
+  out += "\",\"filePresent\":";
+  out += snapshot.gifFilePresent ? "true" : "false";
+  out += ",\"decoderOpen\":";
+  out += snapshot.gifDecoderOpen ? "true" : "false";
+  out += ",\"blocked\":";
+  out += snapshot.gifBlocked ? "true" : "false";
+  out += ",\"lastError\":";
+  appendJSONNullableString(out, snapshot.gifLastErrorStage);
+  out += "}},\"render\":{\"fullCount\":";
+  out += String(renderDiagnostics.fullCount);
+  out += ",\"partialCount\":";
+  out += String(renderDiagnostics.partialCount);
+  out += ",\"lastKind\":\"";
+  out += renderDiagnostics.lastKind;
+  out += "\"}";
   out += ",";
-  appendRenderDiagnosticsJSON(out);
+  out += "\"update\":{\"available\":";
+  out += firmwareUpdate.available ? "true" : "false";
+  out += ",\"latestVersion\":";
+  appendJSONNullableString(out, firmwareUpdate.latestVersion);
+  out += ",\"status\":\"";
+  out += jsonEscape(firmwareUpdate.lastStatus);
+  out += "\",\"lastError\":";
+  appendJSONNullableString(out, firmwareUpdate.lastError);
+  out += ",\"rawFirmwareUrl\":\"http://";
+  out += WiFi.localIP().toString();
+  out += ":8081/update/firmware.raw\",\"upload\":{\"status\":\"";
+  out += otaDiagnostics.status;
+  out += "\",\"successCount\":";
+  out += String(otaDiagnostics.successCount);
+  out += ",\"failureCount\":";
+  out += String(otaDiagnostics.failureCount);
+  out += "}}";
   out += ",";
-  appendFirmwareUpdateJSON(out);
+  appendSettingsJSON(out);
   out += ",\"transport\":{\"active\":\"wifi\",\"supported\":[\"usb\",\"wifi\"],\"httpPort\":80,\"maxFrameBytes\":";
   out += String(kMaxFrameBytes);
   out += "}}";
@@ -1255,6 +1202,38 @@ void handleHealth() {
   Serial.printf("health_requested ip=%s fs_mounted=%d\n", webServer.client().remoteIP().toString().c_str(), filesystemMounted ? 1 : 0);
   addCorsHeaders();
   webServer.send(200, "application/json", out);
+}
+
+bool persistDeviceSettings(const DeviceSettings& next) {
+  const DeviceSettings previous = deviceSettings;
+  deviceSettings = next;
+  if (!saveDeviceSettings()) {
+    deviceSettings = previous;
+    applyDeviceSettings();
+    return false;
+  }
+  applyDeviceSettings();
+  return true;
+}
+
+void handleSettingsAPI() {
+  DeviceSettings next = deviceSettings;
+  if (webServer.hasArg("b")) {
+    next.brightnessPercent = clampBrightnessPercent(webServer.arg("b").toInt());
+  } else {
+    webServer.send(400, "text/plain; charset=utf-8", "bad");
+    return;
+  }
+  if (!persistDeviceSettings(next)) {
+    webServer.send(500, "text/plain; charset=utf-8", "save failed");
+    return;
+  }
+  if (webServer.hasArg("b")) {
+    webServer.sendHeader("Location", "/");
+    webServer.send(303);
+    return;
+  }
+  webServer.send(204);
 }
 
 void handleAssetsList() {
@@ -1971,6 +1950,7 @@ void startHttpServer() {
   webServer.on("/reset-wifi", HTTP_POST, handleResetWifi);
   webServer.on("/hello", HTTP_GET, handleHello);
   webServer.on("/health", HTTP_GET, handleHealth);
+  webServer.on("/api/settings", HTTP_POST, handleSettingsAPI);
   webServer.on("/assets", HTTP_GET, handleAssetsList);
   webServer.on(
       "/assets",
@@ -2139,6 +2119,7 @@ void setup() {
   delay(200);
 
   renderer.Setup(runtimeCtx);
+  loadDeviceSettings();
 #if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
   loadDefaultStoredThemeSpecCache();
 #endif

--- a/firmware_esp8266/src/renderer_esp8266.cpp
+++ b/firmware_esp8266/src/renderer_esp8266.cpp
@@ -14,10 +14,21 @@ namespace esp8266 {
 namespace {
 
 constexpr const char* kDefaultGifAssetPath = "/themes/mini/mini.gif";
+constexpr uint16_t kBacklightPwmRange = 1023;
 
 const char* themeName(Theme theme) {
   (void)theme;
   return "mini";
+}
+
+uint8_t clampBrightnessPercent(uint8_t percent) {
+  if (percent < 1) {
+    return 1;
+  }
+  if (percent > 100) {
+    return 100;
+  }
+  return percent;
 }
 
 }  // namespace
@@ -29,7 +40,7 @@ void RendererESP8266::Setup(app::RuntimeContext& ctx) {
 
 #ifdef TFT_BL
   pinMode(TFT_BL, OUTPUT);
-  digitalWrite(TFT_BL, TFT_BACKLIGHT_ON);
+  ApplyBrightnessPercent(100);
 #endif
   display::Tft().init();
   display::Tft().setRotation(0);
@@ -81,6 +92,33 @@ RendererDebugSnapshot RendererESP8266::DebugSnapshot() const {
   snapshot.activeTheme = "probe";
 #endif
   return snapshot;
+}
+
+bool RendererESP8266::SupportsBrightnessControl() const {
+#ifdef TFT_BL
+  return true;
+#else
+  return false;
+#endif
+}
+
+void RendererESP8266::ApplyBrightnessPercent(uint8_t percent) {
+#ifdef TFT_BL
+  const uint8_t clamped = clampBrightnessPercent(percent);
+  if (clamped >= 100) {
+    digitalWrite(TFT_BL, TFT_BACKLIGHT_ON);
+    return;
+  }
+  analogWriteRange(kBacklightPwmRange);
+  const uint16_t scaled = (static_cast<uint16_t>(clamped) * kBacklightPwmRange) / 100;
+#if TFT_BACKLIGHT_ON == 0
+  analogWrite(TFT_BL, kBacklightPwmRange - scaled);
+#else
+  analogWrite(TFT_BL, scaled);
+#endif
+#else
+  (void)percent;
+#endif
 }
 
 void RendererESP8266::ResetGifStateForAssetUpdate() {

--- a/firmware_esp8266/src/renderer_esp8266.h
+++ b/firmware_esp8266/src/renderer_esp8266.h
@@ -45,6 +45,8 @@ class RendererESP8266 : public app::Renderer {
   void OnFrameAccepted(app::RuntimeContext& ctx, const core::SerialConsumeEvent& event) override;
   RendererDebugSnapshot DebugSnapshot() const;
   void ResetGifStateForAssetUpdate();
+  bool SupportsBrightnessControl() const;
+  void ApplyBrightnessPercent(uint8_t percent);
 
   void DrawSplash(app::RuntimeContext& ctx) override;
   void TickSplash(app::RuntimeContext& ctx) override;

--- a/protocol/PROTOCOL.md
+++ b/protocol/PROTOCOL.md
@@ -127,7 +127,12 @@ On boot or after serial reconnect, firmware emits a capability line over USB. `G
   "features": ["theme", "theme-spec-v1"],
   "maxFrameBytes": 2048,
   "capabilities": {
-    "display": {"widthPx": 240, "heightPx": 240, "colorDepthBits": 16},
+    "display": {
+      "widthPx": 240,
+      "heightPx": 240,
+      "colorDepthBits": 16,
+      "brightness": {"supported": true}
+    },
     "theme": {
       "supportsThemeSpecV1": true,
       "maxThemeSpecBytes": 2048,
@@ -147,6 +152,7 @@ Fields:
 - `preferredProtocolVersion` (number): firmware preference.
 - `features` (array[string], optional): capabilities (for example `theme`, `theme-spec-v1`).
 - `capabilities` (object, optional): extended block for display/theme/transport limits.
+  - `display.brightness.supported` describes browser-adjustable backlight support when the board exposes it. Hosts use 10-100 percent for the current ESP8266 implementation.
 
 Firmware may emit plain readiness lines (`codexbar_display_ready*`) instead of JSON hello.
 Companion treats missing hello as unknown capabilities.


### PR DESCRIPTION
## Summary
- add brightness capability reporting in device hello/companion capability parsing
- add a customer-facing brightness slider on vibetv.local backed by POST /api/settings
- persist brightness on-device and report it through /health
- keep ESP8266 web responses compact enough for runtime stability and firmware size budget

## Tests
- go test ./... (companion)
- go vet ./... (companion)
- pio test -e native_theme_spec_renderer
- ./scripts/check-firmware-size-budget.sh firmware_esp8266 esp8266_smalltv_st7789 46 82 482000 350000
- CODEXBAR_DISPLAY_FW_VERSION=1.0.28 ./scripts/check-firmware-size-budget.sh firmware_esp8266 esp8266_smalltv_st7789 46 82 482000 350000
- OTA flashed attached VibeTV at 192.168.178.163 via raw OTA
- verified /hello reports firmware 1.0.28 and brightness supported
- verified /, /health, and /assets respond after flash
- set brightness to 40, verified /health reports brightnessPercent 40
- rebooted via raw OTA and verified brightnessPercent persisted at 40
- restored brightness to 100 and verified /health reports brightnessPercent 100

No release tag created.