### PR TITLE
[codex] Persist active ThemeSpec across reboot

### DIFF
--- a/docs/hardware-contract.md
+++ b/docs/hardware-contract.md
@@ -64,6 +64,8 @@ Companion negotiation:
 - ThemeSpec v1 (declarative JSON):
   - validated by companion before send
   - checked against capability limits (`maxThemeSpecBytes`, `maxThemePrimitives`, `builtinThemes`)
+  - active stored ThemeSpec path is persisted on the device, so the last activated ThemeSpec is restored after reboot before live usage frames arrive
+  - if the persisted active ThemeSpec is missing or invalid, firmware falls back to the built-in `mini-classic` ThemeSpec cache
   - no user-script execution on firmware
 
 ## Local USB ThemeSpec Flow

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -68,6 +68,7 @@ const char kMdnsName[] = "vibetv";
 const char kMdnsHost[] = "vibetv.local";
 const char kDeviceSettingsPath[] = "/s";
 const char kDeviceAuthTokenPath[] = "/auth";
+const char kActiveThemeSpecPathFile[] = "/theme-active";
 const char kDeviceAuthHeader[] = "X-VibeTV-Token";
 const char kFirmwareManifestUrl[] = "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/firmware-manifest.json";
 const char* const kFirmwareUpdateNoticeTexts[] = {
@@ -1311,6 +1312,10 @@ void handleHealth() {
   out += jsonEscape(snapshot.activeTheme);
   out += "\",\"themeSpec\":{\"active\":";
   out += snapshot.themeSpecActive ? "true" : "false";
+  out += ",\"path\":";
+  appendJSONNullableString(out, activeThemeSpecPath);
+  out += ",\"hash\":";
+  appendJSONNullableString(out, activeThemeSpecHash);
   out += ",\"renderOk\":";
   out += snapshot.themeSpecRenderOk ? "true" : "false";
   out += ",\"renderFailures\":";
@@ -1635,6 +1640,37 @@ void handleAssetDelete() {
 }
 
 #if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
+bool readActiveThemeSpecPath(String& path) {
+  path = "";
+  if (!LittleFS.begin() || !LittleFS.exists(kActiveThemeSpecPathFile)) {
+    return false;
+  }
+  File file = LittleFS.open(kActiveThemeSpecPathFile, "r");
+  if (!file) {
+    return false;
+  }
+  path = file.readString();
+  file.close();
+  path.trim();
+  return isSafeAssetPath(path) && path.startsWith("/themes/");
+}
+
+bool saveActiveThemeSpecPath(const String& path) {
+  if (!isSafeAssetPath(path) || !path.startsWith("/themes/")) {
+    return false;
+  }
+  if (!LittleFS.begin()) {
+    return false;
+  }
+  File file = LittleFS.open(kActiveThemeSpecPathFile, "w");
+  if (!file) {
+    return false;
+  }
+  const size_t written = file.print(path);
+  file.close();
+  return written == path.length();
+}
+
 bool readStoredThemeSpec(const String& path, String& raw, String& error) {
   if (!isSafeAssetPath(path) || !path.startsWith("/themes/")) {
     error = "invalid theme path";
@@ -1775,6 +1811,10 @@ bool activateStoredThemePath(const String& path, String& themeId, int& themeRev,
   if (!themeSpecMetadata(raw, themeId, themeRev, fallbackTheme, error)) {
     return false;
   }
+  if (!saveActiveThemeSpecPath(path)) {
+    error = "save active theme failed";
+    return false;
+  }
 
   activateStoredThemeSpec(path, raw, themeId, themeRev, fallbackTheme);
   return true;
@@ -1846,14 +1886,40 @@ void handleThemeActive() {
 }
 
 #if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
-void loadDefaultStoredThemeSpecCache() {
+bool loadStoredThemeSpecCacheFromPath(const String& path) {
   String error;
-  if (!readStoredThemeSpec(kDefaultThemeSpecPath, runtimeCtx.runtime.cachedThemeSpecRaw, error)) {
-    return;
+  String raw;
+  if (!readStoredThemeSpec(path, raw, error)) {
+    Serial.printf("theme_cache_load_failed path=%s err=%s\n", path.c_str(), error.c_str());
+    return false;
   }
 
-  runtimeCtx.runtime.cachedThemeId = kDefaultThemeSpecId;
-  runtimeCtx.runtime.cachedThemeRev = kDefaultThemeSpecRev;
+  String themeId;
+  int themeRev = 0;
+  String fallbackTheme;
+  if (!themeSpecMetadata(raw, themeId, themeRev, fallbackTheme, error)) {
+    Serial.printf("theme_cache_load_failed path=%s err=%s\n", path.c_str(), error.c_str());
+    return false;
+  }
+
+  runtimeCtx.runtime.cachedThemeId = themeId;
+  runtimeCtx.runtime.cachedThemeRev = themeRev;
+  runtimeCtx.runtime.cachedThemeSpecRaw = raw;
+  activeThemeSpecPath = path;
+  activeThemeSpecHash = hashHex8(raw);
+  Serial.printf("theme_cache_loaded path=%s id=%s rev=%d\n", path.c_str(), themeId.c_str(), themeRev);
+  return true;
+}
+
+void loadDefaultStoredThemeSpecCache() {
+  String activePath;
+  if (readActiveThemeSpecPath(activePath) && loadStoredThemeSpecCacheFromPath(activePath)) {
+    return;
+  }
+  if (loadStoredThemeSpecCacheFromPath(kDefaultThemeSpecPath)) {
+    runtimeCtx.runtime.cachedThemeId = kDefaultThemeSpecId;
+    runtimeCtx.runtime.cachedThemeRev = kDefaultThemeSpecRev;
+  }
 }
 #endif
 


### PR DESCRIPTION
## Summary

- persist the active stored ThemeSpec path on the ESP8266 device when `/theme/active` activates a theme
- restore the persisted ThemeSpec cache on boot before live usage frames arrive
- expose the active ThemeSpec path/hash in `/health` for support diagnostics
- document the persistence contract in the hardware contract

## Root cause

Theme pack files were persisted in LittleFS, but the active ThemeSpec path was only held in RAM. After reboot or recovery, firmware loaded the built-in `mini-classic` ThemeSpec cache instead of the user's last activated custom theme such as Synthwave.

## Validation

Local checks on isolated branch:

- `git diff --check`
- `go test ./cmd/codexbar-display ./internal/transport ./internal/themeinstall ./internal/companionapi` from `companion/`
- `pio run -d firmware_esp8266 -e esp8266_smalltv_st7789`
- `pio test -d firmware_esp8266 -e native_theme_spec_renderer -f test_native_theme_spec`

Live hardware validation on VibeTV `192.168.178.163`:

- flashed patched ESP8266 firmware over WiFi OTA
- activated Synthwave via `/theme/active` with `/themes/u/synthwa-1-0432f1.json`
- verified `/health` reported `activeTheme: synthwave`, `themeSpec.path: /themes/u/synthwa-1-0432f1.json`, `renderOk: true`
- rebooted via a second OTA cycle
- verified after reboot that `/health` still reported `themeSpec.path: /themes/u/synthwa-1-0432f1.json`
- sent a normal authenticated `/frame` usage payload and verified `activeTheme: synthwave`, `renderOk: true`

## Notes

This does not address stale WiFi target discovery. That remains tracked separately in #125.
