### PR TITLE
[codex] Drive Theme Studio limits from device capabilities

### DIFF
--- a/companion/internal/protocol/device.go
+++ b/companion/internal/protocol/device.go
@@ -24,17 +24,18 @@ type DisplayCapabilities struct {
 }
 
 type ThemeCapabilities struct {
-	SupportsThemeSpecV1 bool     `json:"supportsThemeSpecV1,omitempty"`
-	MaxThemeSpecBytes   int      `json:"maxThemeSpecBytes,omitempty"`
-	MaxThemePrimitives  int      `json:"maxThemePrimitives,omitempty"`
-	MaxThemeGifAssets   int      `json:"maxThemeGifAssets,omitempty"`
-	MaxThemeGifBytes    int      `json:"maxThemeGifBytes,omitempty"`
-	MaxThemeGifWidth    int      `json:"maxThemeGifWidth,omitempty"`
-	MaxThemeGifHeight   int      `json:"maxThemeGifHeight,omitempty"`
-	MaxThemeGifPixels   int      `json:"maxThemeGifPixels,omitempty"`
-	BuiltinThemes       []string `json:"builtinThemes,omitempty"`
-	CachedThemeID       string   `json:"cachedThemeId,omitempty"`
-	CachedThemeRev      int      `json:"cachedThemeRev,omitempty"`
+	SupportsThemeSpecV1     bool     `json:"supportsThemeSpecV1,omitempty"`
+	MaxThemeSpecBytes       int      `json:"maxThemeSpecBytes,omitempty"`
+	MaxThemePrimitives      int      `json:"maxThemePrimitives,omitempty"`
+	MaxThemeGifAssets       int      `json:"maxThemeGifAssets,omitempty"`
+	MaxThemeGifBytes        int      `json:"maxThemeGifBytes,omitempty"`
+	MaxThemeGifWidth        int      `json:"maxThemeGifWidth,omitempty"`
+	MaxThemeGifHeight       int      `json:"maxThemeGifHeight,omitempty"`
+	MaxThemeGifPixels       int      `json:"maxThemeGifPixels,omitempty"`
+	SupportedPrimitiveTypes []string `json:"supportedPrimitiveTypes,omitempty"`
+	BuiltinThemes           []string `json:"builtinThemes,omitempty"`
+	CachedThemeID           string   `json:"cachedThemeId,omitempty"`
+	CachedThemeRev          int      `json:"cachedThemeRev,omitempty"`
 }
 
 type TransportCapabilities struct {
@@ -73,6 +74,9 @@ func (h DeviceHello) Normalize() DeviceHello {
 	}
 	for i := range h.Capabilities.Theme.BuiltinThemes {
 		h.Capabilities.Theme.BuiltinThemes[i] = strings.TrimSpace(strings.ToLower(h.Capabilities.Theme.BuiltinThemes[i]))
+	}
+	for i := range h.Capabilities.Theme.SupportedPrimitiveTypes {
+		h.Capabilities.Theme.SupportedPrimitiveTypes[i] = strings.TrimSpace(strings.ToLower(h.Capabilities.Theme.SupportedPrimitiveTypes[i]))
 	}
 	h.Capabilities.Theme.CachedThemeID = strings.TrimSpace(h.Capabilities.Theme.CachedThemeID)
 	h.Capabilities.Transport.Active = strings.TrimSpace(strings.ToLower(h.Capabilities.Transport.Active))
@@ -114,6 +118,7 @@ type DeviceCapabilities struct {
 	MaxThemeGifWidth           int
 	MaxThemeGifHeight          int
 	MaxThemeGifPixels          int
+	SupportedPrimitiveTypes    []string
 	BuiltinThemes              []string
 	CachedThemeID              string
 	CachedThemeRev             int
@@ -165,6 +170,7 @@ func CapabilitiesFromHello(raw DeviceHello) DeviceCapabilities {
 		MaxThemeGifWidth:           h.Capabilities.Theme.MaxThemeGifWidth,
 		MaxThemeGifHeight:          h.Capabilities.Theme.MaxThemeGifHeight,
 		MaxThemeGifPixels:          h.Capabilities.Theme.MaxThemeGifPixels,
+		SupportedPrimitiveTypes:    append([]string(nil), h.Capabilities.Theme.SupportedPrimitiveTypes...),
 		BuiltinThemes:              append([]string(nil), h.Capabilities.Theme.BuiltinThemes...),
 		CachedThemeID:              h.Capabilities.Theme.CachedThemeID,
 		CachedThemeRev:             h.Capabilities.Theme.CachedThemeRev,

--- a/companion/internal/protocol/device_test.go
+++ b/companion/internal/protocol/device_test.go
@@ -22,17 +22,18 @@ func TestCapabilitiesFromHelloKnownAndTheme(t *testing.T) {
 				},
 			},
 			Theme: ThemeCapabilities{
-				SupportsThemeSpecV1: true,
-				MaxThemeSpecBytes:   1024,
-				MaxThemePrimitives:  32,
-				MaxThemeGifAssets:   1,
-				MaxThemeGifBytes:    24576,
-				MaxThemeGifWidth:    80,
-				MaxThemeGifHeight:   80,
-				MaxThemeGifPixels:   6400,
-				BuiltinThemes:       []string{"classic", "crt", "mini"},
-				CachedThemeID:       "mini-transport",
-				CachedThemeRev:      3,
+				SupportsThemeSpecV1:     true,
+				MaxThemeSpecBytes:       1024,
+				MaxThemePrimitives:      32,
+				MaxThemeGifAssets:       1,
+				MaxThemeGifBytes:        24576,
+				MaxThemeGifWidth:        80,
+				MaxThemeGifHeight:       80,
+				MaxThemeGifPixels:       6400,
+				SupportedPrimitiveTypes: []string{"Text", "RECT", "progress", "gif"},
+				BuiltinThemes:           []string{"classic", "crt", "mini"},
+				CachedThemeID:           "mini-transport",
+				CachedThemeRev:          3,
 			},
 			Transport: TransportCapabilities{
 				Active:    "usb",
@@ -64,6 +65,15 @@ func TestCapabilitiesFromHelloKnownAndTheme(t *testing.T) {
 	}
 	if caps.MaxThemeGifAssets != 1 || caps.MaxThemeGifBytes != 24576 || caps.MaxThemeGifWidth != 80 || caps.MaxThemeGifHeight != 80 || caps.MaxThemeGifPixels != 6400 {
 		t.Fatalf("unexpected GIF limits: %+v", caps)
+	}
+	if got, want := caps.SupportedPrimitiveTypes, []string{"text", "rect", "progress", "gif"}; len(got) != len(want) {
+		t.Fatalf("unexpected primitive type count: got=%v want=%v", got, want)
+	} else {
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("unexpected primitive type at %d: got=%v want=%v", i, got, want)
+			}
+		}
 	}
 	if caps.ActiveTransport != "usb" {
 		t.Fatalf("unexpected transport: %q", caps.ActiveTransport)

--- a/companion/internal/themespec/themespec.go
+++ b/companion/internal/themespec/themespec.go
@@ -136,6 +136,13 @@ func ValidateAgainstCapabilities(spec Spec, raw json.RawMessage, caps protocol.D
 			caps.MaxThemePrimitives,
 		)
 	}
+	if len(caps.SupportedPrimitiveTypes) > 0 {
+		for i, primitive := range spec.Primitives {
+			if !containsString(caps.SupportedPrimitiveTypes, primitive.Type) {
+				return fmt.Errorf("primitives[%d] type %q not advertised by device", i, primitive.Type)
+			}
+		}
+	}
 	gifAssets := uniqueGIFAssetPaths(spec)
 	if caps.MaxThemeGifAssets > 0 && len(gifAssets) > caps.MaxThemeGifAssets {
 		return fmt.Errorf("theme spec GIF asset count exceeds device limit: count=%d limit=%d", len(gifAssets), caps.MaxThemeGifAssets)

--- a/companion/internal/themespec/themespec_test.go
+++ b/companion/internal/themespec/themespec_test.go
@@ -395,6 +395,34 @@ func TestValidateAgainstCapabilitiesChecksGifLimits(t *testing.T) {
 	}
 }
 
+func TestValidateAgainstCapabilitiesChecksPrimitiveTypes(t *testing.T) {
+	spec := Spec{
+		ThemeSpecVersion: 1,
+		ThemeID:          "sprite-theme",
+		ThemeRev:         1,
+		FallbackTheme:    "mini",
+		Primitives: []Primitive{
+			{Type: "sprite", X: 0, Y: 0, Width: 24, Height: 24, AssetPath: "/themes/u/s.cbi"},
+		},
+	}
+	raw, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatalf("marshal raw: %v", err)
+	}
+
+	caps := protocol.DeviceCapabilities{
+		Known:                   true,
+		SupportsThemeSpecV1:     true,
+		MaxThemeSpecBytes:       len(raw) + 10,
+		MaxThemePrimitives:      8,
+		SupportedPrimitiveTypes: []string{"text", "rect", "progress", "gif"},
+		BuiltinThemes:           []string{"mini"},
+	}
+	if err := ValidateAgainstCapabilities(spec, raw, caps); err == nil {
+		t.Fatalf("expected primitive type capability mismatch")
+	}
+}
+
 func TestValidateAgainstCapabilitiesAcceptsCompatibleSpec(t *testing.T) {
 	spec := Spec{
 		ThemeSpecVersion: 1,
@@ -411,11 +439,12 @@ func TestValidateAgainstCapabilitiesAcceptsCompatibleSpec(t *testing.T) {
 	}
 
 	caps := protocol.DeviceCapabilities{
-		Known:               true,
-		SupportsThemeSpecV1: true,
-		MaxThemeSpecBytes:   len(raw) + 10,
-		MaxThemePrimitives:  8,
-		BuiltinThemes:       []string{"classic", "mini"},
+		Known:                   true,
+		SupportsThemeSpecV1:     true,
+		MaxThemeSpecBytes:       len(raw) + 10,
+		MaxThemePrimitives:      8,
+		SupportedPrimitiveTypes: []string{"text", "rect", "progress"},
+		BuiltinThemes:           []string{"classic", "mini"},
 	}
 	if err := ValidateAgainstCapabilities(spec, raw, caps); err != nil {
 		t.Fatalf("expected compatible spec, got %v", err)

--- a/docs/v2-usb-first-minimaldesign.md
+++ b/docs/v2-usb-first-minimaldesign.md
@@ -34,7 +34,7 @@ This document captures the transport-agnostic architecture baseline introduced f
 ## Firmware Runtime Notes
 - Core parser accepts optional `themeSpec` object in incoming frames.
 - Runtime caches `themeId/themeRev` and marks cache-hit for unchanged revisions.
-- Hello capability block advertises theme limits (`maxThemeSpecBytes`, `maxThemePrimitives`) and builtin theme list.
+- Hello capability block advertises theme limits (`maxThemeSpecBytes`, `maxStoredThemeSpecBytes`, `maxThemePrimitives`), supported primitive types, GIF limits, and builtin theme list.
 
 ## Renderer/HAL Baseline
 - Shared primitive contract introduced in `firmware_shared/render_primitives.h`.

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -80,6 +80,7 @@ String themeCapabilitiesJSON(bool enabled) {
   }
   out += "{\"supportsThemeSpecV1\":true,\"maxThemeSpecBytes\":2048,\"maxThemePrimitives\":";
   out += String(codexbar_display::themespec::kMaxCompiledThemeSpecPrimitives);
+  out += ",\"supportedPrimitiveTypes\":[\"text\",\"rect\",\"progress\",\"gif\",\"sprite\",\"pixels\"]";
   out += ",\"supportsStoredThemes\":true,\"maxStoredThemeSpecBytes\":";
   out += String(kMaxStoredThemeSpecBytes);
   out += ",\"maxThemeGifAssets\":";

--- a/protocol/PROTOCOL.md
+++ b/protocol/PROTOCOL.md
@@ -137,8 +137,14 @@ On boot or after serial reconnect, firmware emits a capability line over USB. `G
       "supportsThemeSpecV1": true,
       "maxThemeSpecBytes": 2048,
       "maxThemePrimitives": 32,
+      "supportedPrimitiveTypes": ["text", "rect", "progress", "gif", "sprite", "pixels"],
       "supportsStoredThemes": true,
       "maxStoredThemeSpecBytes": 4096,
+      "maxThemeGifAssets": 1,
+      "maxThemeGifBytes": 24576,
+      "maxThemeGifWidth": 80,
+      "maxThemeGifHeight": 80,
+      "maxThemeGifPixels": 6400,
       "builtinThemes": ["classic", "crt", "mini"]
     },
     "transport": {"active": "wifi", "supported": ["usb", "wifi"]}
@@ -153,6 +159,12 @@ Fields:
 - `features` (array[string], optional): capabilities (for example `theme`, `theme-spec-v1`).
 - `capabilities` (object, optional): extended block for display/theme/transport limits.
   - `display.brightness.supported` describes browser-adjustable backlight support when the board exposes it. Hosts use 10-100 percent for the current ESP8266 implementation.
+  - `theme.maxThemeSpecBytes` is the inline `themeSpec` frame byte limit.
+  - `theme.maxStoredThemeSpecBytes` is the uploaded/stored ThemeSpec JSON byte limit for WiFi themes.
+  - `theme.maxThemePrimitives` is the maximum primitive count accepted by the renderer.
+  - `theme.supportedPrimitiveTypes` lists the ThemeSpec primitive types this firmware can render.
+  - `theme.maxThemeGifAssets`, `maxThemeGifBytes`, `maxThemeGifWidth`, `maxThemeGifHeight`, and `maxThemeGifPixels` describe GIF asset and draw-box limits.
+  - `transport.maxFrameBytes` or top-level `maxFrameBytes` is the live frame payload limit. Hosts should use the stricter known value when both are present.
 
 Firmware may emit plain readiness lines (`codexbar_display_ready*`) instead of JSON hello.
 Companion treats missing hello as unknown capabilities.

--- a/tools/theme-studio/src/main.ts
+++ b/tools/theme-studio/src/main.ts
@@ -86,6 +86,38 @@ type GifMetadataCacheEntry = {
   metadata?: GifMetadata;
   error?: string;
 };
+type DeviceProfile = {
+  source: "offline" | "device";
+  label: string;
+  maxStoredThemeSpecBytes: number;
+  maxFrameBytes: number;
+  maxThemePrimitives: number;
+  supportedPrimitiveTypes: PrimitiveType[];
+  maxThemeGifAssets: number;
+  maxThemeGifBytes: number;
+  maxThemeGifWidth: number;
+  maxThemeGifHeight: number;
+  maxThemeGifPixels: number;
+};
+type DeviceHello = {
+  board?: string;
+  firmware?: string;
+  maxFrameBytes?: number;
+  capabilities?: {
+    theme?: {
+      maxThemeSpecBytes?: number;
+      maxStoredThemeSpecBytes?: number;
+      maxThemePrimitives?: number;
+      supportedPrimitiveTypes?: string[];
+      maxThemeGifAssets?: number;
+      maxThemeGifBytes?: number;
+      maxThemeGifWidth?: number;
+      maxThemeGifHeight?: number;
+      maxThemeGifPixels?: number;
+      supportsStoredThemes?: boolean;
+    };
+  };
+};
 type SpriteSource = {
   file: File;
   previewUrl: string;
@@ -212,6 +244,7 @@ interface AppState {
   warnings: string[];
   notice: string;
   targetOrigin: string;
+  deviceProfile: DeviceProfile;
   pixelTool: PixelTool;
   pixelBrushToken: string;
   snapEnabled: boolean;
@@ -275,6 +308,22 @@ const frame: FrameData = {
 };
 const UPDATE_LABEL_PREVIEW_TOGGLE_MS = 1500;
 const UPDATE_LABEL_PREVIEW_TEXTS = ["Update Available:", "vibetv.local"] as const;
+
+function defaultDeviceProfile(): DeviceProfile {
+  return {
+    source: "offline",
+    label: "Offline ESP8266 defaults",
+    maxStoredThemeSpecBytes: MAX_SPEC_BYTES,
+    maxFrameBytes: MAX_FRAME_BYTES,
+    maxThemePrimitives: MAX_PRIMITIVES,
+    supportedPrimitiveTypes: [...SUPPORTED_PRIMITIVE_TYPES],
+    maxThemeGifAssets: MAX_GIF_ASSETS,
+    maxThemeGifBytes: MAX_GIF_BYTES,
+    maxThemeGifWidth: MAX_GIF_WIDTH,
+    maxThemeGifHeight: MAX_GIF_HEIGHT,
+    maxThemeGifPixels: MAX_GIF_PIXELS,
+  };
+}
 
 function previewTime(date: Date): string {
   return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
@@ -2281,6 +2330,7 @@ const state: AppState = {
   warnings: [],
   notice: restoredDraft ? `Last draft restored from ${formatSavedAt(restoredDraft.savedAt)}.` : "",
   targetOrigin: storedTargetOrigin(),
+  deviceProfile: defaultDeviceProfile(),
   pixelTool: "move",
   pixelBrushToken: "a",
   snapEnabled: true,
@@ -2654,6 +2704,81 @@ function normalizeTargetOrigin(value: string): string {
   return withProtocol.replace(/\/+$/, "");
 }
 
+function numberOrDefault(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function primitiveTypesOrDefault(value: unknown, fallback: PrimitiveType[]): PrimitiveType[] {
+  if (!Array.isArray(value)) {
+    return [...fallback];
+  }
+  const supported = value
+    .map((item) => typeof item === "string" ? item.trim().toLowerCase() : "")
+    .filter((item): item is PrimitiveType => SUPPORTED_PRIMITIVE_TYPES.includes(item as PrimitiveType));
+  return supported.length > 0 ? supported : [...fallback];
+}
+
+function deviceProfileFromHello(hello: DeviceHello): DeviceProfile {
+  const defaults = defaultDeviceProfile();
+  const theme = hello.capabilities?.theme;
+  const board = hello.board?.trim() || "Vibe TV";
+  const firmware = hello.firmware?.trim();
+  return {
+    source: "device",
+    label: firmware ? `${board} ${firmware}` : board,
+    maxStoredThemeSpecBytes: numberOrDefault(theme?.maxStoredThemeSpecBytes, numberOrDefault(theme?.maxThemeSpecBytes, defaults.maxStoredThemeSpecBytes)),
+    maxFrameBytes: numberOrDefault(hello.maxFrameBytes, defaults.maxFrameBytes),
+    maxThemePrimitives: numberOrDefault(theme?.maxThemePrimitives, defaults.maxThemePrimitives),
+    supportedPrimitiveTypes: primitiveTypesOrDefault(theme?.supportedPrimitiveTypes, defaults.supportedPrimitiveTypes),
+    maxThemeGifAssets: numberOrDefault(theme?.maxThemeGifAssets, defaults.maxThemeGifAssets),
+    maxThemeGifBytes: numberOrDefault(theme?.maxThemeGifBytes, defaults.maxThemeGifBytes),
+    maxThemeGifWidth: numberOrDefault(theme?.maxThemeGifWidth, defaults.maxThemeGifWidth),
+    maxThemeGifHeight: numberOrDefault(theme?.maxThemeGifHeight, defaults.maxThemeGifHeight),
+    maxThemeGifPixels: numberOrDefault(theme?.maxThemeGifPixels, defaults.maxThemeGifPixels),
+  };
+}
+
+async function readDeviceProfile(targetOrigin: string): Promise<DeviceProfile | null> {
+  const response = await fetchWithCorsFallback(`${targetOrigin}/hello`, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  if (response.type === "opaque") {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(await responseFailureMessage(response, "Device capability check failed"));
+  }
+  return deviceProfileFromHello(await response.json() as DeviceHello);
+}
+
+async function refreshDeviceProfile(): Promise<boolean> {
+  const targetOrigin = normalizeTargetOrigin(state.targetOrigin);
+  state.targetOrigin = targetOrigin;
+  persistTargetOrigin();
+  state.notice = "Reading Vibe TV capabilities.";
+  render();
+  try {
+    const profile = await readDeviceProfile(targetOrigin);
+    if (!profile) {
+      state.deviceProfile = defaultDeviceProfile();
+      state.notice = "Browser could not read device capabilities; using offline ESP8266 defaults.";
+      render();
+      return false;
+    }
+    state.deviceProfile = profile;
+    validateCurrentSpec();
+    state.notice = `Validating against ${state.deviceProfile.label}.`;
+    render();
+    return true;
+  } catch (error) {
+    state.deviceProfile = defaultDeviceProfile();
+    state.notice = error instanceof Error ? error.message : "Could not read device capabilities.";
+  }
+  render();
+  return false;
+}
+
 function syncJsonFromSpec() {
   normalizeMiniThemeSpec(state.spec);
   state.jsonText = prettyJson(state.spec);
@@ -2887,6 +3012,7 @@ function validateThemeAssetPaths(primitive: Primitive, prefix: string, errors: s
 function validateSpec(spec: ThemeSpec): { errors: string[]; warnings: string[] } {
   const errors: string[] = [];
   const warnings: string[] = [];
+  const profile = state.deviceProfile;
 
   if (spec.themeSpecVersion !== 1) {
     errors.push("themeSpecVersion muss 1 sein.");
@@ -2906,14 +3032,16 @@ function validateSpec(spec: ThemeSpec): { errors: string[]; warnings: string[] }
   if (!Array.isArray(spec.primitives) || spec.primitives.length === 0) {
     errors.push("Mindestens ein Primitive ist erforderlich.");
   }
-  if (spec.primitives.length > MAX_PRIMITIVES) {
-    errors.push(`Zu viele Primitives: ${spec.primitives.length}/${MAX_PRIMITIVES}.`);
+  if (spec.primitives.length > profile.maxThemePrimitives) {
+    errors.push(`Zu viele Primitives: ${spec.primitives.length}/${profile.maxThemePrimitives}.`);
   }
 
   spec.primitives.forEach((primitive, index) => {
     const prefix = `Primitive ${index + 1}`;
     if (!SUPPORTED_PRIMITIVE_TYPES.includes(primitive.type)) {
       errors.push(`${prefix}: type muss ${SUPPORTED_PRIMITIVE_TYPES.join(", ")} sein.`);
+    } else if (!profile.supportedPrimitiveTypes.includes(primitive.type)) {
+      errors.push(`${prefix}: ${primitive.type} wird von ${profile.label} nicht unterstützt.`);
     }
     if (!isNonNegativeInteger(primitive.x) || !isNonNegativeInteger(primitive.y)) {
       errors.push(`${prefix}: x/y müssen ganze Zahlen ab 0 sein.`);
@@ -2958,8 +3086,8 @@ function validateSpec(spec: ThemeSpec): { errors: string[]; warnings: string[] }
       if (!isPositiveInteger(primitive.width) || !isPositiveInteger(primitive.height)) {
         errors.push(`${prefix}: width/height müssen größer als 0 sein.`);
       } else {
-        if (primitive.width > MAX_GIF_WIDTH || primitive.height > MAX_GIF_HEIGHT || primitive.width * primitive.height > MAX_GIF_PIXELS) {
-          errors.push(`${prefix}: GIF ist zu groß. Limit ist ${MAX_GIF_WIDTH}x${MAX_GIF_HEIGHT} wie mini.gif.`);
+        if (primitive.width > profile.maxThemeGifWidth || primitive.height > profile.maxThemeGifHeight || primitive.width * primitive.height > profile.maxThemeGifPixels) {
+          errors.push(`${prefix}: GIF ist zu groß. Limit ist ${profile.maxThemeGifWidth}x${profile.maxThemeGifHeight}.`);
         }
       }
       validateThemeAssetPaths(primitive, prefix, errors);
@@ -3009,22 +3137,22 @@ function validateSpec(spec: ThemeSpec): { errors: string[]; warnings: string[] }
   });
 
   const bytes = new TextEncoder().encode(JSON.stringify(buildDeviceThemeSpec(spec))).length;
-  if (bytes > MAX_SPEC_BYTES) {
-    errors.push(`ThemeSpec ist zu groß: ${bytes}/${MAX_SPEC_BYTES} Bytes.`);
+  if (bytes > profile.maxStoredThemeSpecBytes) {
+    errors.push(`ThemeSpec ist zu groß: ${bytes}/${profile.maxStoredThemeSpecBytes} Bytes.`);
   }
   const frameBytes = new TextEncoder().encode(JSON.stringify(buildLiveFramePayload(spec))).length;
-  if (frameBytes > MAX_FRAME_BYTES) {
-    errors.push(`Payload ist zu groß für Vibe TV: ${frameBytes}/${MAX_FRAME_BYTES} Bytes.`);
+  if (frameBytes > profile.maxFrameBytes) {
+    errors.push(`Payload ist zu groß für Vibe TV: ${frameBytes}/${profile.maxFrameBytes} Bytes.`);
   }
 
   const gifPaths = uniqueAssetPaths("gif", spec);
-  if (gifPaths.length > MAX_GIF_ASSETS) {
-    errors.push(`Zu viele GIFs: ${gifPaths.length}/${MAX_GIF_ASSETS}. VibeTV ESP8266 unterstützt ein mini.gif-großes GIF pro Theme.`);
+  if (gifPaths.length > profile.maxThemeGifAssets) {
+    errors.push(`Zu viele GIFs: ${gifPaths.length}/${profile.maxThemeGifAssets}.`);
   }
   for (const path of gifPaths) {
     const file = state.gifAssets[path]?.file;
-    if (file && file.size > MAX_GIF_BYTES) {
-      errors.push(`GIF ${path} ist zu groß: ${file.size}/${MAX_GIF_BYTES} Bytes. Orientiere dich an mini.gif.`);
+    if (file && file.size > profile.maxThemeGifBytes) {
+      errors.push(`GIF ${path} ist zu groß: ${file.size}/${profile.maxThemeGifBytes} Bytes.`);
     }
   }
 
@@ -3180,6 +3308,7 @@ function render() {
   const selectedCount = selectedPrimitiveIndices().length;
   const bytes = new TextEncoder().encode(JSON.stringify(buildDeviceThemeSpec(state.spec))).length;
   const frameBytes = new TextEncoder().encode(JSON.stringify(buildLiveFramePayload())).length;
+  const profile = state.deviceProfile;
 
   app.innerHTML = `
     <section class="studio-shell">
@@ -3187,9 +3316,10 @@ function render() {
         <h1>Theme Studio</h1>
         <div class="appbar-actions">
           <div class="status-strip">
-            ${metric("Theme", bytes, MAX_SPEC_BYTES)}
-            ${metric("Live", frameBytes, MAX_FRAME_BYTES)}
-            ${metric("Primitives", state.spec.primitives.length, MAX_PRIMITIVES)}
+            ${metric("Theme", bytes, profile.maxStoredThemeSpecBytes)}
+            ${metric("Live", frameBytes, profile.maxFrameBytes)}
+            ${metric("Primitives", state.spec.primitives.length, profile.maxThemePrimitives)}
+            <span class="health ${profile.source === "device" ? "ok" : "warn"}">${escapeHtml(profile.label)}</span>
             <span class="health ${state.errors.length ? "bad" : "ok"}">${state.errors.length ? "Invalid" : "Valid"}</span>
           </div>
         </div>
@@ -3204,6 +3334,7 @@ function render() {
           <label>Vibe TV
             <input data-field="targetOrigin" aria-label="Vibe TV URL" value="${escapeAttr(state.targetOrigin)}" />
           </label>
+          <button class="full-width small-button" data-action="read-device-profile">Read Device Profile</button>
           <label>Background
             <span class="color-row">
               <input type="color" data-field="bgColor" value="${escapeAttr(state.spec.bgColor ?? "#000000")}" />
@@ -6513,6 +6644,10 @@ async function handleAction(action: string) {
     await saveThemeLocally();
     return;
   }
+  if (action === "read-device-profile") {
+    await refreshDeviceProfile();
+    return;
+  }
   if (action === "save-draft") {
     if (!applyPendingJsonEdit()) {
       return;
@@ -6702,8 +6837,9 @@ function addGifPrimitive(file: File) {
     render();
     return;
   }
-  if (file.size > MAX_GIF_BYTES) {
-    state.notice = `GIF is too large (${file.size}/${MAX_GIF_BYTES} bytes). Use a mini.gif-sized asset.`;
+  const maxGifBytes = state.deviceProfile.maxThemeGifBytes;
+  if (file.size > maxGifBytes) {
+    state.notice = `GIF is too large (${file.size}/${maxGifBytes} bytes). Use a smaller asset.`;
     render();
     return;
   }
@@ -7472,17 +7608,24 @@ function arrayBufferFor(data: Uint8Array): ArrayBuffer {
 }
 
 async function sendThemeToVibeTV() {
-  validateCurrentSpec();
-  if (state.errors.length > 0) {
-    state.notice = "Theme is invalid. Fix the errors before sending.";
-    render();
-    return;
-  }
-
   try {
     const targetOrigin = normalizeTargetOrigin(state.targetOrigin);
     state.targetOrigin = targetOrigin;
     persistTargetOrigin();
+    state.notice = "Checking Vibe TV capabilities.";
+    render();
+
+    const profile = await readDeviceProfile(targetOrigin);
+    if (profile) {
+      state.deviceProfile = profile;
+    }
+    validateCurrentSpec();
+    if (state.errors.length > 0) {
+      state.notice = `Theme is invalid for ${state.deviceProfile.label}. Fix the errors before sending.`;
+      render();
+      return;
+    }
+
     state.notice = "Sending theme to Vibe TV.";
     render();
     await uploadThemeAssets(targetOrigin);
@@ -7526,7 +7669,7 @@ async function sendThemeToVibeTV() {
 
 async function sendLegacyInlineTheme(targetOrigin: string) {
   const inlineBytes = new TextEncoder().encode(JSON.stringify(buildFramePayload())).length;
-  if (inlineBytes > MAX_FRAME_BYTES) {
+  if (inlineBytes > state.deviceProfile.maxFrameBytes) {
     throw new Error("This Vibe TV firmware does not support stored themes yet. Update the firmware, then send this larger theme again.");
   }
 

--- a/tools/theme-studio/src/styles.css
+++ b/tools/theme-studio/src/styles.css
@@ -183,6 +183,12 @@ h2 {
   color: var(--accent);
 }
 
+.health.warn {
+  border-color: rgba(255, 209, 102, 0.58);
+  background: rgba(255, 209, 102, 0.1);
+  color: #ffe3a1;
+}
+
 .workspace {
   display: grid;
   grid-template-columns: minmax(270px, 310px) minmax(420px, 1fr) minmax(310px, 360px);


### PR DESCRIPTION
## Summary
- read VibeTV `/hello` capabilities into a Theme Studio device profile
- validate ThemeSpec bytes, live frame bytes, primitive count, primitive types, and GIF limits against the active profile before upload
- advertise supported ThemeSpec primitive types from firmware and parse them in Companion capability handling
- document the capability fields in the protocol docs

Closes #84.

## Validation
- `git diff --check`
- `go test ./...` in `companion`
- `go vet ./...` in `companion`
- `npm run build` in `tools/theme-studio`
- `pio test -e native_theme_spec_renderer` in `firmware_esp8266`
- `./scripts/check-firmware-size-budget.sh firmware_esp8266 esp8266_smalltv_st7789 53 82 482000 350000`
- `CODEXBAR_DISPLAY_FW_VERSION=1.0.29-dev ./scripts/check-firmware-size-budget.sh firmware_esp8266 esp8266_smalltv_st7789 53 82 482000 350000`

## Hardware smoke
- Flashed ESP8266 VibeTV at `192.168.178.163` via OTA raw firmware with `CODEXBAR_DISPLAY_FW_VERSION=1.0.29-dev`.
- Device returned to WiFi after reboot.
- `GET /hello` reports `firmware=1.0.29-dev`, `maxStoredThemeSpecBytes=4096`, `maxFrameBytes=2048`, `maxThemePrimitives=32`, GIF limits, and `supportedPrimitiveTypes=[text,rect,progress,gif,sprite,pixels]`.
- `GET /health` reports `themeSpec.active=true`, `renderOk=true`, `brightnessPercent=100`.
- From local Theme Studio origin `http://127.0.0.1:5173`, `/hello` returns `Access-Control-Allow-Origin: *` and the same capability payload.

No release tag created.
