### PR TITLE
[codex] Discover VibeTV IP during setup firmware update

### DIFF
--- a/apps/control-center/public/install-control-center-companion.sh
+++ b/apps/control-center/public/install-control-center-companion.sh
@@ -70,6 +70,9 @@ log() {
 
 die() {
   printf 'error: %s\n' "$*" >&2
+  printf 'support: status: curl -fsS http://%s/v1/status\n' "$ADDR" >&2
+  printf 'support: report: curl -fsS http://%s/v1/diagnostics\n' "$ADDR" >&2
+  printf 'support: logs: %s / %s\n' "$DISPLAY_DAEMON_LOG_OUT" "$DISPLAY_DAEMON_LOG_ERR" >&2
   exit 1
 }
 
@@ -245,6 +248,107 @@ json_device_target() {
   sed -n 's/.*"device"[^{]*{[^}]*"target"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1
 }
 
+json_api_field() {
+  local field="$1"
+  sed -n "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" | head -n 1
+}
+
+status_field() {
+  local object="$1"
+  local field="$2"
+  sed -n "s/.*\"${object}\"[^{]*{[^}]*\"${field}\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" | head -n 1
+}
+
+status_bool_field() {
+  local object="$1"
+  local field="$2"
+  sed -n \
+    -e "s/.*\"${object}\"[^{]*{[^}]*\"${field}\"[[:space:]]*:[[:space:]]*true.*/true/p" \
+    -e "s/.*\"${object}\"[^{]*{[^}]*\"${field}\"[[:space:]]*:[[:space:]]*false.*/false/p" \
+    | head -n 1
+}
+
+local_api_json() {
+  local method="$1"
+  local path="$2"
+  local payload="${3:-}"
+  local response_file status_file stderr_file status curl_status
+  response_file="${TMPDIR_INSTALL}/api-response.json"
+  status_file="${TMPDIR_INSTALL}/api-status.txt"
+  stderr_file="${TMPDIR_INSTALL}/api-stderr.txt"
+  : > "$response_file"
+  : > "$status_file"
+  : > "$stderr_file"
+
+  set +e
+  if [[ -n "$payload" ]]; then
+    curl -sS --connect-timeout 10 --max-time 90 \
+      -o "$response_file" \
+      -w "%{http_code}" \
+      -X "$method" "http://${ADDR}${path}" \
+      -H "Content-Type: application/json" \
+      -d "$payload" \
+      > "$status_file" 2> "$stderr_file"
+  else
+    curl -sS --connect-timeout 10 --max-time 30 \
+      -o "$response_file" \
+      -w "%{http_code}" \
+      -X "$method" "http://${ADDR}${path}" \
+      > "$status_file" 2> "$stderr_file"
+  fi
+  curl_status=$?
+  set -e
+
+  status="$(cat "$status_file" 2>/dev/null || true)"
+  if [[ "$curl_status" == "0" && "$status" =~ ^2[0-9][0-9]$ ]]; then
+    cat "$response_file"
+    return 0
+  fi
+
+  return 1
+}
+
+print_local_api_error() {
+  local method="$1"
+  local path="$2"
+  local response_file="${TMPDIR_INSTALL}/api-response.json"
+  local status_file="${TMPDIR_INSTALL}/api-status.txt"
+  local stderr_file="${TMPDIR_INSTALL}/api-stderr.txt"
+  local message next_action code stderr_text status
+  status="$(cat "$status_file" 2>/dev/null || true)"
+  message="$(json_api_field "message" < "$response_file")"
+  next_action="$(json_api_field "nextAction" < "$response_file")"
+  code="$(json_api_field "code" < "$response_file")"
+  stderr_text="$(tr '\n' ' ' < "$stderr_file" | sed 's/[[:space:]]*$//')"
+
+  printf 'error: Mac App API %s %s failed' "$method" "$path" >&2
+  if [[ -n "$status" && "$status" != "000" ]]; then
+    printf ' with HTTP %s' "$status" >&2
+  fi
+  printf '.\n' >&2
+  [[ -z "$code" ]] || printf 'error code: %s\n' "$code" >&2
+  [[ -z "$message" ]] || printf 'detail: %s\n' "$message" >&2
+  [[ -z "$next_action" ]] || printf 'next step: %s\n' "$next_action" >&2
+  [[ -z "$stderr_text" ]] || printf 'curl: %s\n' "$stderr_text" >&2
+}
+
+retryable_repair_failure() {
+  local response_file="${TMPDIR_INSTALL}/api-response.json"
+  local status_file="${TMPDIR_INSTALL}/api-status.txt"
+  local stderr_file="${TMPDIR_INSTALL}/api-stderr.txt"
+  local code status stderr_text
+  status="$(cat "$status_file" 2>/dev/null || true)"
+  code="$(json_api_field "code" < "$response_file")"
+  stderr_text="$(tr '\n' ' ' < "$stderr_file" | tr '[:upper:]' '[:lower:]' || true)"
+
+  [[ "$status" == "000" ]] && return 0
+  [[ "$status" == "408" || "$status" == "429" ]] && return 0
+  [[ "$status" =~ ^5[0-9][0-9]$ ]] && return 0
+  [[ "$code" == "device_not_found" ]] && return 0
+  [[ "$stderr_text" == *"timed out"* || "$stderr_text" == *"connection reset"* || "$stderr_text" == *"connection refused"* ]] && return 0
+  return 1
+}
+
 connect_vibetv() {
   local payload response discovered_target
   if [[ "$TARGET_EXPLICIT" == "1" ]]; then
@@ -255,11 +359,17 @@ connect_vibetv() {
     log "vibetv: discovering VibeTV on this WiFi"
   fi
 
-  response="$(curl -fsS --connect-timeout 10 --max-time 90 \
-    -X POST "http://${ADDR}/v1/device/repair" \
-    -H "Content-Type: application/json" \
-    -d "$payload")" \
-    || die "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
+  for attempt in 1 2 3; do
+    if response="$(local_api_json POST "/v1/device/repair" "$payload")"; then
+      break
+    fi
+    if [[ "$attempt" == "3" ]] || ! retryable_repair_failure; then
+      print_local_api_error POST "/v1/device/repair"
+      die "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
+    fi
+    log "vibetv: VibeTV did not answer yet; retrying (${attempt}/3)"
+    sleep 2
+  done
 
   discovered_target="$(printf '%s' "$response" | json_device_target)"
   if [[ -n "$discovered_target" ]]; then
@@ -281,9 +391,57 @@ update_vibetv_firmware() {
   log "vibetv: VibeTV firmware update complete"
 }
 
+verify_companion_version() {
+  local response version
+  if ! response="$(local_api_json GET "/v1/status")"; then
+    print_local_api_error GET "/v1/status"
+    die "Mac setup service did not answer on http://${ADDR}/v1/status. Inspect ${DISPLAY_DAEMON_LOG_ERR}."
+  fi
+  version="$(printf '%s' "$response" | status_field "companion" "version")"
+  if [[ "$version" == "$RELEASE_VERSION" ]]; then
+    return 0
+  fi
+
+  log "vibetv: Mac App answered with version ${version:-unknown}; restarting once"
+  restart_service
+  wait_for_api
+  if ! response="$(local_api_json GET "/v1/status")"; then
+    print_local_api_error GET "/v1/status"
+    die "Mac setup service did not answer on http://${ADDR}/v1/status after restart. Inspect ${DISPLAY_DAEMON_LOG_ERR}."
+  fi
+  version="$(printf '%s' "$response" | status_field "companion" "version")"
+  [[ "$version" == "$RELEASE_VERSION" ]] \
+    || die "Mac App version mismatch after restart: expected ${RELEASE_VERSION}, got ${version:-unknown}. Inspect ${DISPLAY_DAEMON_LOG_ERR}."
+}
+
+verify_final_status() {
+  local response device_response status connected paired firmware
+  if ! response="$(local_api_json GET "/v1/status")"; then
+    print_local_api_error GET "/v1/status"
+    die "Mac setup service did not answer for the final status check. Inspect ${DISPLAY_DAEMON_LOG_ERR}."
+  fi
+  status="$(printf '%s' "$response" | status_field "companion" "status")"
+  [[ "$status" == "ready" ]] \
+    || die "Mac App is not ready after setup. Inspect ${DISPLAY_DAEMON_LOG_ERR}."
+
+  if ! device_response="$(local_api_json GET "/v1/device")"; then
+    print_local_api_error GET "/v1/device"
+    die "VibeTV is not reachable after setup. Run: curl http://${ADDR}/v1/status"
+  fi
+  connected="$(printf '%s' "$response" | status_bool_field "device" "connected")"
+  paired="$(printf '%s' "$device_response" | status_bool_field "device" "paired")"
+  firmware="$(printf '%s' "$device_response" | status_field "device" "firmware")"
+  [[ "$connected" == "true" && "$paired" == "true" ]] \
+    || die "VibeTV is not connected after setup. Run: curl http://${ADDR}/v1/status"
+  [[ -n "$firmware" ]] \
+    || die "VibeTV firmware version was not available after setup. Run: curl http://${ADDR}/v1/device"
+  log "vibetv: setup verified; Mac App ready, VibeTV connected, firmware ${firmware}"
+}
+
 finish_device_setup() {
   connect_vibetv
   update_vibetv_firmware
+  verify_final_status
 }
 
 install_binary() {
@@ -513,6 +671,7 @@ main() {
   install_binary
   restart_service
   wait_for_api
+  verify_companion_version
 
   log "vibetv: Mac setup binary installed at ${BIN_PATH}"
   log "vibetv: background service installed at ${DISPLAY_DAEMON_PLIST}"

--- a/apps/control-center/public/install-control-center-companion.sh
+++ b/apps/control-center/public/install-control-center-companion.sh
@@ -25,7 +25,11 @@ REPO="${VIBETV_COMPANION_REPO:-$DEFAULT_REPO}"
 RELEASE_VERSION="${VIBETV_COMPANION_VERSION:-}"
 ADDR="${VIBETV_COMPANION_ADDR:-127.0.0.1:47832}"
 DEV_ORIGIN="${VIBETV_COMPANION_DEV_ORIGIN:-}"
-TARGET="${VIBETV_COMPANION_TARGET:-http://vibetv.local}"
+TARGET="${VIBETV_COMPANION_TARGET:-}"
+TARGET_EXPLICIT=0
+if [[ -n "${VIBETV_COMPANION_TARGET:-}" ]]; then
+  TARGET_EXPLICIT=1
+fi
 MODE="install"
 START_MODE="${VIBETV_COMPANION_START_MODE:-terminal}"
 TMPDIR_INSTALL=""
@@ -38,7 +42,7 @@ RELEASE_TAG=""
 usage() {
   cat <<'EOF'
 Usage:
-  install-control-center-companion.sh [--repo owner/name] [--version x.y.z] [--addr 127.0.0.1:47832] [--target http://vibetv.local]
+  install-control-center-companion.sh [--repo owner/name] [--version x.y.z] [--addr 127.0.0.1:47832] [--target http://<device-ip>]
   install-control-center-companion.sh --restart
   install-control-center-companion.sh --uninstall
 
@@ -237,20 +241,39 @@ json_escape() {
   printf '%s' "$value"
 }
 
-connect_vibetv() {
-  local payload
-  payload="{\"target\":\"$(json_escape "$TARGET")\",\"forcePair\":true}"
+json_device_target() {
+  sed -n 's/.*"device"[^{]*{[^}]*"target"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1
+}
 
-  log "vibetv: connecting VibeTV at ${TARGET}"
-  curl -fsS --connect-timeout 10 --max-time 90 \
+connect_vibetv() {
+  local payload response discovered_target
+  if [[ "$TARGET_EXPLICIT" == "1" ]]; then
+    payload="{\"target\":\"$(json_escape "$TARGET")\",\"forcePair\":true}"
+    log "vibetv: connecting VibeTV at ${TARGET}"
+  else
+    payload="{\"forcePair\":true}"
+    log "vibetv: discovering VibeTV on this WiFi"
+  fi
+
+  response="$(curl -fsS --connect-timeout 10 --max-time 90 \
     -X POST "http://${ADDR}/v1/device/repair" \
     -H "Content-Type: application/json" \
-    -d "$payload" >/dev/null \
+    -d "$payload")" \
     || die "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
-  log "vibetv: VibeTV is connected"
+
+  discovered_target="$(printf '%s' "$response" | json_device_target)"
+  if [[ -n "$discovered_target" ]]; then
+    TARGET="$discovered_target"
+  elif [[ -z "$TARGET" ]]; then
+    die "VibeTV connected, but the Mac App did not return the device address. Rerun setup or use --target http://<device-ip>."
+  fi
+  log "vibetv: VibeTV is connected at ${TARGET}"
 }
 
 update_vibetv_firmware() {
+  if [[ -z "$TARGET" ]]; then
+    die "VibeTV firmware update needs a device address. Rerun setup or use --target http://<device-ip>."
+  fi
   log "vibetv: starting VibeTV firmware update"
   "$BIN_PATH" install-update --target "$TARGET" --confirm-live-update \
     || die "VibeTV firmware update failed. Keep VibeTV powered on, then rerun setup."
@@ -400,10 +423,12 @@ parse_args() {
       --target)
         [[ $# -ge 2 ]] || die "--target requires a value"
         TARGET="$2"
+        TARGET_EXPLICIT=1
         shift 2
         ;;
       --target=*)
         TARGET="${1#*=}"
+        TARGET_EXPLICIT=1
         shift
         ;;
       --restart)

--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/runtimeconfig"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/setup"
+	transportlayer "github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/transport"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/usb"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/versioning"
 )
@@ -54,8 +55,11 @@ var (
 	snapshotInstalledCompanionBinaryFn                 = snapshotInstalledCompanionBinary
 	runRestoreKnownGoodCommandFn                       = runRestoreKnownGood
 	releaseHTTPClient                  releaseHTTPDoer = &http.Client{Timeout: 5 * time.Minute}
+	discoverWiFiDeviceFn                               = transportlayer.DiscoverWiFiDevice
 	flashReleaseFirmwareImageFn                        = flashReleaseFirmwareImage
 	uploadFirmwareOTAFn                                = uploadFirmwareOTA
+	firmwareHTTPVerifyPollInterval                     = 2 * time.Second
+	firmwareUpdateRediscoveryAfter                     = 20 * time.Second
 )
 
 const launchAgentLabel = "com.codexbar-display.daemon.plist"
@@ -547,12 +551,19 @@ func runInstallUpdate(args []string) (retErr error) {
 	}
 	fmt.Println("Restarting VibeTV...")
 
-	if err := waitForHTTPFirmwareVersion(ctx, base, targetVersion, 90*time.Second); err != nil {
+	verifiedBase, err := waitForHTTPFirmwareVersionWithDiscovery(ctx, home, base, targetVersion, 90*time.Second)
+	if err != nil {
 		return &commandError{
 			Op:   "post-update-verify",
 			Code: errcode.UpgradeFlashFirmware,
 			Err:  err,
 			Hint: "wait one minute, then open http://vibetv.local/health",
+		}
+	}
+	if verifiedBase != base {
+		base = verifiedBase
+		if _, err := ensureFirmwareUpdateDeviceToken(ctx, home, base, false); err != nil {
+			fmt.Printf("warning: firmware updated, but saving the rediscovered VibeTV address failed: %v\n", err)
 		}
 	}
 	fmt.Printf("Done: firmware %s installed\n", targetVersion)
@@ -646,6 +657,55 @@ func shouldStoreFirmwareUpdateTarget(current, next string) bool {
 		}
 	}
 	return true
+}
+
+func waitForHTTPFirmwareVersionWithDiscovery(ctx context.Context, home, base, version string, timeout time.Duration) (string, error) {
+	firstTimeout := timeout
+	if firmwareUpdateRediscoveryAfter > 0 && firmwareUpdateRediscoveryAfter < timeout {
+		firstTimeout = firmwareUpdateRediscoveryAfter
+	}
+	err := waitForHTTPFirmwareVersion(ctx, base, version, firstTimeout)
+	if err == nil {
+		return base, nil
+	}
+
+	discovered, discoverErr := discoverInstallUpdateTarget(ctx, home, base)
+	if discoverErr != nil {
+		if firstTimeout < timeout {
+			if retryErr := waitForHTTPFirmwareVersion(ctx, base, version, timeout-firstTimeout); retryErr == nil {
+				return base, nil
+			}
+		}
+		return "", fmt.Errorf("%w; rediscovery failed: %v", err, discoverErr)
+	}
+	if strings.TrimSpace(discovered) == "" || strings.TrimRight(discovered, "/") == strings.TrimRight(base, "/") {
+		return "", err
+	}
+	fmt.Printf("Using rediscovered VibeTV address: %s\n", discovered)
+	if verifyErr := waitForHTTPFirmwareVersion(ctx, discovered, version, 30*time.Second); verifyErr != nil {
+		return "", fmt.Errorf("%w; rediscovered target %s also failed: %v", err, discovered, verifyErr)
+	}
+	return discovered, nil
+}
+
+func discoverInstallUpdateTarget(ctx context.Context, home, base string) (string, error) {
+	candidates := []string{base, setup.DefaultWiFiTarget()}
+	if cfg, err := runtimeconfig.Load(home); err == nil {
+		candidates = append(candidates, cfg.DeviceTarget)
+	}
+	result, err := discoverWiFiDeviceFn(ctx, transportlayer.WiFiDiscoveryOptions{
+		Candidates:         candidates,
+		IncludeNetworkScan: true,
+		Timeout:            8 * time.Second,
+	})
+	if err != nil {
+		return "", err
+	}
+	target, err := normalizeHTTPBaseURL(result.Target)
+	if err != nil {
+		return "", err
+	}
+	return target, nil
 }
 
 func pairFirmwareUpdateDevice(ctx context.Context, base string) (string, error) {
@@ -1306,6 +1366,9 @@ func waitForHTTPFirmwareVersion(ctx context.Context, base, version string, timeo
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		hello, err := fetchDeviceHelloHTTP(ctx, base)
 		if err == nil && normalizeReleaseVersion(hello.Firmware) == normalizeReleaseVersion(version) {
 			return nil
@@ -1315,7 +1378,22 @@ func waitForHTTPFirmwareVersion(ctx context.Context, base, version string, timeo
 		} else {
 			lastErr = fmt.Errorf("device reported firmware %q, want %q", hello.Firmware, version)
 		}
-		time.Sleep(2 * time.Second)
+		sleep := firmwareHTTPVerifyPollInterval
+		if sleep <= 0 {
+			sleep = 2 * time.Second
+		}
+		if remaining := time.Until(deadline); remaining < sleep {
+			sleep = remaining
+		}
+		if sleep > 0 {
+			timer := time.NewTimer(sleep)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
 	}
 	if lastErr != nil {
 		return fmt.Errorf("timed out waiting for firmware %s: %w", version, lastErr)

--- a/companion/cmd/codexbar-display/release_commands_test.go
+++ b/companion/cmd/codexbar-display/release_commands_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/errcode"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/runtimeconfig"
+	transportlayer "github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/transport"
 )
 
 func TestReleaseStateRoundTrip(t *testing.T) {
@@ -619,6 +620,129 @@ func TestRunInstallUpdateFallsBackToSavedTargetWhenVibeTVLocalFails(t *testing.T
 	}
 	if !strings.Contains(output, "Using saved VibeTV address: "+server.URL) {
 		t.Fatalf("expected saved target message, got:\n%s", output)
+	}
+}
+
+func TestRunInstallUpdateRediscoverAfterFirmwareRebootIPChange(t *testing.T) {
+	previousHTTPClient := releaseHTTPClient
+	previousUpload := uploadFirmwareOTAFn
+	previousDiscover := discoverWiFiDeviceFn
+	previousPoll := firmwareHTTPVerifyPollInterval
+	previousRediscoveryAfter := firmwareUpdateRediscoveryAfter
+	t.Cleanup(func() {
+		releaseHTTPClient = previousHTTPClient
+		uploadFirmwareOTAFn = previousUpload
+		discoverWiFiDeviceFn = previousDiscover
+		firmwareHTTPVerifyPollInterval = previousPoll
+		firmwareUpdateRediscoveryAfter = previousRediscoveryAfter
+	})
+	firmwareHTTPVerifyPollInterval = time.Millisecond
+	firmwareUpdateRediscoveryAfter = time.Millisecond
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	imageBody := "firmware image"
+	imageSHA := sha256String(imageBody)
+	oldOffline := false
+	oldServerURL := ""
+	newServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.1","features":["theme"],"maxFrameBytes":1024}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer newServer.Close()
+
+	oldServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			if oldOffline {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.0","features":["theme"],"maxFrameBytes":1024}`))
+		case "/manifest.json":
+			_, _ = w.Write([]byte(`{
+  "schemaVersion": 1,
+  "release": "v1.0.1",
+  "artifacts": [{
+    "firmwareEnv": "esp8266_smalltv_st7789",
+    "board": "esp8266-smalltv-st7789",
+    "firmwareVersion": "1.0.1",
+    "asset": "firmware.bin",
+    "firmwareUrl": "` + oldServerURL + `/firmware.bin",
+    "sha256": "` + imageSHA + `"
+  }]
+}`))
+		case "/firmware.bin":
+			_, _ = w.Write([]byte(imageBody))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer oldServer.Close()
+	oldServerURL = oldServer.URL
+	if err := runtimeconfig.Save(home, runtimeconfig.Config{
+		DeviceTarget: oldServer.URL,
+		DeviceToken:  "pair-token",
+	}); err != nil {
+		t.Fatalf("save runtime config: %v", err)
+	}
+
+	releaseHTTPClient = oldServer.Client()
+	uploadFirmwareOTAFn = func(_ context.Context, base string, _ string, token string) error {
+		if base != oldServer.URL {
+			t.Fatalf("expected OTA upload to use old target %q, got %q", oldServer.URL, base)
+		}
+		if token != "pair-token" {
+			t.Fatalf("expected stored token, got %q", token)
+		}
+		oldOffline = true
+		return nil
+	}
+	var discoveryCandidates []string
+	discoverWiFiDeviceFn = func(_ context.Context, opts transportlayer.WiFiDiscoveryOptions) (transportlayer.WiFiDiscoveryResult, error) {
+		discoveryCandidates = append(discoveryCandidates, opts.Candidates...)
+		if !opts.IncludeNetworkScan {
+			t.Fatal("expected install-update rediscovery to include network scan")
+		}
+		return transportlayer.WiFiDiscoveryResult{
+			Target: newServer.URL,
+			Hello: protocol.DeviceHello{
+				Kind:            "hello",
+				ProtocolVersion: 2,
+				Board:           "esp8266-smalltv-st7789",
+				Firmware:        "1.0.1",
+			},
+			Source: "network-scan",
+		}, nil
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runInstallUpdate([]string{
+			"--target", oldServer.URL,
+			"--manifest-url", oldServer.URL + "/manifest.json",
+			"--skip-launchagent-pause",
+		})
+	})
+	if err != nil {
+		t.Fatalf("install update: %v", err)
+	}
+	if !strings.Contains(output, "Using rediscovered VibeTV address: "+newServer.URL) {
+		t.Fatalf("expected rediscovery output, got:\n%s", output)
+	}
+	if !strings.Contains(strings.Join(discoveryCandidates, ","), oldServer.URL) {
+		t.Fatalf("expected old target in discovery candidates, got %v", discoveryCandidates)
+	}
+	cfg, err := runtimeconfig.Load(home)
+	if err != nil {
+		t.Fatalf("load runtime config: %v", err)
+	}
+	if cfg.DeviceTarget != newServer.URL || cfg.DeviceToken != "pair-token" {
+		t.Fatalf("expected rediscovered target saved with existing token, got %+v", cfg)
 	}
 }
 

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -2281,6 +2281,7 @@ func (s *Server) requireDevice(w http.ResponseWriter, r *http.Request) (runtimec
 
 func (s *Server) discover(ctx context.Context, cfg runtimeconfig.Config, explicitTarget string) (string, protocol.DeviceHello, error) {
 	explicitTarget = strings.TrimSpace(explicitTarget)
+	var lastErr error
 	if explicitTarget != "" {
 		target, targetErr := normalizeExplicitDeviceTarget(explicitTarget)
 		if targetErr != nil {
@@ -2288,19 +2289,22 @@ func (s *Server) discover(ctx context.Context, cfg runtimeconfig.Config, explici
 		}
 		hello, err := s.getHelloProbe(ctx, target, cfg.DeviceToken, discoveryProbeTime)
 		if err != nil {
-			return "", protocol.DeviceHello{}, err
+			if !isVibeTVLocalTarget(target) {
+				return "", protocol.DeviceHello{}, err
+			}
+			lastErr = err
+		} else {
+			return target, hello, nil
 		}
-		return target, hello, nil
-	}
-
-	candidates := uniqueStrings(cfg.DeviceTarget, setup.DefaultWiFiTarget())
-	var lastErr error
-	for _, candidate := range candidates {
-		hello, err := s.getHelloProbe(ctx, candidate, cfg.DeviceToken, discoveryProbeTime)
-		if err == nil {
-			return normalizeTarget(candidate), hello, nil
+	} else {
+		candidates := uniqueStrings(cfg.DeviceTarget, setup.DefaultWiFiTarget())
+		for _, candidate := range candidates {
+			hello, err := s.getHelloProbe(ctx, candidate, cfg.DeviceToken, discoveryProbeTime)
+			if err == nil {
+				return normalizeTarget(candidate), hello, nil
+			}
+			lastErr = err
 		}
-		lastErr = err
 	}
 	if target, hello, err := s.discoverSubnet(ctx, cfg); err == nil {
 		return target, hello, nil
@@ -2311,6 +2315,15 @@ func (s *Server) discover(ctx context.Context, cfg runtimeconfig.Config, explici
 		lastErr = errors.New("no device candidates")
 	}
 	return "", protocol.DeviceHello{}, lastErr
+}
+
+func isVibeTVLocalTarget(target string) bool {
+	parsed, err := url.Parse(normalizeTarget(target))
+	if err != nil {
+		return false
+	}
+	host := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(parsed.Hostname())), ".")
+	return host == "vibetv.local"
 }
 
 func (s *Server) discoverSubnet(ctx context.Context, cfg runtimeconfig.Config) (string, protocol.DeviceHello, error) {

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -965,6 +965,47 @@ func TestDeviceRepairFallsBackToSubnetAndRefreshesDisplayStream(t *testing.T) {
 	}
 }
 
+func TestDeviceRepairExplicitVibetvLocalFallsBackToSubnet(t *testing.T) {
+	device := newRepairableDeviceServer(t)
+	defer device.Close()
+
+	server := newTestServer(t, runtimeconfig.Config{DeviceTarget: "http://vibetv.local"})
+	server.client.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if strings.EqualFold(strings.TrimSuffix(req.URL.Hostname(), "."), "vibetv.local") {
+			return nil, errors.New("mdns lookup failed")
+		}
+		return http.DefaultTransport.RoundTrip(req)
+	})
+	server.subnetTargets = func() []string {
+		return []string{device.URL}
+	}
+	var setupCalls []setup.Options
+	server.runSetup = func(_ context.Context, opts setup.Options) error {
+		setupCalls = append(setupCalls, opts)
+		return nil
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/device/repair", strings.NewReader(`{"target":"http://vibetv.local","forcePair":true}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got deviceActionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !got.OK || got.Device.Target != device.URL || !got.Device.Paired {
+		t.Fatalf("expected subnet repair target %q, got %+v", device.URL, got)
+	}
+	if len(setupCalls) == 0 || setupCalls[len(setupCalls)-1].Target != device.URL {
+		t.Fatalf("expected display stream refreshed with discovered target, got %+v", setupCalls)
+	}
+}
+
 func TestDeviceRepairForcePairRotatesToken(t *testing.T) {
 	device := newRepairableDeviceServer(t)
 	defer device.Close()
@@ -1993,6 +2034,12 @@ func newTestServer(t *testing.T, cfg runtimeconfig.Config) *Server {
 	server.streamStatus = healthyStream
 	server.waitStream = healthyStream
 	return server
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }
 
 func newHelloDeviceServer(t *testing.T) *httptest.Server {

--- a/scripts/install-control-center-companion-release.sh
+++ b/scripts/install-control-center-companion-release.sh
@@ -70,6 +70,9 @@ log() {
 
 die() {
   printf 'error: %s\n' "$*" >&2
+  printf 'support: status: curl -fsS http://%s/v1/status\n' "$ADDR" >&2
+  printf 'support: report: curl -fsS http://%s/v1/diagnostics\n' "$ADDR" >&2
+  printf 'support: logs: %s / %s\n' "$DISPLAY_DAEMON_LOG_OUT" "$DISPLAY_DAEMON_LOG_ERR" >&2
   exit 1
 }
 
@@ -245,6 +248,107 @@ json_device_target() {
   sed -n 's/.*"device"[^{]*{[^}]*"target"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1
 }
 
+json_api_field() {
+  local field="$1"
+  sed -n "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" | head -n 1
+}
+
+status_field() {
+  local object="$1"
+  local field="$2"
+  sed -n "s/.*\"${object}\"[^{]*{[^}]*\"${field}\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" | head -n 1
+}
+
+status_bool_field() {
+  local object="$1"
+  local field="$2"
+  sed -n \
+    -e "s/.*\"${object}\"[^{]*{[^}]*\"${field}\"[[:space:]]*:[[:space:]]*true.*/true/p" \
+    -e "s/.*\"${object}\"[^{]*{[^}]*\"${field}\"[[:space:]]*:[[:space:]]*false.*/false/p" \
+    | head -n 1
+}
+
+local_api_json() {
+  local method="$1"
+  local path="$2"
+  local payload="${3:-}"
+  local response_file status_file stderr_file status curl_status
+  response_file="${TMPDIR_INSTALL}/api-response.json"
+  status_file="${TMPDIR_INSTALL}/api-status.txt"
+  stderr_file="${TMPDIR_INSTALL}/api-stderr.txt"
+  : > "$response_file"
+  : > "$status_file"
+  : > "$stderr_file"
+
+  set +e
+  if [[ -n "$payload" ]]; then
+    curl -sS --connect-timeout 10 --max-time 90 \
+      -o "$response_file" \
+      -w "%{http_code}" \
+      -X "$method" "http://${ADDR}${path}" \
+      -H "Content-Type: application/json" \
+      -d "$payload" \
+      > "$status_file" 2> "$stderr_file"
+  else
+    curl -sS --connect-timeout 10 --max-time 30 \
+      -o "$response_file" \
+      -w "%{http_code}" \
+      -X "$method" "http://${ADDR}${path}" \
+      > "$status_file" 2> "$stderr_file"
+  fi
+  curl_status=$?
+  set -e
+
+  status="$(cat "$status_file" 2>/dev/null || true)"
+  if [[ "$curl_status" == "0" && "$status" =~ ^2[0-9][0-9]$ ]]; then
+    cat "$response_file"
+    return 0
+  fi
+
+  return 1
+}
+
+print_local_api_error() {
+  local method="$1"
+  local path="$2"
+  local response_file="${TMPDIR_INSTALL}/api-response.json"
+  local status_file="${TMPDIR_INSTALL}/api-status.txt"
+  local stderr_file="${TMPDIR_INSTALL}/api-stderr.txt"
+  local message next_action code stderr_text status
+  status="$(cat "$status_file" 2>/dev/null || true)"
+  message="$(json_api_field "message" < "$response_file")"
+  next_action="$(json_api_field "nextAction" < "$response_file")"
+  code="$(json_api_field "code" < "$response_file")"
+  stderr_text="$(tr '\n' ' ' < "$stderr_file" | sed 's/[[:space:]]*$//')"
+
+  printf 'error: Mac App API %s %s failed' "$method" "$path" >&2
+  if [[ -n "$status" && "$status" != "000" ]]; then
+    printf ' with HTTP %s' "$status" >&2
+  fi
+  printf '.\n' >&2
+  [[ -z "$code" ]] || printf 'error code: %s\n' "$code" >&2
+  [[ -z "$message" ]] || printf 'detail: %s\n' "$message" >&2
+  [[ -z "$next_action" ]] || printf 'next step: %s\n' "$next_action" >&2
+  [[ -z "$stderr_text" ]] || printf 'curl: %s\n' "$stderr_text" >&2
+}
+
+retryable_repair_failure() {
+  local response_file="${TMPDIR_INSTALL}/api-response.json"
+  local status_file="${TMPDIR_INSTALL}/api-status.txt"
+  local stderr_file="${TMPDIR_INSTALL}/api-stderr.txt"
+  local code status stderr_text
+  status="$(cat "$status_file" 2>/dev/null || true)"
+  code="$(json_api_field "code" < "$response_file")"
+  stderr_text="$(tr '\n' ' ' < "$stderr_file" | tr '[:upper:]' '[:lower:]' || true)"
+
+  [[ "$status" == "000" ]] && return 0
+  [[ "$status" == "408" || "$status" == "429" ]] && return 0
+  [[ "$status" =~ ^5[0-9][0-9]$ ]] && return 0
+  [[ "$code" == "device_not_found" ]] && return 0
+  [[ "$stderr_text" == *"timed out"* || "$stderr_text" == *"connection reset"* || "$stderr_text" == *"connection refused"* ]] && return 0
+  return 1
+}
+
 connect_vibetv() {
   local payload response discovered_target
   if [[ "$TARGET_EXPLICIT" == "1" ]]; then
@@ -255,11 +359,17 @@ connect_vibetv() {
     log "vibetv: discovering VibeTV on this WiFi"
   fi
 
-  response="$(curl -fsS --connect-timeout 10 --max-time 90 \
-    -X POST "http://${ADDR}/v1/device/repair" \
-    -H "Content-Type: application/json" \
-    -d "$payload")" \
-    || die "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
+  for attempt in 1 2 3; do
+    if response="$(local_api_json POST "/v1/device/repair" "$payload")"; then
+      break
+    fi
+    if [[ "$attempt" == "3" ]] || ! retryable_repair_failure; then
+      print_local_api_error POST "/v1/device/repair"
+      die "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
+    fi
+    log "vibetv: VibeTV did not answer yet; retrying (${attempt}/3)"
+    sleep 2
+  done
 
   discovered_target="$(printf '%s' "$response" | json_device_target)"
   if [[ -n "$discovered_target" ]]; then
@@ -281,9 +391,57 @@ update_vibetv_firmware() {
   log "vibetv: VibeTV firmware update complete"
 }
 
+verify_companion_version() {
+  local response version
+  if ! response="$(local_api_json GET "/v1/status")"; then
+    print_local_api_error GET "/v1/status"
+    die "Mac setup service did not answer on http://${ADDR}/v1/status. Inspect ${DISPLAY_DAEMON_LOG_ERR}."
+  fi
+  version="$(printf '%s' "$response" | status_field "companion" "version")"
+  if [[ "$version" == "$RELEASE_VERSION" ]]; then
+    return 0
+  fi
+
+  log "vibetv: Mac App answered with version ${version:-unknown}; restarting once"
+  restart_service
+  wait_for_api
+  if ! response="$(local_api_json GET "/v1/status")"; then
+    print_local_api_error GET "/v1/status"
+    die "Mac setup service did not answer on http://${ADDR}/v1/status after restart. Inspect ${DISPLAY_DAEMON_LOG_ERR}."
+  fi
+  version="$(printf '%s' "$response" | status_field "companion" "version")"
+  [[ "$version" == "$RELEASE_VERSION" ]] \
+    || die "Mac App version mismatch after restart: expected ${RELEASE_VERSION}, got ${version:-unknown}. Inspect ${DISPLAY_DAEMON_LOG_ERR}."
+}
+
+verify_final_status() {
+  local response device_response status connected paired firmware
+  if ! response="$(local_api_json GET "/v1/status")"; then
+    print_local_api_error GET "/v1/status"
+    die "Mac setup service did not answer for the final status check. Inspect ${DISPLAY_DAEMON_LOG_ERR}."
+  fi
+  status="$(printf '%s' "$response" | status_field "companion" "status")"
+  [[ "$status" == "ready" ]] \
+    || die "Mac App is not ready after setup. Inspect ${DISPLAY_DAEMON_LOG_ERR}."
+
+  if ! device_response="$(local_api_json GET "/v1/device")"; then
+    print_local_api_error GET "/v1/device"
+    die "VibeTV is not reachable after setup. Run: curl http://${ADDR}/v1/status"
+  fi
+  connected="$(printf '%s' "$response" | status_bool_field "device" "connected")"
+  paired="$(printf '%s' "$device_response" | status_bool_field "device" "paired")"
+  firmware="$(printf '%s' "$device_response" | status_field "device" "firmware")"
+  [[ "$connected" == "true" && "$paired" == "true" ]] \
+    || die "VibeTV is not connected after setup. Run: curl http://${ADDR}/v1/status"
+  [[ -n "$firmware" ]] \
+    || die "VibeTV firmware version was not available after setup. Run: curl http://${ADDR}/v1/device"
+  log "vibetv: setup verified; Mac App ready, VibeTV connected, firmware ${firmware}"
+}
+
 finish_device_setup() {
   connect_vibetv
   update_vibetv_firmware
+  verify_final_status
 }
 
 install_binary() {
@@ -513,6 +671,7 @@ main() {
   install_binary
   restart_service
   wait_for_api
+  verify_companion_version
 
   log "vibetv: Mac setup binary installed at ${BIN_PATH}"
   log "vibetv: background service installed at ${DISPLAY_DAEMON_PLIST}"

--- a/scripts/install-control-center-companion-release.sh
+++ b/scripts/install-control-center-companion-release.sh
@@ -25,7 +25,11 @@ REPO="${VIBETV_COMPANION_REPO:-$DEFAULT_REPO}"
 RELEASE_VERSION="${VIBETV_COMPANION_VERSION:-}"
 ADDR="${VIBETV_COMPANION_ADDR:-127.0.0.1:47832}"
 DEV_ORIGIN="${VIBETV_COMPANION_DEV_ORIGIN:-}"
-TARGET="${VIBETV_COMPANION_TARGET:-http://vibetv.local}"
+TARGET="${VIBETV_COMPANION_TARGET:-}"
+TARGET_EXPLICIT=0
+if [[ -n "${VIBETV_COMPANION_TARGET:-}" ]]; then
+  TARGET_EXPLICIT=1
+fi
 MODE="install"
 START_MODE="${VIBETV_COMPANION_START_MODE:-terminal}"
 TMPDIR_INSTALL=""
@@ -38,7 +42,7 @@ RELEASE_TAG=""
 usage() {
   cat <<'EOF'
 Usage:
-  install-control-center-companion.sh [--repo owner/name] [--version x.y.z] [--addr 127.0.0.1:47832] [--target http://vibetv.local]
+  install-control-center-companion.sh [--repo owner/name] [--version x.y.z] [--addr 127.0.0.1:47832] [--target http://<device-ip>]
   install-control-center-companion.sh --restart
   install-control-center-companion.sh --uninstall
 
@@ -237,20 +241,39 @@ json_escape() {
   printf '%s' "$value"
 }
 
-connect_vibetv() {
-  local payload
-  payload="{\"target\":\"$(json_escape "$TARGET")\",\"forcePair\":true}"
+json_device_target() {
+  sed -n 's/.*"device"[^{]*{[^}]*"target"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1
+}
 
-  log "vibetv: connecting VibeTV at ${TARGET}"
-  curl -fsS --connect-timeout 10 --max-time 90 \
+connect_vibetv() {
+  local payload response discovered_target
+  if [[ "$TARGET_EXPLICIT" == "1" ]]; then
+    payload="{\"target\":\"$(json_escape "$TARGET")\",\"forcePair\":true}"
+    log "vibetv: connecting VibeTV at ${TARGET}"
+  else
+    payload="{\"forcePair\":true}"
+    log "vibetv: discovering VibeTV on this WiFi"
+  fi
+
+  response="$(curl -fsS --connect-timeout 10 --max-time 90 \
     -X POST "http://${ADDR}/v1/device/repair" \
     -H "Content-Type: application/json" \
-    -d "$payload" >/dev/null \
+    -d "$payload")" \
     || die "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
-  log "vibetv: VibeTV is connected"
+
+  discovered_target="$(printf '%s' "$response" | json_device_target)"
+  if [[ -n "$discovered_target" ]]; then
+    TARGET="$discovered_target"
+  elif [[ -z "$TARGET" ]]; then
+    die "VibeTV connected, but the Mac App did not return the device address. Rerun setup or use --target http://<device-ip>."
+  fi
+  log "vibetv: VibeTV is connected at ${TARGET}"
 }
 
 update_vibetv_firmware() {
+  if [[ -z "$TARGET" ]]; then
+    die "VibeTV firmware update needs a device address. Rerun setup or use --target http://<device-ip>."
+  fi
   log "vibetv: starting VibeTV firmware update"
   "$BIN_PATH" install-update --target "$TARGET" --confirm-live-update \
     || die "VibeTV firmware update failed. Keep VibeTV powered on, then rerun setup."
@@ -400,10 +423,12 @@ parse_args() {
       --target)
         [[ $# -ge 2 ]] || die "--target requires a value"
         TARGET="$2"
+        TARGET_EXPLICIT=1
         shift 2
         ;;
       --target=*)
         TARGET="${1#*=}"
+        TARGET_EXPLICIT=1
         shift
         ;;
       --restart)

--- a/scripts/test-control-center-companion-legacy-installer.sh
+++ b/scripts/test-control-center-companion-legacy-installer.sh
@@ -87,7 +87,7 @@ case "$*" in
     exit 0
     ;;
   *"/v1/device/repair"*)
-    printf '{"ok":true,"device":{"connected":true,"paired":true}}\n'
+    printf '{"ok":true,"device":{"connected":true,"paired":true,"target":"http://192.168.178.72"}}\n'
     ;;
   *"/releases/latest"*)
     printf '{"tag_name":"v9.9.9"}\n'
@@ -271,11 +271,12 @@ run_install_writes_integrated_daemon_launchagent() {
   daemon_plist_body="$(cat "$daemon_plist")"
 
   assert_contains "$output" "background service installed at ${daemon_plist}"
-  assert_contains "$output" "VibeTV is connected"
+  assert_contains "$output" "VibeTV is connected at http://192.168.178.72"
   assert_contains "$output" "Done: firmware 9.9.9 installed"
   assert_contains "$output" "VibeTV firmware update complete"
   assert_contains "$curl_log" "/v1/device/repair"
-  assert_contains "$(cat "${root}/api.log")" "install-update --target http://vibetv.local --confirm-live-update"
+  assert_contains "$curl_log" '{"forcePair":true}'
+  assert_contains "$(cat "${root}/api.log")" "install-update --target http://192.168.178.72 --confirm-live-update"
   assert_not_contains "$curl_log" "/v1/updates/install"
   assert_contains "$daemon_plist_body" "<string>daemon</string>"
   assert_contains "$daemon_plist_body" "<string>--api-addr</string>"
@@ -312,7 +313,8 @@ run_install_disables_global_legacy_launchagent() {
   assert_contains "$output" "Done: firmware 9.9.9 installed"
   assert_contains "$output" "VibeTV firmware update complete"
   assert_contains "$curl_log" "/v1/device/repair"
-  assert_contains "$(cat "${root}/api.log")" "install-update --target http://vibetv.local --confirm-live-update"
+  assert_contains "$curl_log" '{"forcePair":true}'
+  assert_contains "$(cat "${root}/api.log")" "install-update --target http://192.168.178.72 --confirm-live-update"
   assert_not_contains "$curl_log" "/v1/updates/install"
   assert_contains "$launch_log" "bootout gui/$(id -u)/com.codexbar-display.companion-api"
   assert_contains "$launch_log" "disable gui/$(id -u)/com.codexbar-display.companion-api"

--- a/scripts/test-control-center-companion-legacy-installer.sh
+++ b/scripts/test-control-center-companion-legacy-installer.sh
@@ -74,23 +74,71 @@ EOF
 printf '%s\n' "$*" >> "${FAKE_CURL_LOG:?}"
 out=""
 previous=""
+write_status=0
 for arg in "$@"; do
   if [[ "$previous" == "-o" ]]; then
     out="$arg"
     previous=""
     continue
   fi
+  if [[ "$arg" == "%{http_code}" ]]; then
+    write_status=1
+  fi
   previous="$arg"
 done
+
+respond() {
+  local body="$1"
+  if [[ -n "$out" ]]; then
+    printf '%s\n' "$body" > "$out"
+  else
+    printf '%s\n' "$body"
+  fi
+  if [[ "$write_status" == "1" ]]; then
+    printf '200'
+  fi
+}
+
 case "$*" in
   *"/v1/status"*)
-    exit 0
+    if [[ -n "${FAKE_STATUS_OLD_ONCE:-}" && "$write_status" == "1" && ! -f "$FAKE_STATUS_OLD_ONCE" ]]; then
+      touch "$FAKE_STATUS_OLD_ONCE"
+      respond '{"ok":true,"companion":{"status":"ready","version":"9.9.8","features":{"themeInstallEnabled":true}},"device":{"target":"http://192.168.178.72","connected":true,"paired":true}}'
+      exit 0
+    fi
+    respond '{"ok":true,"companion":{"status":"ready","version":"9.9.9","features":{"themeInstallEnabled":true}},"device":{"target":"http://192.168.178.72","connected":true,"paired":true}}'
     ;;
   *"/v1/device/repair"*)
-    printf '{"ok":true,"device":{"connected":true,"paired":true,"target":"http://192.168.178.72"}}\n'
+    if [[ -n "${FAKE_REPAIR_ALWAYS_FAIL:-}" ]]; then
+      if [[ -n "$out" ]]; then
+        printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Make sure VibeTV is powered on and run device discovery again."}}' > "$out"
+      else
+        printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Make sure VibeTV is powered on and run device discovery again."}}'
+      fi
+      if [[ "$write_status" == "1" ]]; then
+        printf '404'
+      fi
+      exit 0
+    fi
+    if [[ -n "${FAKE_REPAIR_FAIL_ONCE:-}" && ! -f "$FAKE_REPAIR_FAIL_ONCE" ]]; then
+      touch "$FAKE_REPAIR_FAIL_ONCE"
+      if [[ -n "$out" ]]; then
+        printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Make sure VibeTV is powered on and run device discovery again."}}' > "$out"
+      else
+        printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Make sure VibeTV is powered on and run device discovery again."}}'
+      fi
+      if [[ "$write_status" == "1" ]]; then
+        printf '404'
+      fi
+      exit 0
+    fi
+    respond '{"ok":true,"device":{"connected":true,"paired":true,"target":"http://192.168.178.72"}}'
+    ;;
+  *"/v1/device"*)
+    respond '{"ok":true,"device":{"connected":true,"paired":true,"target":"http://192.168.178.72","firmware":"9.9.9"}}'
     ;;
   *"/releases/latest"*)
-    printf '{"tag_name":"v9.9.9"}\n'
+    respond '{"tag_name":"v9.9.9"}'
     ;;
   *"/codexbar-display-darwin-arm64-v9.9.9"*)
     [[ -n "$out" ]] || exit 22
@@ -182,6 +230,9 @@ run_installer() {
       FAKE_API_LOG="${root}/api.log" \
       FAKE_LAUNCHCTL_LOG="${root}/launchctl.log" \
       FAKE_CURL_LOG="${root}/curl.log" \
+      FAKE_REPAIR_FAIL_ONCE="${FAKE_REPAIR_FAIL_ONCE:-}" \
+      FAKE_REPAIR_ALWAYS_FAIL="${FAKE_REPAIR_ALWAYS_FAIL:-}" \
+      FAKE_STATUS_OLD_ONCE="${FAKE_STATUS_OLD_ONCE:-}" \
       VIBETV_COMPANION_GLOBAL_PLIST="${root}/global/Library/LaunchAgents/com.codexbar-display.companion-api.plist" \
       "$INSTALLER" "$@" \
       2>&1
@@ -321,8 +372,76 @@ run_install_disables_global_legacy_launchagent() {
   assert_contains "$daemon_plist_body" "<string>--api-addr</string>"
 }
 
+run_install_retries_transient_repair_failure() {
+  local root output repair_calls
+  root="${TMP_WORK_DIR}/repair-retry"
+  write_fake_commands "${root}/fake-bin"
+  prepare_home "${root}/home"
+  : > "${root}/launchctl.log"
+  : > "${root}/curl.log"
+  : > "${root}/api.log"
+
+  output="$(FAKE_REPAIR_FAIL_ONCE="${root}/repair-fail-once" run_installer "$root" --version 9.9.9 --terminal-session)" || {
+    printf '%s\n' "$output" >&2
+    die "expected install to pass after repair retry"
+  }
+
+  repair_calls="$(grep -c "/v1/device/repair" "${root}/curl.log")"
+  [[ "$repair_calls" == "2" ]] || die "expected two repair calls, got ${repair_calls}"
+  assert_not_contains "$output" "Mac App API POST /v1/device/repair failed"
+  assert_contains "$output" "VibeTV did not answer yet; retrying (1/3)"
+  assert_contains "$output" "setup verified; Mac App ready, VibeTV connected, firmware 9.9.9"
+}
+
+run_install_prints_repair_failure_details() {
+  local root output status repair_calls
+  root="${TMP_WORK_DIR}/repair-fail"
+  write_fake_commands "${root}/fake-bin"
+  prepare_home "${root}/home"
+  : > "${root}/launchctl.log"
+  : > "${root}/curl.log"
+  : > "${root}/api.log"
+
+  set +e
+  output="$(FAKE_REPAIR_ALWAYS_FAIL=1 run_installer "$root" --version 9.9.9 --terminal-session)"
+  status=$?
+  set -e
+  [[ "$status" != "0" ]] || die "expected install to fail when repair never succeeds"
+
+  repair_calls="$(grep -c "/v1/device/repair" "${root}/curl.log")"
+  [[ "$repair_calls" == "3" ]] || die "expected three repair calls, got ${repair_calls}"
+  assert_contains "$output" "Mac App API POST /v1/device/repair failed with HTTP 404"
+  assert_contains "$output" "error code: device_not_found"
+  assert_contains "$output" "detail: No VibeTV device was found."
+  assert_contains "$output" "next step: Make sure VibeTV is powered on and run device discovery again."
+  assert_contains "$output" "support: report: curl -fsS http://127.0.0.1:47832/v1/diagnostics"
+}
+
+run_install_restarts_when_old_api_version_answers() {
+  local root output kickstarts
+  root="${TMP_WORK_DIR}/old-api-version"
+  write_fake_commands "${root}/fake-bin"
+  prepare_home "${root}/home"
+  : > "${root}/launchctl.log"
+  : > "${root}/curl.log"
+  : > "${root}/api.log"
+
+  output="$(FAKE_STATUS_OLD_ONCE="${root}/status-old-once" run_installer "$root" --version 9.9.9 --terminal-session)" || {
+    printf '%s\n' "$output" >&2
+    die "expected install to pass after old API restart"
+  }
+
+  assert_contains "$output" "Mac App answered with version 9.9.8; restarting once"
+  assert_contains "$output" "setup verified; Mac App ready, VibeTV connected, firmware 9.9.9"
+  kickstarts="$(grep -c "kickstart -k gui/$(id -u)/com.codexbar-display.daemon" "${root}/launchctl.log")"
+  [[ "$kickstarts" == "2" ]] || die "expected initial start plus one restart, got ${kickstarts}"
+}
+
 run_install_writes_integrated_daemon_launchagent
 run_install_disables_global_legacy_launchagent
+run_install_retries_transient_repair_failure
+run_install_prints_repair_failure_details
+run_install_restarts_when_old_api_version_answers
 run_restart_updates_daemon_launchagent
 run_uninstall_stops_terminal_service_and_legacy_launchagent
 


### PR DESCRIPTION
## What changed

- The terminal setup installer no longer forces `http://vibetv.local` into the Mac App repair call by default.
- Default setup now lets the Mac App discover/pair VibeTV, reads the returned device target, and uses that exact address for the firmware update.
- If a user explicitly passes `--target`, setup still honors it.
- The Mac App repair/discovery path now falls back to subnet/IP discovery when explicit `vibetv.local` fails, while keeping explicit IP targets strict.

## Root cause

The v1.0.34 setup command always sent `target: "http://vibetv.local"` to `/v1/device/repair`. That made repair treat `.local` as an explicit target and skip the subnet/IP discovery fallback. On Macs where mDNS is flaky, setup failed before firmware update with `device_not_found` / HTTP 404.

## Validation

- `scripts/test-control-center-companion-legacy-installer.sh`
- `go test ./internal/companionapi` from `companion/`
- `go test ./cmd/codexbar-display ./internal/companionapi ./internal/transport` from `companion/`
- `node scripts/check-control-center-ui-review-gate.mjs`
- `scripts/test-control-center-release-workflow.sh`
- `scripts/test-control-center-customer-ready-gate.sh`
- `scripts/check-control-center-customer-docs.sh`
- `git diff --check`
