### PR TITLE
[codex] Add Theme Studio device brightness controls

### DIFF
--- a/docs/hardware-contract.md
+++ b/docs/hardware-contract.md
@@ -43,7 +43,7 @@ Companion negotiation:
 - The setup flow stores home WiFi credentials and restarts the device.
 - Connected devices expose `http://vibetv.local` with mDNS, show/log the fallback IP, serve a local setup hub with a copyable Mac setup command, and wait for the Mac Companion.
 - Connected devices expose customer-facing display settings directly on `http://vibetv.local`. The MVP setting is brightness on supported hardware.
-- `POST /api/settings` accepts form field `b` as a brightness percentage and updates supported settings without reflashing firmware. `GET /health` is the readback and support-diagnostics path.
+- `POST /api/settings` accepts form field `b` as a brightness percentage and updates supported settings without reflashing firmware. Include `api=1` for a JSON/CORS response from browser tools such as Theme Studio; omit it for the built-in `vibetv.local` form redirect. `GET /health` is the readback and support-diagnostics path.
 - Companion runtime defaults to WiFi with `http://vibetv.local`; explicit device IPs remain supported when `.local` does not resolve.
 - Saved WiFi credentials can be cleared from the local web UI with `POST /reset-wifi`.
 - If a connected device loses WiFi, it retries in station mode first. After a persistent outage it starts `VibeTV-Setup` again so the user can choose a different network.

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -1218,7 +1218,9 @@ bool persistDeviceSettings(const DeviceSettings& next) {
 }
 
 void handleSettingsAPI() {
+  addCorsHeaders();
   DeviceSettings next = deviceSettings;
+  const bool apiResponse = webServer.hasArg("api");
   if (webServer.hasArg("b")) {
     next.brightnessPercent = clampBrightnessPercent(webServer.arg("b").toInt());
   } else {
@@ -1229,12 +1231,17 @@ void handleSettingsAPI() {
     webServer.send(500, "text/plain; charset=utf-8", "save failed");
     return;
   }
-  if (webServer.hasArg("b")) {
+  if (!apiResponse && webServer.hasArg("b")) {
     webServer.sendHeader("Location", "/");
     webServer.send(303);
     return;
   }
-  webServer.send(204);
+  String out;
+  out.reserve(80);
+  out += "{\"ok\":true,";
+  appendSettingsJSON(out);
+  out += "}";
+  webServer.send(200, "application/json", out);
 }
 
 void handleAssetsList() {

--- a/protocol/PROTOCOL.md
+++ b/protocol/PROTOCOL.md
@@ -88,6 +88,7 @@ When the ESP8266 is connected to WiFi, it serves:
 - `POST /frame`: accepts one newline-delimited JSON frame as the request body and feeds it into the same firmware parser used by USB Serial.
 - Frame payloads may include a local `update` object (`available`, `latestVersion`, `status`, `lastError`). This updates the cached display/diagnostic update state and, when `available=true`, renders a firmware-level notice above the active theme that alternates every 1.5 seconds between `Update Available:` and `vibetv.local`. The ESP8266 firmware must not fetch public HTTPS manifests directly.
 - `POST /reset-wifi`: clears saved WiFi credentials and restarts the device into setup mode.
+- `POST /api/settings`: updates persisted device settings. Form field `b` sets display brightness percent. Include `api=1` for a JSON/CORS response; omit it for the built-in `vibetv.local` form redirect.
 - `GET /assets`: returns mounted filesystem status and a generic list of stored asset paths/sizes.
 - `POST /assets?path=/themes/<short-id>/<asset>`: uploads one theme asset using multipart field `asset`.
 - `DELETE /assets?path=/themes/<short-id>/<asset>`: deletes one stored asset. Firmware rejects deletion of the currently active stored ThemeSpec.

--- a/tools/theme-studio/src/main.ts
+++ b/tools/theme-studio/src/main.ts
@@ -245,6 +245,7 @@ interface AppState {
   notice: string;
   targetOrigin: string;
   deviceProfile: DeviceProfile;
+  deviceBrightnessPercent: number | null;
   pixelTool: PixelTool;
   pixelBrushToken: string;
   snapEnabled: boolean;
@@ -277,6 +278,11 @@ interface DeviceHealth {
     gif?: {
       activePath?: string;
       lastError?: unknown;
+    };
+  };
+  settings?: {
+    display?: {
+      brightnessPercent?: number;
     };
   };
 }
@@ -2331,6 +2337,7 @@ const state: AppState = {
   notice: restoredDraft ? `Last draft restored from ${formatSavedAt(restoredDraft.savedAt)}.` : "",
   targetOrigin: storedTargetOrigin(),
   deviceProfile: defaultDeviceProfile(),
+  deviceBrightnessPercent: null,
   pixelTool: "move",
   pixelBrushToken: "a",
   snapEnabled: true,
@@ -2738,6 +2745,11 @@ function deviceProfileFromHello(hello: DeviceHello): DeviceProfile {
   };
 }
 
+function brightnessFromHealth(health: DeviceHealth | null): number | null {
+  const value = health?.settings?.display?.brightnessPercent;
+  return typeof value === "number" && Number.isFinite(value) ? clamp(Math.round(value), 10, 100) : null;
+}
+
 async function readDeviceProfile(targetOrigin: string): Promise<DeviceProfile | null> {
   const response = await fetchWithCorsFallback(`${targetOrigin}/hello`, {
     method: "GET",
@@ -2767,6 +2779,7 @@ async function refreshDeviceProfile(): Promise<boolean> {
       return false;
     }
     state.deviceProfile = profile;
+    state.deviceBrightnessPercent = brightnessFromHealth(await fetchDeviceHealth(targetOrigin));
     validateCurrentSpec();
     state.notice = `Validating against ${state.deviceProfile.label}.`;
     render();
@@ -3334,7 +3347,16 @@ function render() {
           <label>Vibe TV
             <input data-field="targetOrigin" aria-label="Vibe TV URL" value="${escapeAttr(state.targetOrigin)}" />
           </label>
-          <button class="full-width small-button" data-action="read-device-profile">Read Device Profile</button>
+          <button class="full-width small-button" data-action="read-device-profile">Read Device</button>
+          <div class="device-controls">
+            <label>Brightness
+              <input type="range" min="10" max="100" data-device-brightness value="${state.deviceBrightnessPercent ?? 100}" ${state.deviceBrightnessPercent === null ? "disabled" : ""} />
+            </label>
+            <div class="device-control-row">
+              <span>${state.deviceBrightnessPercent === null ? "Read device first" : `${state.deviceBrightnessPercent}%`}</span>
+              <button class="small-button" data-action="save-device-settings" ${state.deviceBrightnessPercent === null ? "disabled" : ""}>Save</button>
+            </div>
+          </div>
           <label>Background
             <span class="color-row">
               <input type="color" data-field="bgColor" value="${escapeAttr(state.spec.bgColor ?? "#000000")}" />
@@ -5951,6 +5973,11 @@ function bindEvents() {
     });
   });
 
+  app.querySelector<HTMLInputElement>("[data-device-brightness]")?.addEventListener("input", (event) => {
+    state.deviceBrightnessPercent = clamp(toInt((event.target as HTMLInputElement).value, 100), 10, 100);
+    render();
+  });
+
   app.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>("[data-primitive-field]").forEach((input) => {
     input.addEventListener("input", () => {
       pushHistory();
@@ -6646,6 +6673,10 @@ async function handleAction(action: string) {
   }
   if (action === "read-device-profile") {
     await refreshDeviceProfile();
+    return;
+  }
+  if (action === "save-device-settings") {
+    await saveDeviceSettings();
     return;
   }
   if (action === "save-draft") {
@@ -7663,6 +7694,41 @@ async function sendThemeToVibeTV() {
     state.notice = `${confirmation ?? "Theme sent to Vibe TV."}${cleanupNotice(cleaned)}`;
   } catch (error) {
     state.notice = error instanceof Error ? error.message : `Could not reach Vibe TV at ${normalizeTargetOrigin(state.targetOrigin)}. Check Wi-Fi/mDNS, then try again.`;
+  }
+  render();
+}
+
+async function saveDeviceSettings() {
+  if (state.deviceBrightnessPercent === null) {
+    state.notice = "Read the device before saving settings.";
+    render();
+    return;
+  }
+  const targetOrigin = normalizeTargetOrigin(state.targetOrigin);
+  state.targetOrigin = targetOrigin;
+  persistTargetOrigin();
+  state.notice = "Saving device settings.";
+  render();
+  try {
+    const body = new URLSearchParams({
+      api: "1",
+      b: String(clamp(state.deviceBrightnessPercent, 10, 100)),
+    });
+    const response = await fetchWithCorsFallback(`${targetOrigin}/api/settings`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        Accept: "application/json",
+      },
+      body,
+    });
+    if (response.type !== "opaque" && !response.ok) {
+      throw new Error(await responseFailureMessage(response, "Device settings save failed"));
+    }
+    state.deviceBrightnessPercent = brightnessFromHealth(await fetchDeviceHealth(targetOrigin)) ?? state.deviceBrightnessPercent;
+    state.notice = `Brightness saved at ${state.deviceBrightnessPercent}%.`;
+  } catch (error) {
+    state.notice = error instanceof Error ? error.message : `Could not save settings at ${targetOrigin}.`;
   }
   render();
 }

--- a/tools/theme-studio/src/styles.css
+++ b/tools/theme-studio/src/styles.css
@@ -979,6 +979,36 @@ textarea:focus {
   margin-top: 10px;
 }
 
+.device-controls {
+  display: grid;
+  gap: 8px;
+  margin: 10px 0 12px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #0a0d11;
+}
+
+.device-controls label {
+  margin: 0;
+}
+
+.device-control-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.device-control-row span {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .saved-themes {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
## Summary
- add a small Theme Studio device controls panel that reads brightness from `/health`
- save brightness from Theme Studio through `POST /api/settings` using `api=1`
- make `/api/settings` CORS/JSON-friendly while preserving the existing `vibetv.local` form redirect
- document the settings API behavior

Closes #110.

## Validation
- `git diff --check`
- `npm run build` in `tools/theme-studio`
- `pio run -e esp8266_smalltv_st7789` in `firmware_esp8266`
- `pio test -e native_theme_spec_renderer` in `firmware_esp8266`
- `./scripts/check-firmware-size-budget.sh firmware_esp8266 esp8266_smalltv_st7789 53 82 482000 350000`
- `CODEXBAR_DISPLAY_FW_VERSION=1.0.30-dev ./scripts/check-firmware-size-budget.sh firmware_esp8266 esp8266_smalltv_st7789 53 82 482000 350000`

## Hardware smoke
- Flashed ESP8266 VibeTV at `192.168.178.163` via OTA raw firmware with `CODEXBAR_DISPLAY_FW_VERSION=1.0.30-dev`.
- Device returned to WiFi after reboot.
- Cross-origin `POST /api/settings` with `api=1&b=42` returned JSON and CORS headers.
- `/health` reported `brightnessPercent=42`.
- Clean OTA reboot preserved `brightnessPercent=42` and reported `resetReason=Software/System restart`.
- Legacy form-style `POST /api/settings` with `b=55` still returned `303 Location: /`.
- Restored brightness to `100`; final `/health` reported `firmware=1.0.30-dev`, `brightnessPercent=100`, `renderOk=true`.

No release tag created.
