### PR TITLE
CODEX: Add VibeTV write API pairing

### DIFF
--- a/companion/internal/transport/wifi_transport.go
+++ b/companion/internal/transport/wifi_transport.go
@@ -21,6 +21,8 @@ const (
 	defaultWiFiTimeout      = 5 * time.Second
 	assetUploadAttempts     = 3
 	assetUploadRetryMaxBody = 512
+	deviceAuthHeader        = "X-VibeTV-Token"
+	deviceAuthEnv           = "CODEXBAR_DISPLAY_DEVICE_TOKEN"
 )
 
 var assetUploadRetryDelay = 1500 * time.Millisecond
@@ -63,7 +65,7 @@ func (WiFiTransport) Name() string {
 }
 
 func (t WiFiTransport) ResolvePort(requested string) (string, error) {
-	return normalizeWiFiTarget(requested)
+	return normalizeWiFiTargetWithToken(requested)
 }
 
 func (t WiFiTransport) DeviceCapabilities(target string) (protocol.DeviceCapabilities, error) {
@@ -93,7 +95,13 @@ func (t WiFiTransport) SendLine(target string, line []byte) error {
 	if err != nil {
 		return err
 	}
-	resp, err := t.client.Post(base+"/frame", "application/json", bytes.NewReader(line))
+	req, err := http.NewRequest(http.MethodPost, base+"/frame", bytes.NewReader(line))
+	if err != nil {
+		return fmt.Errorf("build frame request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	applyDeviceAuth(req, target)
+	resp, err := t.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("post frame: %w", err)
 	}
@@ -135,7 +143,13 @@ func (t WiFiTransport) UploadAsset(target, devicePath, filename string, data []b
 	contentType := writer.FormDataContentType()
 	var lastErr error
 	for attempt := 1; attempt <= assetUploadAttempts; attempt++ {
-		resp, err := t.client.Post(endpoint, contentType, bytes.NewReader(body.Bytes()))
+		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body.Bytes()))
+		if err != nil {
+			return fmt.Errorf("build asset request %s: %w", devicePath, err)
+		}
+		req.Header.Set("Content-Type", contentType)
+		applyDeviceAuth(req, target)
+		resp, err := t.client.Do(req)
 		if err != nil {
 			lastErr = fmt.Errorf("post asset %s: %w", devicePath, err)
 			if shouldRetryAssetUpload(err) && attempt < assetUploadAttempts {
@@ -222,7 +236,13 @@ func (t WiFiTransport) ActivateStoredTheme(target, devicePath string) error {
 	if err != nil {
 		return fmt.Errorf("marshal theme activation: %w", err)
 	}
-	resp, err := t.client.Post(base+"/theme/active", "application/json", bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, base+"/theme/active", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build theme activation request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	applyDeviceAuth(req, target)
+	resp, err := t.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("post theme activation: %w", err)
 	}
@@ -232,6 +252,54 @@ func (t WiFiTransport) ActivateStoredTheme(target, devicePath string) error {
 		return fmt.Errorf("post theme activation: status=%d body=%q", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return nil
+}
+
+func applyDeviceAuth(req *http.Request, rawTarget string) {
+	if token := deviceAuthTokenForTarget(rawTarget); token != "" {
+		req.Header.Set(deviceAuthHeader, token)
+	}
+}
+
+func deviceAuthTokenForTarget(raw string) string {
+	token := deviceAuthTokenFromTarget(raw)
+	if token != "" {
+		return token
+	}
+	return strings.TrimSpace(os.Getenv(deviceAuthEnv))
+}
+
+func deviceAuthTokenFromTarget(raw string) string {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return ""
+	}
+	if !strings.Contains(target, "://") {
+		target = "http://" + target
+	}
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(parsed.Query().Get("token"))
+}
+
+func normalizeWiFiTargetWithToken(raw string) (string, error) {
+	base, err := normalizeWiFiTarget(raw)
+	if err != nil {
+		return "", err
+	}
+	token := deviceAuthTokenFromTarget(raw)
+	if token == "" {
+		return base, nil
+	}
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	query := parsed.Query()
+	query.Set("token", token)
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
 }
 
 func normalizeWiFiTarget(raw string) (string, error) {

--- a/companion/internal/transport/wifi_transport_test.go
+++ b/companion/internal/transport/wifi_transport_test.go
@@ -35,10 +35,12 @@ func TestWiFiTransportDeviceCapabilitiesReadsHello(t *testing.T) {
 
 func TestWiFiTransportSendLinePostsFrame(t *testing.T) {
 	var gotBody string
+	var gotToken string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/frame" {
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
+		gotToken = r.Header.Get(deviceAuthHeader)
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("read request body: %v", err)
@@ -50,11 +52,14 @@ func TestWiFiTransportSendLinePostsFrame(t *testing.T) {
 
 	transport := NewWiFiTransportWithClient(server.Client())
 	line := []byte(`{"provider":"codex","session":12}` + "\n")
-	if err := transport.SendLine(server.URL+"/", line); err != nil {
+	if err := transport.SendLine(server.URL+"/?token=pair-token-123", line); err != nil {
 		t.Fatalf("SendLine returned error: %v", err)
 	}
 	if gotBody != string(line) {
 		t.Fatalf("unexpected body %q", gotBody)
+	}
+	if gotToken != "pair-token-123" {
+		t.Fatalf("unexpected auth token %q", gotToken)
 	}
 }
 
@@ -69,14 +74,27 @@ func TestWiFiTransportResolveTargetAddsHTTPDefault(t *testing.T) {
 	}
 }
 
+func TestWiFiTransportResolveTargetPreservesPairingToken(t *testing.T) {
+	transport := NewWiFiTransportWithClient(nil)
+	target, err := transport.ResolvePort("192.168.178.123?token=pair-token-123&debug=1")
+	if err != nil {
+		t.Fatalf("ResolvePort returned error: %v", err)
+	}
+	if target != "http://192.168.178.123?token=pair-token-123" {
+		t.Fatalf("unexpected target %q", target)
+	}
+}
+
 func TestWiFiTransportUploadAssetPostsMultipart(t *testing.T) {
 	var gotPath string
 	var gotFilename string
 	var gotBody string
+	var gotToken string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/assets" {
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
+		gotToken = r.Header.Get(deviceAuthHeader)
 		gotPath = r.URL.Query().Get("path")
 		reader, err := r.MultipartReader()
 		if err != nil {
@@ -99,12 +117,16 @@ func TestWiFiTransportUploadAssetPostsMultipart(t *testing.T) {
 	}))
 	defer server.Close()
 
+	t.Setenv(deviceAuthEnv, "env-token-456")
 	transport := NewWiFiTransportWithClient(server.Client())
 	if err := transport.UploadAsset(server.URL, "/themes/u/cm.cbi", "cm.cbi", []byte("CBI1\n")); err != nil {
 		t.Fatalf("UploadAsset returned error: %v", err)
 	}
 	if gotPath != "/themes/u/cm.cbi" || gotFilename != "cm.cbi" || gotBody != "CBI1\n" {
 		t.Fatalf("unexpected upload path=%q filename=%q body=%q", gotPath, gotFilename, gotBody)
+	}
+	if gotToken != "env-token-456" {
+		t.Fatalf("unexpected auth token %q", gotToken)
 	}
 }
 
@@ -156,10 +178,12 @@ func TestWiFiTransportUploadAssetRetriesConnectionReset(t *testing.T) {
 
 func TestWiFiTransportActivateStoredThemePostsPath(t *testing.T) {
 	var gotBody string
+	var gotToken string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/theme/active" {
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
+		gotToken = r.Header.Get(deviceAuthHeader)
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("read request body: %v", err)
@@ -170,11 +194,14 @@ func TestWiFiTransportActivateStoredThemePostsPath(t *testing.T) {
 	defer server.Close()
 
 	transport := NewWiFiTransportWithClient(server.Client())
-	if err := transport.ActivateStoredTheme(server.URL, "/themes/u/cm.json"); err != nil {
+	if err := transport.ActivateStoredTheme(server.URL+"?token=pair-token-789", "/themes/u/cm.json"); err != nil {
 		t.Fatalf("ActivateStoredTheme returned error: %v", err)
 	}
 	if gotBody != `{"path":"/themes/u/cm.json"}` {
 		t.Fatalf("unexpected body %q", gotBody)
+	}
+	if gotToken != "pair-token-789" {
+		t.Fatalf("unexpected auth token %q", gotToken)
 	}
 }
 

--- a/docs/customer-setup.md
+++ b/docs/customer-setup.md
@@ -79,6 +79,20 @@ curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/do
 
 That command refreshes the Mac Companion first, then installs firmware if a newer release exists. USB flashing is not part of the customer flow.
 
+## Theme Studio Pairing
+
+Theme Studio can change the Vibe TV layout and display settings over the local network.
+
+1. Open `http://vibetv.local`.
+2. In the Pairing section, create a token if one is not shown yet.
+3. Open Theme Studio.
+4. Set the Vibe TV field to `http://vibetv.local` or the IP shown on the display.
+5. Paste the token into the Pairing token field, or select `Pair Device` to let Theme Studio create a new token.
+
+After pairing, Vibe TV accepts layout, brightness, asset, and firmware write requests only when that token is included. Status pages such as `/health` still work without a token.
+
+If the token is lost, open `http://vibetv.local` again and create/rotate the token. Do not reset WiFi just to fix pairing.
+
 ## What the Installer Does
 
 The installer handles everything automatically:

--- a/docs/hardware-contract.md
+++ b/docs/hardware-contract.md
@@ -44,6 +44,7 @@ Companion negotiation:
 - Connected devices expose `http://vibetv.local` with mDNS, show/log the fallback IP, serve a local setup hub with a copyable Mac setup command, and wait for the Mac Companion.
 - Connected devices expose customer-facing display settings directly on `http://vibetv.local`. The MVP setting is brightness on supported hardware.
 - `POST /api/settings` accepts form field `b` as a brightness percentage and updates supported settings without reflashing firmware. Include `api=1` for a JSON/CORS response from browser tools such as Theme Studio; omit it for the built-in `vibetv.local` form redirect. `GET /health` is the readback and support-diagnostics path.
+- Connected devices expose `POST /api/pair` to create or rotate a local LAN pairing token. After pairing, write APIs require `X-VibeTV-Token` or the built-in form/raw-OTA `token` query parameter. Read-only diagnostics (`/hello`, `/health`, `GET /assets`) remain open.
 - Companion runtime defaults to WiFi with `http://vibetv.local`; explicit device IPs remain supported when `.local` does not resolve.
 - Saved WiFi credentials can be cleared from the local web UI with `POST /reset-wifi`.
 - If a connected device loses WiFi, it retries in station mode first. After a persistent outage it starts `VibeTV-Setup` again so the user can choose a different network.

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -64,6 +64,8 @@ const char kSetupHost[] = "vibetv.local";
 const char kMdnsName[] = "vibetv";
 const char kMdnsHost[] = "vibetv.local";
 const char kDeviceSettingsPath[] = "/s";
+const char kDeviceAuthTokenPath[] = "/auth";
+const char kDeviceAuthHeader[] = "X-VibeTV-Token";
 const char kFirmwareManifestUrl[] = "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/firmware-manifest.json";
 const char* const kFirmwareUpdateNoticeTexts[] = {
     "Update Available:",
@@ -177,6 +179,9 @@ bool firmwareUpdateNoticeDirty = false;
 OtaUploadDiagnostics otaDiagnostics;
 RuntimeRenderDiagnostics renderDiagnostics;
 DeviceSettings deviceSettings;
+String deviceAuthToken;
+
+void addCorsHeaders();
 
 #if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
 constexpr const char* kDefaultThemeSpecPath = "/themes/u/mini-cl-1-410a37.json";
@@ -309,6 +314,112 @@ bool saveDeviceSettings() {
   const size_t written = file.write(&deviceSettings.brightnessPercent, 1);
   file.close();
   return written > 0;
+}
+
+bool validAuthToken(const String& value) {
+  if (value.length() < 16 || value.length() > 64) {
+    return false;
+  }
+  for (size_t i = 0; i < value.length(); ++i) {
+    const char c = value.charAt(i);
+    const bool ok =
+        (c >= 'a' && c <= 'z') ||
+        (c >= 'A' && c <= 'Z') ||
+        (c >= '0' && c <= '9') ||
+        c == '-' ||
+        c == '_';
+    if (!ok) {
+      return false;
+    }
+  }
+  return true;
+}
+
+String generateAuthToken() {
+  uint32_t seed = ESP.getCycleCount() ^ micros() ^ (static_cast<uint32_t>(ESP.getChipId()) << 8);
+  randomSeed(seed);
+  String token;
+  token.reserve(32);
+  for (uint8_t i = 0; i < 4; ++i) {
+    uint32_t value = static_cast<uint32_t>(random(0x10000)) << 16;
+    value |= static_cast<uint32_t>(random(0x10000));
+    char chunk[9];
+    snprintf(chunk, sizeof(chunk), "%08lx", static_cast<unsigned long>(value));
+    token += chunk;
+  }
+  return token;
+}
+
+bool loadDeviceAuthToken() {
+  deviceAuthToken = "";
+  if (!LittleFS.begin() || !LittleFS.exists(kDeviceAuthTokenPath)) {
+    return false;
+  }
+  File file = LittleFS.open(kDeviceAuthTokenPath, "r");
+  if (!file) {
+    return false;
+  }
+  String token = file.readString();
+  file.close();
+  token.trim();
+  if (!validAuthToken(token)) {
+    return false;
+  }
+  deviceAuthToken = token;
+  return true;
+}
+
+bool saveDeviceAuthToken(const String& token) {
+  if (!validAuthToken(token) || !LittleFS.begin()) {
+    return false;
+  }
+  File file = LittleFS.open(kDeviceAuthTokenPath, "w");
+  if (!file) {
+    return false;
+  }
+  file.print(token);
+  file.close();
+  deviceAuthToken = token;
+  return true;
+}
+
+bool deviceAuthConfigured() {
+  return deviceAuthToken.length() > 0;
+}
+
+String requestAuthToken() {
+  String token = webServer.header(kDeviceAuthHeader);
+  token.trim();
+  if (token.length() == 0) {
+    token = webServer.arg("token");
+    token.trim();
+  }
+  return token;
+}
+
+bool requestHasValidAuth() {
+  if (!deviceAuthConfigured()) {
+    return true;
+  }
+  return requestAuthToken() == deviceAuthToken;
+}
+
+bool requireWriteAuth() {
+  if (requestHasValidAuth()) {
+    return true;
+  }
+  addCorsHeaders();
+  webServer.sendHeader("WWW-Authenticate", "VibeTV token");
+  webServer.send(401, "text/plain; charset=utf-8", "pairing token required");
+  return false;
+}
+
+void appendAuthStatusJSON(String& out) {
+  out += "\"auth\":{\"paired\":";
+  out += deviceAuthConfigured() ? "true" : "false";
+  out += ",\"tokenHeader\":\"";
+  out += kDeviceAuthHeader;
+  out += "\"}";
 }
 
 void appendBrightnessCapabilityJSON(String& out) {
@@ -584,6 +695,8 @@ const char* transportCapabilitiesJSON(const char* activeTransport) {
   json += themeCapabilitiesJSON(false);
 #endif
 #endif
+  json += ",";
+  appendAuthStatusJSON(json);
   json += ",\"transport\":{\"active\":\"";
   json += isUsb ? "usb" : "wifi";
   json += "\",\"supported\":[\"usb\",\"wifi\"]}}";
@@ -914,11 +1027,25 @@ String connectedPageHTML() {
     html += F("</pre></section>");
   }
   html += F("<p><a href='/health'>Status</a> <a href='/update'>Update</a></p>");
+  const String tokenQuery = deviceAuthConfigured() ? String("?token=") + deviceAuthToken : String();
   if (renderer.SupportsBrightnessControl()) {
-    html += F("<section><form method='post' action='/api/settings'><label>Bright</label><input name='b' type='range' min='10' max='100' value='");
+    html += F("<section><form method='post' action='/api/settings");
+    html += tokenQuery;
+    html += F("'><label>Bright</label><input name='b' type='range' min='10' max='100' value='");
     html += String(deviceSettings.brightnessPercent);
     html += F("'><button>OK</button></form></section>");
   }
+  html += F("<section><h2>Pairing</h2>");
+  if (deviceAuthConfigured()) {
+    html += F("<p>Token</p><code>");
+    html += htmlEscape(deviceAuthToken);
+    html += F("</code><p class='muted'>Use this in Theme Studio or as CODEXBAR_DISPLAY_DEVICE_TOKEN for the Mac Companion.</p>");
+    html += F("<form method='post' action='/api/pair'><button>Rotate token</button></form>");
+  } else {
+    html += F("<p class='muted'>Create a token before exposing theme controls to other devices on your network.</p>");
+    html += F("<form method='post' action='/api/pair'><button>Create token</button></form>");
+  }
+  html += F("</section>");
   html += F("<form method='post' action='/reset-wifi' onsubmit=\"return confirm('Clear WiFi settings and restart setup?')\"><button>Reset WiFi</button></form>");
   return html;
 }
@@ -988,7 +1115,7 @@ void handleResetWifi() {
 void addCorsHeaders() {
   webServer.sendHeader("Access-Control-Allow-Origin", "*");
   webServer.sendHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,OPTIONS");
-  webServer.sendHeader("Access-Control-Allow-Headers", "Content-Type");
+  webServer.sendHeader("Access-Control-Allow-Headers", String("Content-Type,") + kDeviceAuthHeader);
 }
 
 void handleHello() {
@@ -1219,6 +1346,9 @@ bool persistDeviceSettings(const DeviceSettings& next) {
 
 void handleSettingsAPI() {
   addCorsHeaders();
+  if (!requireWriteAuth()) {
+    return;
+  }
   DeviceSettings next = deviceSettings;
   const bool apiResponse = webServer.hasArg("api");
   if (webServer.hasArg("b")) {
@@ -1242,6 +1372,26 @@ void handleSettingsAPI() {
   appendSettingsJSON(out);
   out += "}";
   webServer.send(200, "application/json", out);
+}
+
+void handlePairingAPI() {
+  addCorsHeaders();
+  const String token = generateAuthToken();
+  if (!saveDeviceAuthToken(token)) {
+    webServer.send(500, "text/plain; charset=utf-8", "pairing token save failed");
+    return;
+  }
+  if (webServer.hasArg("api")) {
+    String out;
+    out.reserve(100);
+    out += "{\"ok\":true,\"token\":\"";
+    out += jsonEscape(token);
+    out += "\"}";
+    webServer.send(200, "application/json", out);
+    return;
+  }
+  webServer.sendHeader("Location", "/");
+  webServer.send(303);
 }
 
 void handleAssetsList() {
@@ -1315,6 +1465,10 @@ void handleAssetUpload() {
     renderer.ResetGifStateForAssetUpdate();
     waitStatusRendered = true;
 
+    if (!requestHasValidAuth()) {
+      setAssetUploadError("unauthorized");
+      return;
+    }
     if (!isSafeAssetPath(assetUploadPath)) {
       setAssetUploadError("invalid asset path");
       return;
@@ -1371,6 +1525,12 @@ void handleAssetUpload() {
 }
 
 void handleAssetUploadResult() {
+  if (assetUploadError == "unauthorized") {
+    addCorsHeaders();
+    webServer.sendHeader("WWW-Authenticate", "VibeTV token");
+    webServer.send(401, "text/plain; charset=utf-8", "pairing token required");
+    return;
+  }
   if (!assetUploadSucceeded || assetUploadError.length() > 0) {
     const String error = assetUploadError.length() > 0 ? assetUploadError : "upload failed";
     addCorsHeaders();
@@ -1388,6 +1548,9 @@ void handleAssetUploadResult() {
 }
 
 void handleAssetDelete() {
+  if (!requireWriteAuth()) {
+    return;
+  }
   String path = webServer.arg("path");
   path.trim();
   if (!isSafeAssetPath(path)) {
@@ -1552,6 +1715,9 @@ void activateStoredThemeSpec(const String& path, const String& raw, const String
 
 void handleThemeActive() {
 #if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
+  if (!requireWriteAuth()) {
+    return;
+  }
   String body = webServer.arg("plain");
   body.trim();
   if (body.length() == 0 || body.length() > 160) {
@@ -1623,6 +1789,7 @@ void loadDefaultStoredThemeSpecCache() {
 
 String updatePageHTML() {
   const String installCommand = updateInstallCommand();
+  const String tokenQuery = deviceAuthConfigured() ? String("?token=") + deviceAuthToken : String();
   String html;
   html.reserve(1600);
   html += F("<!doctype html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'>");
@@ -1633,7 +1800,9 @@ String updatePageHTML() {
   html += F("<h2>Check with Mac</h2><p class='muted'>Copy this command into Terminal. It refreshes the Mac helper first, then installs firmware if needed.</p><pre id='cmd'>");
   html += htmlEscape(installCommand);
   html += F("</pre><textarea id='cmdFallback' readonly style='position:absolute;left:-9999px'></textarea><button type='button' onclick='copyCmd()' id='copyBtn'>Copy update command</button><details><summary>Manual upload</summary>");
-  html += F("<form method='post' action='/update/firmware' enctype='multipart/form-data'>");
+  html += F("<form method='post' action='/update/firmware");
+  html += tokenQuery;
+  html += F("' enctype='multipart/form-data'>");
   html += F("<input type='file' name='firmware' accept='.bin,application/octet-stream' required>");
   html += F("<button type='submit'>Upload firmware</button></form>");
   html += F("</details>");
@@ -1706,6 +1875,10 @@ void handleOtaUpload(int command, const char* target) {
     const String targetLabel = command == U_FS ? "Loading display" : "Loading firmware";
     drawUpdateStatus(targetLabel);
     waitStatusRendered = true;
+    if (!requestHasValidAuth()) {
+      setOtaError("unauthorized");
+      return;
+    }
     enterOtaSafeMode(command);
     if (!Update.begin(maxSize, command)) {
       setOtaError(Update.getErrorString());
@@ -1746,6 +1919,18 @@ void scheduleReboot(const char* reason) {
 }
 
 void handleOtaResult(const char* target) {
+  if (otaUploadError == "unauthorized") {
+    otaUploadInProgress = false;
+    otaDiagnostics.status = "failed";
+    otaDiagnostics.lastError = otaUploadError;
+    otaDiagnostics.updateError = Update.getError();
+    otaDiagnostics.endedAtMs = millis();
+    otaDiagnostics.failureCount++;
+    addCorsHeaders();
+    webServer.sendHeader("WWW-Authenticate", "VibeTV token");
+    webServer.send(401, "text/plain; charset=utf-8", "pairing token required");
+    return;
+  }
   if (!otaUploadSucceeded || otaUploadError.length() > 0 || Update.hasError()) {
     otaUploadInProgress = false;
     const String error = otaUploadError.length() > 0 ? otaUploadError : Update.getErrorString();
@@ -1787,7 +1972,28 @@ void sendRawOtaResponse(WiFiClient& client, int status, const char* statusText, 
 
 bool rawRequestLineIsFirmwarePost(const String& line) {
   return line.startsWith("POST /update/firmware.raw ") ||
-         line.startsWith("PUT /update/firmware.raw ");
+         line.startsWith("POST /update/firmware.raw?") ||
+         line.startsWith("PUT /update/firmware.raw ") ||
+         line.startsWith("PUT /update/firmware.raw?");
+}
+
+String rawRequestToken(const String& line) {
+  const int queryStart = line.indexOf("?token=");
+  if (queryStart < 0) {
+    return "";
+  }
+  int tokenStart = queryStart + 7;
+  int tokenEnd = line.indexOf(' ', tokenStart);
+  const int nextParam = line.indexOf('&', tokenStart);
+  if (nextParam >= 0 && (tokenEnd < 0 || nextParam < tokenEnd)) {
+    tokenEnd = nextParam;
+  }
+  if (tokenEnd < 0) {
+    tokenEnd = line.length();
+  }
+  String token = line.substring(tokenStart, tokenEnd);
+  token.trim();
+  return token;
 }
 
 void handleRawOtaClient() {
@@ -1809,6 +2015,7 @@ void handleRawOtaClient() {
     return;
   }
 
+  String rawToken = rawRequestToken(requestLine);
   size_t contentLength = 0;
   while (client.connected()) {
     String header = client.readStringUntil('\n');
@@ -1822,7 +2029,16 @@ void handleRawOtaClient() {
       String value = header.substring(header.indexOf(':') + 1);
       value.trim();
       contentLength = static_cast<size_t>(value.toInt());
+    } else if (lower.startsWith("x-vibetv-token:")) {
+      rawToken = header.substring(header.indexOf(':') + 1);
+      rawToken.trim();
     }
+  }
+
+  if (deviceAuthConfigured() && rawToken != deviceAuthToken) {
+    sendRawOtaResponse(client, 401, "Unauthorized", "pairing token required");
+    client.stop();
+    return;
   }
 
   if (contentLength == 0) {
@@ -1906,6 +2122,9 @@ void handleRawOtaClient() {
 }
 
 void handleFrame() {
+  if (!requireWriteAuth()) {
+    return;
+  }
   String rawBody = webServer.arg("plain");
   if (rawBody.length() == 0) {
     addCorsHeaders();
@@ -1959,6 +2178,7 @@ void startHttpServer() {
   webServer.on("/hello", HTTP_GET, handleHello);
   webServer.on("/health", HTTP_GET, handleHealth);
   webServer.on("/api/settings", HTTP_POST, handleSettingsAPI);
+  webServer.on("/api/pair", HTTP_POST, handlePairingAPI);
   webServer.on("/assets", HTTP_GET, handleAssetsList);
   webServer.on(
       "/assets",
@@ -1999,6 +2219,7 @@ void startHttpServer() {
     }
     webServer.send(404, "text/plain; charset=utf-8", "not found");
   });
+  webServer.collectHeaders(kDeviceAuthHeader);
   webServer.begin();
   httpServerStarted = true;
   rawOtaServer.begin();
@@ -2128,6 +2349,7 @@ void setup() {
 
   renderer.Setup(runtimeCtx);
   loadDeviceSettings();
+  loadDeviceAuthToken();
 #if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
   loadDefaultStoredThemeSpecCache();
 #endif

--- a/protocol/PROTOCOL.md
+++ b/protocol/PROTOCOL.md
@@ -88,11 +88,19 @@ When the ESP8266 is connected to WiFi, it serves:
 - `POST /frame`: accepts one newline-delimited JSON frame as the request body and feeds it into the same firmware parser used by USB Serial.
 - Frame payloads may include a local `update` object (`available`, `latestVersion`, `status`, `lastError`). This updates the cached display/diagnostic update state and, when `available=true`, renders a firmware-level notice above the active theme that alternates every 1.5 seconds between `Update Available:` and `vibetv.local`. The ESP8266 firmware must not fetch public HTTPS manifests directly.
 - `POST /reset-wifi`: clears saved WiFi credentials and restarts the device into setup mode.
+- `POST /api/pair`: creates or rotates the local LAN pairing token. Include `api=1` for a JSON/CORS response (`{"ok":true,"token":"..."}`); omit it for the built-in `vibetv.local` form redirect.
 - `POST /api/settings`: updates persisted device settings. Form field `b` sets display brightness percent. Include `api=1` for a JSON/CORS response; omit it for the built-in `vibetv.local` form redirect.
 - `GET /assets`: returns mounted filesystem status and a generic list of stored asset paths/sizes.
 - `POST /assets?path=/themes/<short-id>/<asset>`: uploads one theme asset using multipart field `asset`.
 - `DELETE /assets?path=/themes/<short-id>/<asset>`: deletes one stored asset. Firmware rejects deletion of the currently active stored ThemeSpec.
 - `POST /theme/active`: activates a stored ThemeSpec JSON file uploaded via `/assets`. Body: `{"path":"/themes/u/<short-id>.json"}`. This loads the spec into the firmware cache, so future `/frame` requests can stay small and only include live usage values. The response and `/health` diagnostics include a content `hash` for firmware that supports stored-theme verification.
+
+Pairing/auth:
+- Fresh unpaired devices keep write APIs open for backwards compatibility.
+- Once `/api/pair` has created a token, write APIs require `X-VibeTV-Token: <token>` or a `token=<token>` query parameter for built-in browser forms and raw OTA.
+- Protected write APIs are `POST /frame`, `POST /api/settings`, `POST /assets`, `DELETE /assets`, `POST /theme/active`, and firmware/filesystem OTA upload paths.
+- Read APIs such as `GET /hello`, `GET /health`, and `GET /assets` stay open for diagnostics.
+- This is a local-network pairing token, not a cloud security boundary. Anyone who can open `vibetv.local` can rotate the token locally.
 
 Installable customer themes use VibeTV Theme Packs: a directory or `.zip` with `manifest.json`, one ThemeSpec JSON file, and optional asset files. See `docs/theme-packs.md`.
 
@@ -106,11 +114,12 @@ Example:
 
 ```bash
 curl http://192.168.178.123/hello
-curl -X POST -F asset=@theme.json 'http://192.168.178.123/assets?path=/themes/u/cozy-1-a1b2c3.json'
-curl -X POST -H 'Content-Type: text/plain' --data '{"path":"/themes/u/cozy-1-a1b2c3.json"}' \
+TOKEN="$(curl -fsS -X POST -d api=1 http://192.168.178.123/api/pair | jq -r .token)"
+curl -X POST -H "X-VibeTV-Token: $TOKEN" -F asset=@theme.json 'http://192.168.178.123/assets?path=/themes/u/cozy-1-a1b2c3.json'
+curl -X POST -H "X-VibeTV-Token: $TOKEN" -H 'Content-Type: text/plain' --data '{"path":"/themes/u/cozy-1-a1b2c3.json"}' \
   http://192.168.178.123/theme/active
 printf '{"v":2,"provider":"codex","label":"Codex","session":17,"weekly":42,"resetSecs":15480}\n' \
-  | curl -X POST --data-binary @- http://192.168.178.123/frame
+  | curl -X POST -H "X-VibeTV-Token: $TOKEN" --data-binary @- http://192.168.178.123/frame
 ```
 
 ## Device Hello (Firmware -> Host)
@@ -148,6 +157,10 @@ On boot or after serial reconnect, firmware emits a capability line over USB. `G
       "maxThemeGifPixels": 6400,
       "builtinThemes": ["classic", "crt", "mini"]
     },
+    "auth": {
+      "paired": false,
+      "tokenHeader": "X-VibeTV-Token"
+    },
     "transport": {"active": "wifi", "supported": ["usb", "wifi"]}
   }
 }
@@ -165,6 +178,8 @@ Fields:
   - `theme.maxThemePrimitives` is the maximum primitive count accepted by the renderer.
   - `theme.supportedPrimitiveTypes` lists the ThemeSpec primitive types this firmware can render.
   - `theme.maxThemeGifAssets`, `maxThemeGifBytes`, `maxThemeGifWidth`, `maxThemeGifHeight`, and `maxThemeGifPixels` describe GIF asset and draw-box limits.
+  - `auth.paired` tells hosts whether write APIs currently require a pairing token.
+  - `auth.tokenHeader` names the HTTP header hosts should use for write auth.
   - `transport.maxFrameBytes` or top-level `maxFrameBytes` is the live frame payload limit. Hosts should use the stricter known value when both are present.
 
 Firmware may emit plain readiness lines (`codexbar_display_ready*`) instead of JSON hello.

--- a/tools/theme-studio/README.md
+++ b/tools/theme-studio/README.md
@@ -15,6 +15,7 @@ Animated sprites can use a `Clear` color in the inspector. Set it to the solid l
 GIF elements can also use `Background` as their local clear color. This does not magically key out every black pixel; it gives the firmware a color to restore behind transparent GIF pixels and between GIF loops.
 Use `Cozy Meadow` to load a warm pastoral sample theme with a generated meadow background sprite, birds, a butterfly, flowers, a small GIF, and live usage text.
 Set the Vibe TV field to the device URL, for example `http://192.168.178.163` or `http://vibetv.local`.
+For paired firmware, paste the `vibetv.local` Pairing token into the Pairing token field. `Pair Device` creates or rotates that token and stores it in browser storage.
 The Studio clears any cached ThemeSpec, uploads referenced GIF and sprite assets, uploads the compact ThemeSpec JSON as a content-hashed `/themes/u/<short-id>-<hash>.json`, activates it with `/theme/active`, then sends a small live `/frame` with usage values only.
 The health confirmation checks the active stored path and firmware-reported content hash so inspector edits such as text color, font, size, and position cannot be mistaken for an older same-id/same-revision theme.
 Use `Watch 60s` after sending when you need stronger confidence before publishing. It polls `/health` for one minute and reports whether the theme stayed active, whether render/GIF failures appeared, whether reset diagnostics changed, and whether free heap is low. A successful send confirms immediate activation; the watch check confirms short-run stability.
@@ -48,7 +49,7 @@ Advanced fallback through the companion CLI:
 ```bash
 cd ../../companion
 go run ./cmd/codexbar-display theme-validate --transport wifi --target http://vibetv.local --spec ../tools/theme-studio/theme.json
-go run ./cmd/codexbar-display theme-apply --transport wifi --target http://vibetv.local --spec ../tools/theme-studio/theme.json
+CODEXBAR_DISPLAY_DEVICE_TOKEN=<pairing-token> go run ./cmd/codexbar-display theme-apply --transport wifi --target http://vibetv.local --spec ../tools/theme-studio/theme.json
 ```
 
 Current MVP scope:

--- a/tools/theme-studio/src/main.ts
+++ b/tools/theme-studio/src/main.ts
@@ -25,6 +25,8 @@ const FIXED_FALLBACK_THEME = "mini";
 const THEME_PACK_MIN_FIRMWARE = "1.0.24";
 const DEFAULT_TARGET_ORIGIN = "http://vibetv.local";
 const TARGET_STORAGE_KEY = "codexbar.themeStudio.targetOrigin";
+const DEVICE_TOKEN_STORAGE_KEY = "codexbar.themeStudio.deviceToken";
+const DEVICE_AUTH_HEADER = "X-VibeTV-Token";
 const DEFAULT_GIF_SIZE = 80;
 const MAX_GIF_ASSETS = 1;
 const MAX_GIF_BYTES = 24 * 1024;
@@ -250,6 +252,7 @@ interface AppState {
   warnings: string[];
   notice: string;
   targetOrigin: string;
+  deviceToken: string;
   deviceProfile: DeviceProfile;
   deviceBrightnessPercent: number | null;
   stabilityCheck: StabilityCheckState;
@@ -2359,6 +2362,7 @@ const state: AppState = {
   warnings: [],
   notice: restoredDraft ? `Last draft restored from ${formatSavedAt(restoredDraft.savedAt)}.` : "",
   targetOrigin: storedTargetOrigin(),
+  deviceToken: storedDeviceToken(),
   deviceProfile: defaultDeviceProfile(),
   deviceBrightnessPercent: null,
   stabilityCheck: defaultStabilityCheck(),
@@ -2412,6 +2416,26 @@ function persistTargetOrigin() {
     window.localStorage.setItem(TARGET_STORAGE_KEY, state.targetOrigin);
   } catch {
     // Local storage is optional; sending still works without it.
+  }
+}
+
+function storedDeviceToken(): string {
+  try {
+    return (window.localStorage.getItem(DEVICE_TOKEN_STORAGE_KEY) ?? "").trim();
+  } catch {
+    return "";
+  }
+}
+
+function persistDeviceToken() {
+  try {
+    if (state.deviceToken.trim()) {
+      window.localStorage.setItem(DEVICE_TOKEN_STORAGE_KEY, state.deviceToken.trim());
+    } else {
+      window.localStorage.removeItem(DEVICE_TOKEN_STORAGE_KEY);
+    }
+  } catch {
+    // Local storage is optional; pairing can still be entered for the current session.
   }
 }
 
@@ -3371,6 +3395,10 @@ function render() {
           <label>Vibe TV
             <input data-field="targetOrigin" aria-label="Vibe TV URL" value="${escapeAttr(state.targetOrigin)}" />
           </label>
+          <label>Pairing token
+            <input data-field="deviceToken" aria-label="Vibe TV pairing token" type="password" autocomplete="off" value="${escapeAttr(state.deviceToken)}" />
+          </label>
+          <button class="full-width small-button" data-action="pair-device">Pair Device</button>
           <button class="full-width small-button" data-action="read-device-profile">Read Device</button>
           <div class="device-controls">
             <label>Brightness
@@ -6019,6 +6047,10 @@ function bindEvents() {
         state.targetOrigin = input.value.trim();
         persistTargetOrigin();
       }
+      if (key === "deviceToken") {
+        state.deviceToken = input.value.trim();
+        persistDeviceToken();
+      }
       if (key === "bgColor") {
         pushHistory();
         state.spec.bgColor = input.value.trim();
@@ -6728,6 +6760,10 @@ async function handleAction(action: string) {
   }
   if (action === "read-device-profile") {
     await refreshDeviceProfile();
+    return;
+  }
+  if (action === "pair-device") {
+    await pairDevice();
     return;
   }
   if (action === "save-device-settings") {
@@ -7760,6 +7796,47 @@ async function sendThemeToVibeTV() {
   render();
 }
 
+function deviceAuthHeaders(): Record<string, string> {
+  const token = state.deviceToken.trim();
+  return token ? { [DEVICE_AUTH_HEADER]: token } : {};
+}
+
+async function pairDevice() {
+  const targetOrigin = normalizeTargetOrigin(state.targetOrigin);
+  state.targetOrigin = targetOrigin;
+  persistTargetOrigin();
+  state.notice = "Pairing with Vibe TV.";
+  render();
+  try {
+    const body = new URLSearchParams({ api: "1" });
+    const response = await fetchWithCorsFallback(`${targetOrigin}/api/pair`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        Accept: "application/json",
+      },
+      body,
+    });
+    if (response.type === "opaque") {
+      throw new Error("Pairing response was not readable. Open vibetv.local and copy the token manually.");
+    }
+    if (!response.ok) {
+      throw new Error(await responseFailureMessage(response, "Pairing failed"));
+    }
+    const result = await response.json() as { token?: string };
+    const token = typeof result.token === "string" ? result.token.trim() : "";
+    if (!token) {
+      throw new Error("Pairing did not return a token.");
+    }
+    state.deviceToken = token;
+    persistDeviceToken();
+    state.notice = "Vibe TV paired. Future changes will use this token.";
+  } catch (error) {
+    state.notice = error instanceof Error ? error.message : `Could not pair with Vibe TV at ${targetOrigin}.`;
+  }
+  render();
+}
+
 async function saveDeviceSettings() {
   if (state.deviceBrightnessPercent === null) {
     state.notice = "Read the device before saving settings.";
@@ -7779,6 +7856,7 @@ async function saveDeviceSettings() {
     const response = await fetchWithCorsFallback(`${targetOrigin}/api/settings`, {
       method: "POST",
       headers: {
+        ...deviceAuthHeaders(),
         "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
         Accept: "application/json",
       },
@@ -7928,7 +8006,7 @@ async function clearDeviceThemeSpec(targetOrigin: string) {
 async function postFramePayload(targetOrigin: string, payload: Record<string, unknown>): Promise<Response> {
   return fetchWithCorsFallback(`${targetOrigin}/frame`, {
     method: "POST",
-    headers: { "Content-Type": "text/plain;charset=utf-8" },
+    headers: { ...deviceAuthHeaders(), "Content-Type": "text/plain;charset=utf-8" },
     body: JSON.stringify(payload),
   });
 }
@@ -7936,7 +8014,7 @@ async function postFramePayload(targetOrigin: string, payload: Record<string, un
 async function activateStoredTheme(targetOrigin: string, path: string): Promise<Response> {
   return fetchWithCorsFallback(`${targetOrigin}/theme/active`, {
     method: "POST",
-    headers: { "Content-Type": "text/plain;charset=utf-8" },
+    headers: { ...deviceAuthHeaders(), "Content-Type": "text/plain;charset=utf-8" },
     body: JSON.stringify({ path }),
   });
 }
@@ -7958,6 +8036,7 @@ async function uploadThemeAsset(targetOrigin: string, path: string, asset: Uploa
   body.append("asset", asset.file, asset.file.name);
   const response = await fetchWithCorsFallback(`${targetOrigin}/assets?path=${encodeURIComponent(path)}`, {
     method: "POST",
+    headers: deviceAuthHeaders(),
     body,
   });
   if (response.type !== "opaque" && !response.ok) {
@@ -8009,6 +8088,7 @@ async function fetchDeviceAssets(targetOrigin: string): Promise<DeviceAssets | n
 async function deleteThemeAsset(targetOrigin: string, path: string): Promise<Response> {
   return fetchWithCorsFallback(`${targetOrigin}/assets?path=${encodeURIComponent(path)}`, {
     method: "DELETE",
+    headers: deviceAuthHeaders(),
   });
 }
 


### PR DESCRIPTION
## Summary
- add local LAN pairing token support to VibeTV firmware write APIs
- add Theme Studio pairing token storage and Pair Device flow
- send X-VibeTV-Token from WiFi companion writes via target token or CODEXBAR_DISPLAY_DEVICE_TOKEN
- document pairing/auth behavior and recovery

Closes #80.

## Tests
- npm run build (tools/theme-studio)
- go test ./... (companion)
- pio test -e native_theme_spec_renderer
- pio run -e esp8266_smalltv_st7789
- ./scripts/check-firmware-size-budget.sh firmware_esp8266 esp8266_smalltv_st7789 46 82 482000 350000

## Hardware
- flashed attached VibeTV at 192.168.178.163 to 1.0.31-dev by WiFi Raw-OTA
- verified /hello reports auth paired=false after first boot
- paired device with /api/pair and verified auth paired=true
- verified unauthenticated /frame, /api/settings, /theme/active, DELETE /assets, and raw OTA return 401
- verified authenticated /frame, /api/settings, POST /assets, /theme/active, DELETE /assets, and raw OTA succeed
- restored brightness to 100
- final /health: firmware=1.0.31-dev, wifi connected at 192.168.178.163, renderOk=true

No release tag yet.