### PR TITLE
Fix setup firmware update and theme activation recovery

### DIFF
--- a/apps/control-center/public/install-control-center-companion.sh
+++ b/apps/control-center/public/install-control-center-companion.sh
@@ -49,6 +49,7 @@ What it does:
   - stops the old standalone Mac setup service if it exists
   - starts the normal VibeTV Mac App background service
   - verifies http://127.0.0.1:47832/v1/status
+  - connects VibeTV and installs the latest firmware when available
 
 Examples:
   curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install-control-center-companion.sh | bash
@@ -227,6 +228,39 @@ wait_for_api() {
     sleep 0.5
   done
   die "Mac setup service did not answer on http://${ADDR}/v1/status. Inspect ${DISPLAY_DAEMON_LOG_ERR}."
+}
+
+json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s' "$value"
+}
+
+connect_vibetv() {
+  local payload
+  payload="{\"target\":\"$(json_escape "$TARGET")\",\"forcePair\":true}"
+
+  log "vibetv: connecting VibeTV at ${TARGET}"
+  curl -fsS --connect-timeout 10 --max-time 90 \
+    -X POST "http://${ADDR}/v1/device/repair" \
+    -H "Content-Type: application/json" \
+    -d "$payload" >/dev/null \
+    || die "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
+  log "vibetv: VibeTV is connected"
+}
+
+update_vibetv_firmware() {
+  log "vibetv: starting VibeTV firmware update"
+  "$BIN_PATH" install-update --target "$TARGET" --confirm-live-update \
+    || die "VibeTV firmware update failed. Keep VibeTV powered on, then rerun setup."
+  wait_for_api
+  log "vibetv: VibeTV firmware update complete"
+}
+
+finish_device_setup() {
+  connect_vibetv
+  update_vibetv_firmware
 }
 
 install_binary() {
@@ -457,6 +491,7 @@ main() {
 
   log "vibetv: Mac setup binary installed at ${BIN_PATH}"
   log "vibetv: background service installed at ${DISPLAY_DAEMON_PLIST}"
+  finish_device_setup
 }
 
 main "$@"

--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -186,6 +186,10 @@ async function main() {
     );
     await testSettingsStayCustomerOnly(browser, appContext.appUrl);
     await testUpdatesShowCustomerCompanionAction(browser, appContext.appUrl);
+    await testOverviewSeparatesMacAppAndFirmwareVersions(
+      browser,
+      appContext.appUrl,
+    );
     await testFirmwareUpdateShowsCustomerProgress(browser, appContext.appUrl);
     await testSupportReportExportsAppearAfterReportLoads(browser, appContext.appUrl);
     await testVibeTVAddressCopyStaysCustomerOnly(browser, appContext.appUrl);
@@ -1106,6 +1110,34 @@ async function testSavedAddressDoesNotBlockAutomaticVibeTVSearch(
   await page.close();
 }
 
+async function testOverviewSeparatesMacAppAndFirmwareVersions(
+  browser,
+  appUrl,
+) {
+  const page = await newCustomerPage(browser, appUrl, {
+    viewport: desktopViewport,
+  });
+  const installRequests = [];
+  await routeCompanionOnline(page, installRequests, () => {}, {
+    companionVersion: "1.0.33",
+    device: {
+      ...companionDevice,
+      firmware: "1.0.32",
+    },
+  });
+
+  await page.goto(appUrl, { waitUntil: "networkidle" });
+  await page.getByText("VibeTV is connected").waitFor({ timeout: 10_000 });
+  await page.getByText("Mac App").waitFor({ timeout: 10_000 });
+  await page.getByText("Online 1.0.33").waitFor({ timeout: 10_000 });
+  await page.getByText("VibeTV firmware").waitFor({ timeout: 10_000 });
+  await page.getByText("1.0.32").waitFor({ timeout: 10_000 });
+
+  assertNoInstallRequests(installRequests);
+  await assertNoMobileOverflow(page);
+  await page.close();
+}
+
 async function testInstallLinkKeepsRequestedTheme(browser, appUrl) {
   const page = await newCustomerPage(browser, appUrl, { viewport });
   const installRequests = [];
@@ -1722,6 +1754,7 @@ async function routeCompanionOnline(
   onSettings = () => {},
   {
     companionFeatures = { themeInstallEnabled: true },
+    companionVersion = "1.0.32",
     device = companionDevice,
     onDiscover,
     onPair,
@@ -1981,7 +2014,7 @@ async function routeCompanionOnline(
         body: JSON.stringify({
           ok: true,
           companion: {
-            version: "1.0.32",
+            version: companionVersion,
             features: companionFeatures,
           },
           device: currentDevice,
@@ -2008,7 +2041,7 @@ async function routeCompanionOnline(
         body: JSON.stringify({
           ok: true,
           companion: {
-            version: "1.0.32",
+            version: companionVersion,
             features: companionFeatures,
           },
           device: currentDevice,
@@ -2045,7 +2078,7 @@ async function routeCompanionOnline(
           ok: true,
           generatedAt: "2026-06-19T12:00:00.000Z",
           companion: {
-            version: "1.0.32",
+            version: companionVersion,
             features: companionFeatures,
           },
           device: currentDevice,
@@ -2358,6 +2391,11 @@ async function assertMacAppSetupUsesTerminalCommand(page) {
   assert(
     prompt.includes("start it in the background"),
     "agent setup prompt should describe the background Mac App",
+  );
+  assert(
+    prompt.includes("connect VibeTV") &&
+      prompt.includes("latest firmware"),
+    "agent setup prompt should say the terminal command connects VibeTV and updates firmware",
   );
   assert(
     !prompt.includes("LaunchAgent"),

--- a/apps/control-center/src/components/control-center-app.tsx
+++ b/apps/control-center/src/components/control-center-app.tsx
@@ -27,6 +27,7 @@ import { UsageScreen } from "./usage-screen";
 
 const COMPANION_URL = "http://127.0.0.1:47832";
 const DEVICE_TARGET_STORAGE_KEY = "vibetv.controlCenter.deviceTarget";
+const COMPANION_REQUEST_TIMEOUT_MS = 45_000;
 const RECENT_COMPANION_REQUEST_MS = 5_000;
 
 type LocalNetworkRequestInit = RequestInit & {
@@ -312,9 +313,14 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
         headers.set("Content-Type", "application/json");
       }
       const useLocalProxy = shouldUseLocalCompanionProxy();
+      const controller = new AbortController();
+      const timeout = window.setTimeout(() => {
+        controller.abort();
+      }, COMPANION_REQUEST_TIMEOUT_MS);
       const requestInit: LocalNetworkRequestInit = {
         ...init,
         headers,
+        signal: controller.signal,
       };
       if (!useLocalProxy) {
         requestInit.targetAddressSpace = "loopback";
@@ -337,7 +343,16 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
             throw localNetworkAccessError(accessState);
           }
         }
+        if (error instanceof DOMException && error.name === "AbortError") {
+          throw {
+            code: "COMPANION_TIMEOUT",
+            message: "Mac App took too long to answer.",
+            nextAction: "Run setup again, then try again.",
+          } satisfies ApiError;
+        }
         throw error;
+      } finally {
+        window.clearTimeout(timeout);
       }
     },
     [],
@@ -1528,6 +1543,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
       {activeShellTab === "overview" ? (
         <OverviewScreen
           busyAction={busyAction}
+          companionVersion={companionInfo?.version}
           companionStatus={companionStatus}
           device={device}
           deviceState={deviceState}

--- a/apps/control-center/src/components/overview-screen.tsx
+++ b/apps/control-center/src/components/overview-screen.tsx
@@ -21,6 +21,7 @@ import {
 } from "./control-center-types";
 
 type OverviewScreenProps = {
+  companionVersion?: string;
   companionStatus: CompanionStatus;
   deviceState: DeviceState;
   device: DeviceInfo | null;
@@ -31,6 +32,7 @@ type OverviewScreenProps = {
 
 export function OverviewScreen({
   busyAction,
+  companionVersion,
   companionStatus,
   deviceState,
   device,
@@ -65,7 +67,7 @@ export function OverviewScreen({
             <StatusRow
               icon={<Wifi size={18} aria-hidden />}
               label="Mac App"
-              value={labelForCompanion(companionStatus)}
+              value={labelForCompanion(companionStatus, companionVersion)}
             />
             <StatusRow
               icon={<Monitor size={18} aria-hidden />}
@@ -76,7 +78,7 @@ export function OverviewScreen({
             <StatusRow
               badge={firmwareUpdateAvailable ? "Update" : undefined}
               icon={<ArrowUpFromLine size={18} aria-hidden />}
-              label="Firmware"
+              label="VibeTV firmware"
               value={device?.firmware || "Waiting for VibeTV"}
             />
           </dl>
@@ -207,9 +209,12 @@ function buildHeroCopy({
   };
 }
 
-function labelForCompanion(status: CompanionStatus): string {
+function labelForCompanion(
+  status: CompanionStatus,
+  companionVersion?: string,
+): string {
   if (status === "online") {
-    return "Online";
+    return companionVersion ? `Online ${companionVersion}` : "Online";
   }
   if (status === "missing") {
     return "Needs install";

--- a/apps/control-center/src/components/setup-screen.tsx
+++ b/apps/control-center/src/components/setup-screen.tsx
@@ -54,7 +54,7 @@ Run this Terminal command:
 
 ${terminalCommand}
 
-This command should install or update the VibeTV Mac App and start it in the background. Do not install a signed package or a macOS package.
+This command should install or update the VibeTV Mac App, start it in the background, connect VibeTV, and update VibeTV to the latest firmware. Do not install a signed package or a macOS package.
 
 After the command finishes, verify it with:
 
@@ -64,9 +64,11 @@ Then tell me:
 - what was installed
 - whether any dependencies were installed
 - whether the status check worked
+- whether VibeTV connected
+- whether the VibeTV firmware update completed, was already current, or failed
 - the next step: return to app.vibetv.shop, choose Allow when the browser asks for access, and continue setup
 
-Normal usage frames may update the VibeTV display. Do not flash firmware, install themes, reset WiFi, upload assets, or change WiFi settings. Only install and verify the Mac App.`;
+Normal usage frames may update the VibeTV display. Do not install themes, reset WiFi, upload theme assets, or change WiFi settings. Only run the setup command and verify its result.`;
 }
 
 type SetupScreenProps = {
@@ -532,11 +534,16 @@ function FinishSetupContent({
   }
 
   return (
-    <StatusNote
-      icon={<Loader2 className="animate-spin" size={16} aria-hidden />}
-    >
-      Connecting VibeTV...
-    </StatusNote>
+    <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+      <p className="text-sm leading-6 text-[#444933]">
+        Make sure VibeTV is powered on and connected to the same WiFi.
+      </p>
+      <PrimaryButton
+        icon={<RefreshCw size={18} aria-hidden />}
+        label="Connect VibeTV"
+        onClick={() => onRepairConnection?.()}
+      />
+    </div>
   );
 }
 

--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -429,6 +429,7 @@ func runInstallUpdate(args []string) (retErr error) {
 	manifestURL := fs.String("manifest-url", vibeTVFirmwareManifestURL, "firmware manifest URL")
 	force := fs.Bool("force", false, "install even when the device already reports the latest firmware")
 	confirmLiveUpdate := fs.Bool("confirm-live-update", false, "allow installing from the default live Shopify firmware manifest")
+	skipLaunchAgentPause := fs.Bool("skip-launchagent-pause", false, "internal: keep the Mac App running while updating firmware")
 	verbose := fs.Bool("verbose", false, "show manifest, asset, and local firmware file details")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -518,9 +519,11 @@ func runInstallUpdate(args []string) (retErr error) {
 		}
 	}
 
-	fmt.Println("Pausing Mac App during firmware update...")
-	cleanupLaunchAgent := beginUpgradeLaunchAgentRecovery(home, &retErr)
-	defer cleanupLaunchAgent()
+	if !*skipLaunchAgentPause {
+		fmt.Println("Pausing Mac App during firmware update...")
+		cleanupLaunchAgent := beginUpgradeLaunchAgentRecovery(home, &retErr)
+		defer cleanupLaunchAgent()
+	}
 
 	fmt.Println("Uploading firmware...")
 	uploadErr := uploadFirmwareOTAFn(ctx, base, imagePath, deviceToken)

--- a/companion/cmd/codexbar-display/release_commands_test.go
+++ b/companion/cmd/codexbar-display/release_commands_test.go
@@ -880,6 +880,97 @@ func TestRunInstallUpdatePausesLaunchAgentDuringOTAAndRestarts(t *testing.T) {
 	}
 }
 
+func TestRunInstallUpdateCanSkipLaunchAgentPauseForLocalAPI(t *testing.T) {
+	previousHTTPClient := releaseHTTPClient
+	previousUpload := uploadFirmwareOTAFn
+	previousStop := upgradeStopLaunchAgentFn
+	previousRestart := upgradeRestartLaunchAgentFn
+	t.Cleanup(func() {
+		releaseHTTPClient = previousHTTPClient
+		uploadFirmwareOTAFn = previousUpload
+		upgradeStopLaunchAgentFn = previousStop
+		upgradeRestartLaunchAgentFn = previousRestart
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := runtimeconfig.Save(home, runtimeconfig.Config{DeviceToken: "pair-token"}); err != nil {
+		t.Fatalf("save runtime config: %v", err)
+	}
+
+	imageBody := "firmware image"
+	imageSHA := sha256String(imageBody)
+	firmwareVersion := "1.0.0"
+	serverURL := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"` + firmwareVersion + `","features":["theme"],"maxFrameBytes":1024}`))
+		case "/manifest.json":
+			_, _ = w.Write([]byte(`{
+  "schemaVersion": 1,
+  "release": "v1.0.1",
+  "artifacts": [{
+    "firmwareEnv": "esp8266_smalltv_st7789",
+    "board": "esp8266-smalltv-st7789",
+    "firmwareVersion": "1.0.1",
+    "asset": "firmware.bin",
+    "firmwareUrl": "` + serverURL + `/firmware.bin",
+    "sha256": "` + imageSHA + `"
+  }]
+}`))
+		case "/firmware.bin":
+			_, _ = w.Write([]byte(imageBody))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+	releaseHTTPClient = server.Client()
+
+	stopCalls := 0
+	restartCalls := 0
+	upgradeStopLaunchAgentFn = func() {
+		stopCalls++
+	}
+	upgradeRestartLaunchAgentFn = func(string) error {
+		restartCalls++
+		return nil
+	}
+	uploadFirmwareOTAFn = func(_ context.Context, _ string, _ string, token string) error {
+		if stopCalls != 0 {
+			t.Fatalf("local API update must not stop launch agent, got %d stop calls", stopCalls)
+		}
+		if token != "pair-token" {
+			t.Fatalf("unexpected token %q", token)
+		}
+		firmwareVersion = "1.0.1"
+		return nil
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runInstallUpdate([]string{
+			"--target", server.URL,
+			"--manifest-url", server.URL + "/manifest.json",
+			"--skip-launchagent-pause",
+		})
+	})
+	if err != nil {
+		t.Fatalf("install update: %v", err)
+	}
+	if stopCalls != 0 {
+		t.Fatalf("expected no stop call, got %d", stopCalls)
+	}
+	if restartCalls != 0 {
+		t.Fatalf("expected no restart call, got %d", restartCalls)
+	}
+	if strings.Contains(output, "Pausing Mac App during firmware update") {
+		t.Fatalf("local API update should not claim it paused the Mac App, got:\n%s", output)
+	}
+}
+
 func TestRunInstallUpdateRequiresLiveManifestConfirmation(t *testing.T) {
 	previousHTTPClient := releaseHTTPClient
 	t.Cleanup(func() {

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -1649,6 +1649,7 @@ func (s *Server) runThemeInstall(ctx context.Context, cfg runtimeconfig.Config, 
 		SkipFirmwareUpdate: skipFirmwareUpdate,
 		Verbose:            true,
 		Out:                out,
+		HTTPClient:         s.client,
 		PairTokenStore: func(target, token string) error {
 			target = normalizeTarget(target)
 			if target != "" {
@@ -1840,6 +1841,12 @@ func customerInstallProgress(line string, job *themeInstallJob) (string, int, bo
 		return "Uploaded theme layout.", 76, true
 	case strings.HasPrefix(line, "Activating theme"):
 		return "Activating theme.", 84, true
+	case strings.HasPrefix(line, "Theme activation interrupted"):
+		return "Theme activation interrupted. Retrying.", maxInt(job.Progress, 84), true
+	case strings.HasPrefix(line, "Theme activation retry"):
+		return "Retrying theme activation.", maxInt(job.Progress, 84), true
+	case strings.HasPrefix(line, "Theme activation did not settle"):
+		return "Waiting for VibeTV to apply theme.", maxInt(job.Progress, 86), true
 	case strings.HasPrefix(line, "Live usage frame: refreshed"):
 		return "Refreshing live usage.", 90, true
 	case strings.HasPrefix(line, "Live usage frame: skipped"):
@@ -2158,7 +2165,13 @@ func runFirmwareUpdateCommand(ctx context.Context, home string, cfg runtimeconfi
 	if target == "" {
 		return errors.New("device target is empty")
 	}
-	args := []string{"install-update", "--target", target, "--confirm-live-update"}
+	args := []string{
+		"install-update",
+		"--target",
+		target,
+		"--confirm-live-update",
+		"--skip-launchagent-pause",
+	}
 	if req.Force {
 		args = append(args, "--force")
 	}

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -1460,6 +1460,9 @@ func TestThemeInstallAsyncReportsCustomerProgress(t *testing.T) {
 		_, _ = io.WriteString(opts.Out, "Uploading theme files...\n")
 		_, _ = io.WriteString(opts.Out, "Uploaded asset: /themes/u/clippy.cbi bytes=123\n")
 		_, _ = io.WriteString(opts.Out, "Activating theme...\n")
+		_, _ = io.WriteString(opts.Out, "Theme activation interrupted, retrying...\n")
+		_, _ = io.WriteString(opts.Out, "Theme activation retry 2/3.\n")
+		_, _ = io.WriteString(opts.Out, "Theme activation did not settle, retrying...\n")
 		return themeinstall.Result{
 			ThemeID:       opts.ThemeID,
 			PackID:        "clippy",
@@ -1510,7 +1513,15 @@ func TestThemeInstallAsyncReportsCustomerProgress(t *testing.T) {
 		t.Fatalf("expected result in completed job, got %+v", got.Job)
 	}
 	joinedLogs := strings.Join(got.Job.Logs, "\n")
-	for _, want := range []string{"Preparing theme files.", "Uploading theme files.", "Uploaded theme file 1.", "Theme is active on VibeTV."} {
+	for _, want := range []string{
+		"Preparing theme files.",
+		"Uploading theme files.",
+		"Uploaded theme file 1.",
+		"Theme activation interrupted. Retrying.",
+		"Retrying theme activation.",
+		"Waiting for VibeTV to apply theme.",
+		"Theme is active on VibeTV.",
+	} {
 		if !strings.Contains(joinedLogs, want) {
 			t.Fatalf("expected customer progress log %q in %q", want, joinedLogs)
 		}

--- a/companion/internal/themeinstall/themeinstall.go
+++ b/companion/internal/themeinstall/themeinstall.go
@@ -33,6 +33,8 @@ const (
 var (
 	renderHealthAttempts = 8
 	renderHealthDelay    = 500 * time.Millisecond
+	activationAttempts   = 3
+	activationRetryDelay = 1500 * time.Millisecond
 )
 
 var installingThemeSpec = json.RawMessage(`{"v":1,"id":"installing","rev":1,"fb":"mini","p":[{"t":"r","x":0,"y":0,"w":240,"h":240,"c":"#111111"},{"t":"tx","x":28,"y":58,"v":"INSTALLING","s":2,"c":"#B6FF00"},{"t":"tx","x":36,"y":94,"v":"NEW THEME","s":2,"c":"#FFFFFF"},{"t":"p","x":34,"y":150,"w":172,"h":18,"b":"s","c":"#B6FF00","bg":"#303030"}]}`)
@@ -300,42 +302,32 @@ func Install(ctx context.Context, opts Options) (Result, error) {
 	}
 
 	fmt.Fprintln(out, "Activating theme...")
-	if err := activateThemeWithPairRetry(wifi, &resolvedTarget, pack.ThemeSpecFile.Entry.Path, opts.PairTokenStore); err != nil {
-		return Result{}, &InstallError{
-			Op:   "theme-pack/activate",
-			Code: errcode.UpgradeFlashFirmware,
-			Err:  err,
-			Hint: "keep VibeTV powered and on the same WiFi, then retry theme install",
-		}
-	}
-	if err := sendLiveThemeFrame(ctx, wifi, resolvedTarget, caps, opts.FetchLiveFrame); err != nil {
-		if authRequired(err) {
-			pairedTarget, pairErr := pairThemeInstallTarget(wifi, resolvedTarget, opts.PairTokenStore)
-			if pairErr != nil {
-				return Result{}, &InstallError{
-					Op:   "theme-pack/pair",
-					Code: errcode.UpgradeFlashFirmware,
-					Err:  pairErr,
-					Hint: "keep VibeTV powered and on the same WiFi, then retry theme install",
-				}
+	if err := activateAndVerifyTheme(
+		ctx,
+		wifi,
+		&resolvedTarget,
+		caps,
+		pack.ThemeSpecFile.Entry.Path,
+		requiredGIFAssets(pack.ThemeSpec),
+		opts.PairTokenStore,
+		opts.FetchLiveFrame,
+		out,
+	); err != nil {
+		op := "theme-pack/activate"
+		hint := "keep VibeTV powered and on the same WiFi, then retry theme install"
+		var phaseErr *themeActivationError
+		if errors.As(err, &phaseErr) {
+			op = phaseErr.op
+			err = phaseErr.err
+			if op == "theme-pack/render-health" {
+				hint = "keep VibeTV powered and retry theme install; if this repeats, contact support with `codexbar-display health` output"
 			}
-			resolvedTarget = pairedTarget
-			err = sendLiveThemeFrame(ctx, wifi, resolvedTarget, caps, opts.FetchLiveFrame)
 		}
-		if err != nil {
-			fmt.Fprintf(out, "Live usage frame: skipped (%v)\n", err)
-		} else {
-			fmt.Fprintln(out, "Live usage frame: refreshed")
-		}
-	} else {
-		fmt.Fprintln(out, "Live usage frame: refreshed")
-	}
-	if err := verifyThemeInstallHealth(wifi, resolvedTarget, pack.ThemeSpecFile.Entry.Path, requiredGIFAssets(pack.ThemeSpec)); err != nil {
 		return Result{}, &InstallError{
-			Op:   "theme-pack/render-health",
+			Op:   op,
 			Code: errcode.UpgradeFlashFirmware,
 			Err:  err,
-			Hint: "keep VibeTV powered and retry theme install; if this repeats, contact support with `codexbar-display health` output",
+			Hint: hint,
 		}
 	}
 
@@ -440,6 +432,120 @@ func sendLiveThemeFrame(ctx context.Context, wifi transportlayer.WiFiTransport, 
 	return nil
 }
 
+type themeActivationError struct {
+	op  string
+	err error
+}
+
+func (e *themeActivationError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *themeActivationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func activateAndVerifyTheme(
+	ctx context.Context,
+	wifi transportlayer.WiFiTransport,
+	target *string,
+	caps protocol.DeviceCapabilities,
+	activePath string,
+	gifAssets []string,
+	store PairTokenStore,
+	fetchFrame func(context.Context) (protocol.Frame, error),
+	out io.Writer,
+) error {
+	attempts := activationAttempts
+	if attempts < 1 {
+		attempts = 1
+	}
+	var lastErr error
+	lastOp := "theme-pack/activate"
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if attempt > 1 {
+			fmt.Fprintf(out, "Theme activation retry %d/%d.\n", attempt, attempts)
+		}
+		if err := activateThemeWithPairRetry(wifi, target, activePath, store); err != nil {
+			lastErr = err
+			lastOp = "theme-pack/activate"
+			if !themeInstallRetryableError(err) || attempt == attempts {
+				return &themeActivationError{op: lastOp, err: lastErr}
+			}
+			fmt.Fprintln(out, "Theme activation interrupted, retrying...")
+			if err := sleepActivationRetry(ctx); err != nil {
+				return &themeActivationError{op: lastOp, err: err}
+			}
+			continue
+		}
+
+		sendLiveThemeFrameWithPairRetry(ctx, wifi, target, caps, store, fetchFrame, out)
+		if err := verifyThemeInstallHealth(wifi, *target, activePath, gifAssets); err != nil {
+			lastErr = err
+			lastOp = "theme-pack/render-health"
+			if attempt == attempts {
+				return &themeActivationError{op: lastOp, err: lastErr}
+			}
+			fmt.Fprintln(out, "Theme activation did not settle, retrying...")
+			if err := sleepActivationRetry(ctx); err != nil {
+				return &themeActivationError{op: lastOp, err: err}
+			}
+			continue
+		}
+		return nil
+	}
+	if lastErr == nil {
+		lastErr = errors.New("theme activation did not complete")
+	}
+	return &themeActivationError{op: lastOp, err: lastErr}
+}
+
+func sendLiveThemeFrameWithPairRetry(
+	ctx context.Context,
+	wifi transportlayer.WiFiTransport,
+	target *string,
+	caps protocol.DeviceCapabilities,
+	store PairTokenStore,
+	fetchFrame func(context.Context) (protocol.Frame, error),
+	out io.Writer,
+) {
+	err := sendLiveThemeFrame(ctx, wifi, *target, caps, fetchFrame)
+	if err != nil && authRequired(err) {
+		pairedTarget, pairErr := pairThemeInstallTarget(wifi, *target, store)
+		if pairErr == nil {
+			*target = pairedTarget
+			err = sendLiveThemeFrame(ctx, wifi, *target, caps, fetchFrame)
+		} else {
+			err = pairErr
+		}
+	}
+	if err != nil {
+		fmt.Fprintf(out, "Live usage frame: skipped (%v)\n", err)
+		return
+	}
+	fmt.Fprintln(out, "Live usage frame: refreshed")
+}
+
+func sleepActivationRetry(ctx context.Context) error {
+	if activationRetryDelay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(activationRetryDelay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 func uploadAssetWithPairRetry(wifi transportlayer.WiFiTransport, target *string, devicePath, filename string, data []byte, store PairTokenStore) error {
 	err := wifi.UploadAsset(*target, devicePath, filename, data)
 	if err == nil || !authRequired(err) {
@@ -526,6 +632,36 @@ func authRequired(err error) bool {
 	return strings.Contains(msg, "status=401") ||
 		strings.Contains(msg, "pairing token required") ||
 		strings.Contains(msg, "unauthorized")
+}
+
+func themeInstallRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "status=408") ||
+		strings.Contains(msg, "status=429") ||
+		strings.Contains(msg, "status=500") ||
+		strings.Contains(msg, "status=502") ||
+		strings.Contains(msg, "status=503") ||
+		strings.Contains(msg, "status=504") {
+		return true
+	}
+	for _, part := range []string{
+		"timeout",
+		"context deadline exceeded",
+		"connection reset",
+		"connection refused",
+		"broken pipe",
+		"server closed idle connection",
+		"eof",
+		"temporary",
+	} {
+		if strings.Contains(msg, part) {
+			return true
+		}
+	}
+	return false
 }
 
 func verifyThemeInstallHealth(wifi transportlayer.WiFiTransport, target, activePath string, gifAssets []string) error {

--- a/companion/internal/themeinstall/themeinstall_test.go
+++ b/companion/internal/themeinstall/themeinstall_test.go
@@ -1,12 +1,19 @@
 package themeinstall
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
 	transportlayer "github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/transport"
 )
 
@@ -132,6 +139,94 @@ func TestVerifyThemeInstallHealthIgnoresGIFStatusForNonGIFThemes(t *testing.T) {
 	}
 }
 
+func TestInstallRetriesTransientThemeActivationFailure(t *testing.T) {
+	withFastActivationRetries(t)
+	packDir := writeMinimalThemePack(t)
+	const activePath = "/themes/u/synth.json"
+	var activationAttempts int
+	currentActivePath := "/themes/u/claude.json"
+	server := themeInstallDeviceServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/theme/active":
+			activationAttempts++
+			if activationAttempts == 1 {
+				http.Error(w, "try again", http.StatusServiceUnavailable)
+				return
+			}
+			currentActivePath = activePath
+			w.WriteHeader(http.StatusOK)
+		case "/health":
+			writeThemeHealth(t, w, currentActivePath)
+		}
+	})
+	defer server.Close()
+
+	var out bytes.Buffer
+	result, err := Install(context.Background(), Options{
+		PackURL:            packDir,
+		Target:             server.URL,
+		SkipFirmwareUpdate: true,
+		Out:                &out,
+		HTTPClient:         server.Client(),
+		UploadSettleDelay:  -1,
+		FetchLiveFrame:     testLiveFrame,
+	})
+	if err != nil {
+		t.Fatalf("Install returned error: %v\nlogs:\n%s", err, out.String())
+	}
+	if result.ThemeID != "synthwave" {
+		t.Fatalf("unexpected theme result: %+v", result)
+	}
+	if activationAttempts != 2 {
+		t.Fatalf("expected activation retry, got attempts=%d", activationAttempts)
+	}
+	if !strings.Contains(out.String(), "Theme activation interrupted, retrying") ||
+		!strings.Contains(out.String(), "Theme activation retry 2/3") {
+		t.Fatalf("missing retry log:\n%s", out.String())
+	}
+}
+
+func TestInstallReactivatesWhenHealthStillShowsPreviousTheme(t *testing.T) {
+	withFastActivationRetries(t)
+	packDir := writeMinimalThemePack(t)
+	const activePath = "/themes/u/synth.json"
+	var activationAttempts int
+	currentActivePath := "/themes/u/claude.json"
+	server := themeInstallDeviceServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/theme/active":
+			activationAttempts++
+			if activationAttempts >= 2 {
+				currentActivePath = activePath
+			}
+			w.WriteHeader(http.StatusOK)
+		case "/health":
+			writeThemeHealth(t, w, currentActivePath)
+		}
+	})
+	defer server.Close()
+
+	var out bytes.Buffer
+	_, err := Install(context.Background(), Options{
+		PackURL:            packDir,
+		Target:             server.URL,
+		SkipFirmwareUpdate: true,
+		Out:                &out,
+		HTTPClient:         server.Client(),
+		UploadSettleDelay:  -1,
+		FetchLiveFrame:     testLiveFrame,
+	})
+	if err != nil {
+		t.Fatalf("Install returned error: %v\nlogs:\n%s", err, out.String())
+	}
+	if activationAttempts != 2 {
+		t.Fatalf("expected activation to be retried after stale health, got attempts=%d", activationAttempts)
+	}
+	if !strings.Contains(out.String(), "Theme activation did not settle, retrying") {
+		t.Fatalf("missing stale-health retry log:\n%s", out.String())
+	}
+}
+
 func withFastRenderHealthCheck(t *testing.T) {
 	t.Helper()
 	oldAttempts := renderHealthAttempts
@@ -144,6 +239,24 @@ func withFastRenderHealthCheck(t *testing.T) {
 	})
 }
 
+func withFastActivationRetries(t *testing.T) {
+	t.Helper()
+	oldRenderAttempts := renderHealthAttempts
+	oldRenderDelay := renderHealthDelay
+	oldActivationAttempts := activationAttempts
+	oldActivationDelay := activationRetryDelay
+	renderHealthAttempts = 1
+	renderHealthDelay = 0
+	activationAttempts = 3
+	activationRetryDelay = 0
+	t.Cleanup(func() {
+		renderHealthAttempts = oldRenderAttempts
+		renderHealthDelay = oldRenderDelay
+		activationAttempts = oldActivationAttempts
+		activationRetryDelay = oldActivationDelay
+	})
+}
+
 func healthServer(t *testing.T, body string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -153,4 +266,93 @@ func healthServer(t *testing.T, body string) *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
 	}))
+}
+
+func writeMinimalThemePack(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	spec := `{"v":1,"id":"synthwave","rev":1,"fb":"mini","p":[{"t":"tx","x":0,"y":0,"v":"OK","s":1}]}`
+	manifest := `{
+		"kind":"vibetv-theme-pack",
+		"schemaVersion":1,
+		"id":"synthwave",
+		"name":"Synthwave",
+		"themeSpec":{"path":"/themes/u/synth.json","file":"theme.json"}
+	}`
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "theme.json"), []byte(spec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func themeInstallDeviceServer(t *testing.T, handle func(http.ResponseWriter, *http.Request)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"kind":"hello",
+				"protocolVersion":2,
+				"board":"esp8266-smalltv-st7789",
+				"firmware":"1.0.33",
+				"features":["theme","theme-spec-v1"],
+				"maxFrameBytes":1024,
+				"capabilities":{
+					"theme":{"supportsThemeSpecV1":true,"maxThemeSpecBytes":4096,"maxThemePrimitives":32},
+					"transport":{"active":"wifi"}
+				}
+			}`))
+		case "/assets":
+			if r.URL.Query().Get("path") != "/themes/u/synth.json" {
+				t.Fatalf("unexpected asset path %q", r.URL.Query().Get("path"))
+			}
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+		case "/frame":
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+		case "/theme/active", "/health":
+			handle(w, r)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+}
+
+func writeThemeHealth(t *testing.T, w http.ResponseWriter, activePath string) {
+	t.Helper()
+	activeTheme := "claude-creature"
+	if activePath == "/themes/u/synth.json" {
+		activeTheme = "synthwave"
+	}
+	payload := map[string]any{
+		"ok": true,
+		"display": map[string]any{
+			"activeTheme": activeTheme,
+			"themeSpec": map[string]any{
+				"active":   true,
+				"path":     activePath,
+				"renderOk": true,
+			},
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testLiveFrame(context.Context) (protocol.Frame, error) {
+	return protocol.Frame{
+		V:         protocol.ProtocolVersionV2,
+		Provider:  "codex",
+		Label:     "Codex",
+		Session:   74,
+		Weekly:    80,
+		UsageMode: "remaining",
+	}, nil
 }

--- a/scripts/install-control-center-companion-release.sh
+++ b/scripts/install-control-center-companion-release.sh
@@ -49,6 +49,7 @@ What it does:
   - stops the old standalone Mac setup service if it exists
   - starts the normal VibeTV Mac App background service
   - verifies http://127.0.0.1:47832/v1/status
+  - connects VibeTV and installs the latest firmware when available
 
 Examples:
   curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install-control-center-companion.sh | bash
@@ -227,6 +228,39 @@ wait_for_api() {
     sleep 0.5
   done
   die "Mac setup service did not answer on http://${ADDR}/v1/status. Inspect ${DISPLAY_DAEMON_LOG_ERR}."
+}
+
+json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s' "$value"
+}
+
+connect_vibetv() {
+  local payload
+  payload="{\"target\":\"$(json_escape "$TARGET")\",\"forcePair\":true}"
+
+  log "vibetv: connecting VibeTV at ${TARGET}"
+  curl -fsS --connect-timeout 10 --max-time 90 \
+    -X POST "http://${ADDR}/v1/device/repair" \
+    -H "Content-Type: application/json" \
+    -d "$payload" >/dev/null \
+    || die "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
+  log "vibetv: VibeTV is connected"
+}
+
+update_vibetv_firmware() {
+  log "vibetv: starting VibeTV firmware update"
+  "$BIN_PATH" install-update --target "$TARGET" --confirm-live-update \
+    || die "VibeTV firmware update failed. Keep VibeTV powered on, then rerun setup."
+  wait_for_api
+  log "vibetv: VibeTV firmware update complete"
+}
+
+finish_device_setup() {
+  connect_vibetv
+  update_vibetv_firmware
 }
 
 install_binary() {
@@ -457,6 +491,7 @@ main() {
 
   log "vibetv: Mac setup binary installed at ${BIN_PATH}"
   log "vibetv: background service installed at ${DISPLAY_DAEMON_PLIST}"
+  finish_device_setup
 }
 
 main "$@"

--- a/scripts/test-control-center-companion-legacy-installer.sh
+++ b/scripts/test-control-center-companion-legacy-installer.sh
@@ -86,6 +86,9 @@ case "$*" in
   *"/v1/status"*)
     exit 0
     ;;
+  *"/v1/device/repair"*)
+    printf '{"ok":true,"device":{"connected":true,"paired":true}}\n'
+    ;;
   *"/releases/latest"*)
     printf '{"tag_name":"v9.9.9"}\n'
     ;;
@@ -94,6 +97,12 @@ case "$*" in
     cat > "$out" <<'BIN'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "${FAKE_API_LOG:?}"
+if [[ "${1:-}" == "install-update" ]]; then
+  printf 'Checking device...\n'
+  printf 'Checking firmware...\n'
+  printf 'Done: firmware 9.9.9 installed\n'
+  exit 0
+fi
 while true; do
   sleep 60
 done
@@ -144,6 +153,12 @@ prepare_home() {
   cat > "$bin_path" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "${FAKE_API_LOG:?}"
+if [[ "${1:-}" == "install-update" ]]; then
+  printf 'Checking device...\n'
+  printf 'Checking firmware...\n'
+  printf 'Done: firmware 9.9.9 installed\n'
+  exit 0
+fi
 while true; do
   sleep 60
 done
@@ -237,7 +252,7 @@ run_uninstall_stops_terminal_service_and_legacy_launchagent() {
 }
 
 run_install_writes_integrated_daemon_launchagent() {
-  local root output launch_log daemon_plist daemon_plist_body
+  local root output launch_log daemon_plist daemon_plist_body curl_log
   root="${TMP_WORK_DIR}/install"
   write_fake_commands "${root}/fake-bin"
   prepare_home "${root}/home"
@@ -251,10 +266,17 @@ run_install_writes_integrated_daemon_launchagent() {
   }
 
   launch_log="$(cat "${root}/launchctl.log")"
+  curl_log="$(cat "${root}/curl.log")"
   daemon_plist="${root}/home/Library/LaunchAgents/com.codexbar-display.daemon.plist"
   daemon_plist_body="$(cat "$daemon_plist")"
 
   assert_contains "$output" "background service installed at ${daemon_plist}"
+  assert_contains "$output" "VibeTV is connected"
+  assert_contains "$output" "Done: firmware 9.9.9 installed"
+  assert_contains "$output" "VibeTV firmware update complete"
+  assert_contains "$curl_log" "/v1/device/repair"
+  assert_contains "$(cat "${root}/api.log")" "install-update --target http://vibetv.local --confirm-live-update"
+  assert_not_contains "$curl_log" "/v1/updates/install"
   assert_contains "$daemon_plist_body" "<string>daemon</string>"
   assert_contains "$daemon_plist_body" "<string>--api-addr</string>"
   assert_contains "$daemon_plist_body" "<string>127.0.0.1:47832</string>"
@@ -266,7 +288,7 @@ run_install_writes_integrated_daemon_launchagent() {
 }
 
 run_install_disables_global_legacy_launchagent() {
-  local root output launch_log global_plist daemon_plist_body
+  local root output launch_log global_plist daemon_plist_body curl_log
   root="${TMP_WORK_DIR}/global-legacy"
   write_fake_commands "${root}/fake-bin"
   prepare_home "${root}/home"
@@ -283,9 +305,15 @@ run_install_disables_global_legacy_launchagent() {
   }
 
   launch_log="$(cat "${root}/launchctl.log")"
+  curl_log="$(cat "${root}/curl.log")"
   daemon_plist_body="$(cat "${root}/home/Library/LaunchAgents/com.codexbar-display.daemon.plist")"
 
   assert_contains "$output" "old Mac setup service disabled for this user"
+  assert_contains "$output" "Done: firmware 9.9.9 installed"
+  assert_contains "$output" "VibeTV firmware update complete"
+  assert_contains "$curl_log" "/v1/device/repair"
+  assert_contains "$(cat "${root}/api.log")" "install-update --target http://vibetv.local --confirm-live-update"
+  assert_not_contains "$curl_log" "/v1/updates/install"
   assert_contains "$launch_log" "bootout gui/$(id -u)/com.codexbar-display.companion-api"
   assert_contains "$launch_log" "disable gui/$(id -u)/com.codexbar-display.companion-api"
   assert_contains "$daemon_plist_body" "<string>--api-addr</string>"


### PR DESCRIPTION
## Summary
- update the Control Center setup prompt and installer so setup connects VibeTV and runs latest firmware update
- keep the Mac App alive during firmware updates triggered from the local API
- retry theme activation when VibeTV briefly times out or health still reports the previous theme
- clarify Mac App vs VibeTV firmware versions in the UI

## Tests
- npm run lint
- npm run check:customer-ui-copy
- npm run test:customer-flows
- go test ./internal/themeinstall ./internal/companionapi ./cmd/codexbar-display
- ./scripts/test-control-center-companion-legacy-installer.sh
- ./scripts/test-control-center-release-workflow.sh
- bash -n installer scripts
- live VibeTV synthwave install smoke test
