### PR TITLE
Harden setup after VibeTV rediscovery

### DIFF
--- a/apps/control-center/public/install-control-center-companion.sh
+++ b/apps/control-center/public/install-control-center-companion.sh
@@ -20,6 +20,7 @@ DISPLAY_DAEMON_PLIST="${PLIST_DIR}/${DISPLAY_DAEMON_LABEL}.plist"
 DISPLAY_DAEMON_SERVICE="gui/$(id -u)/${DISPLAY_DAEMON_LABEL}"
 DISPLAY_DAEMON_LOG_OUT="/tmp/codexbar-display-daemon.out.log"
 DISPLAY_DAEMON_LOG_ERR="/tmp/codexbar-display-daemon.err.log"
+CONFIG_PATH="${APP_SUPPORT_DIR}/config.json"
 
 REPO="${VIBETV_COMPANION_REPO:-$DEFAULT_REPO}"
 RELEASE_VERSION="${VIBETV_COMPANION_VERSION:-}"
@@ -30,6 +31,8 @@ TARGET_EXPLICIT=0
 if [[ -n "${VIBETV_COMPANION_TARGET:-}" ]]; then
   TARGET_EXPLICIT=1
 fi
+REPAIR_MAX_ATTEMPTS="${VIBETV_COMPANION_REPAIR_ATTEMPTS:-45}"
+REPAIR_RETRY_DELAY="${VIBETV_COMPANION_REPAIR_RETRY_DELAY:-2}"
 MODE="install"
 START_MODE="${VIBETV_COMPANION_START_MODE:-terminal}"
 TMPDIR_INSTALL=""
@@ -151,8 +154,27 @@ xml_escape() {
   printf '%s' "$value"
 }
 
+runtime_config_target() {
+  [[ -f "$CONFIG_PATH" ]] || return 0
+  sed -n 's/.*"deviceTarget"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$CONFIG_PATH" | head -n 1
+}
+
+daemon_target_for_plist() {
+  if [[ -n "$TARGET" ]]; then
+    printf '%s\n' "$TARGET"
+    return 0
+  fi
+  runtime_config_target
+}
+
 write_plist() {
-  local daemon_args=("$BIN_PATH" "daemon" "--interval" "30s" "--transport" "wifi" "--target" "$TARGET" "--api-addr" "$ADDR")
+  local daemon_target
+  daemon_target="$(daemon_target_for_plist)"
+
+  local daemon_args=("$BIN_PATH" "daemon" "--interval" "30s" "--transport" "wifi" "--api-addr" "$ADDR")
+  if [[ -n "$daemon_target" ]]; then
+    daemon_args+=("--target" "$daemon_target")
+  fi
   if [[ -n "$DEV_ORIGIN" ]]; then
     daemon_args+=("--api-dev-origin" "$DEV_ORIGIN")
   fi
@@ -349,8 +371,22 @@ retryable_repair_failure() {
   return 1
 }
 
+recover_connected_device_from_status() {
+  local response connected paired known_target
+  response="$(local_api_json GET "/v1/status")" || return 1
+  connected="$(printf '%s' "$response" | status_bool_field "device" "connected")"
+  paired="$(printf '%s' "$response" | status_bool_field "device" "paired")"
+  known_target="$(printf '%s' "$response" | json_device_target)"
+  if [[ "$connected" == "true" && "$paired" == "true" && -n "$known_target" ]]; then
+    TARGET="$known_target"
+    log "vibetv: VibeTV is already connected at ${TARGET}"
+    return 0
+  fi
+  return 1
+}
+
 connect_vibetv() {
-  local payload response discovered_target
+  local payload response discovered_target saved_response saved_status saved_stderr
   if [[ "$TARGET_EXPLICIT" == "1" ]]; then
     payload="{\"target\":\"$(json_escape "$TARGET")\",\"forcePair\":true}"
     log "vibetv: connecting VibeTV at ${TARGET}"
@@ -359,16 +395,25 @@ connect_vibetv() {
     log "vibetv: discovering VibeTV on this WiFi"
   fi
 
-  for attempt in 1 2 3; do
+  for attempt in $(seq 1 "$REPAIR_MAX_ATTEMPTS"); do
     if response="$(local_api_json POST "/v1/device/repair" "$payload")"; then
       break
     fi
-    if [[ "$attempt" == "3" ]] || ! retryable_repair_failure; then
+    if [[ "$attempt" == "$REPAIR_MAX_ATTEMPTS" ]] || ! retryable_repair_failure; then
+      saved_response="$(cat "${TMPDIR_INSTALL}/api-response.json" 2>/dev/null || true)"
+      saved_status="$(cat "${TMPDIR_INSTALL}/api-status.txt" 2>/dev/null || true)"
+      saved_stderr="$(cat "${TMPDIR_INSTALL}/api-stderr.txt" 2>/dev/null || true)"
+      if recover_connected_device_from_status; then
+        return 0
+      fi
+      printf '%s' "$saved_response" > "${TMPDIR_INSTALL}/api-response.json"
+      printf '%s' "$saved_status" > "${TMPDIR_INSTALL}/api-status.txt"
+      printf '%s' "$saved_stderr" > "${TMPDIR_INSTALL}/api-stderr.txt"
       print_local_api_error POST "/v1/device/repair"
       die "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
     fi
-    log "vibetv: VibeTV did not answer yet; retrying (${attempt}/3)"
-    sleep 2
+    log "vibetv: VibeTV did not answer yet; retrying (${attempt}/${REPAIR_MAX_ATTEMPTS})"
+    sleep "$REPAIR_RETRY_DELAY"
   done
 
   discovered_target="$(printf '%s' "$response" | json_device_target)"
@@ -378,6 +423,14 @@ connect_vibetv() {
     die "VibeTV connected, but the Mac App did not return the device address. Rerun setup or use --target http://<device-ip>."
   fi
   log "vibetv: VibeTV is connected at ${TARGET}"
+}
+
+restart_service_with_discovered_target() {
+  [[ -n "$TARGET" ]] || return 0
+  log "vibetv: saving VibeTV address ${TARGET} for the background service"
+  restart_service
+  wait_for_api
+  verify_companion_version
 }
 
 update_vibetv_firmware() {
@@ -440,6 +493,7 @@ verify_final_status() {
 
 finish_device_setup() {
   connect_vibetv
+  restart_service_with_discovered_target
   update_vibetv_firmware
   verify_final_status
 }

--- a/docs/control-center-ui-review-checkpoint.md
+++ b/docs/control-center-ui-review-checkpoint.md
@@ -13,6 +13,11 @@ To reset the gate:
 
 ## Last Review Notes
 
+- Reviewed scope: hosted Mac App installer script as a public Control Center asset, setup recovery when VibeTV briefly disappears from WiFi, and final background-service target persistence after automatic discovery.
+- Customer rule: no new visible Control Center UI, buttons, tabs, or customer decisions were added; setup remains one Mac App install/update action that should recover the VibeTV connection automatically instead of asking customers to understand IP discovery, pairing, LaunchAgents, or local targets.
+- Simplifications accepted: the customer-facing app stays unchanged; installer output keeps using Mac App and VibeTV wording while preserving detailed support commands only for diagnostics.
+- Verification: UI was reviewed against `docs/control-center-ui-principles.md`; `scripts/test-control-center-companion-legacy-installer.sh`, targeted Companion Go tests, release-workflow tests, customer-ready gate tests, install.sh migration tests, installer sync check, and `git diff --check` passed locally.
+
 - Reviewed scope: setup prompt copy for Mac App install/update, setup step 4 stuck-state fallback, Overview version labels, Mac App release/update request timeout handling, and Theme Library activation retry progress copy.
 - Customer rule: setup remains one guided customer action; the prompt may ask the agent to update VibeTV firmware, but the visible UI must still say Mac App, VibeTV, Connect, and Update instead of daemon/API/LaunchAgent/release internals. Version rows must distinguish Mac App from VibeTV firmware so customers do not compare unrelated numbers.
 - Simplifications accepted: no new customer setup decision was added; the endless `Connecting VibeTV...` state now falls back to one `Connect VibeTV` action; Theme Library retries are shown as passive progress, not extra troubleshooting buttons.

--- a/scripts/install-control-center-companion-release.sh
+++ b/scripts/install-control-center-companion-release.sh
@@ -20,6 +20,7 @@ DISPLAY_DAEMON_PLIST="${PLIST_DIR}/${DISPLAY_DAEMON_LABEL}.plist"
 DISPLAY_DAEMON_SERVICE="gui/$(id -u)/${DISPLAY_DAEMON_LABEL}"
 DISPLAY_DAEMON_LOG_OUT="/tmp/codexbar-display-daemon.out.log"
 DISPLAY_DAEMON_LOG_ERR="/tmp/codexbar-display-daemon.err.log"
+CONFIG_PATH="${APP_SUPPORT_DIR}/config.json"
 
 REPO="${VIBETV_COMPANION_REPO:-$DEFAULT_REPO}"
 RELEASE_VERSION="${VIBETV_COMPANION_VERSION:-}"
@@ -30,6 +31,8 @@ TARGET_EXPLICIT=0
 if [[ -n "${VIBETV_COMPANION_TARGET:-}" ]]; then
   TARGET_EXPLICIT=1
 fi
+REPAIR_MAX_ATTEMPTS="${VIBETV_COMPANION_REPAIR_ATTEMPTS:-45}"
+REPAIR_RETRY_DELAY="${VIBETV_COMPANION_REPAIR_RETRY_DELAY:-2}"
 MODE="install"
 START_MODE="${VIBETV_COMPANION_START_MODE:-terminal}"
 TMPDIR_INSTALL=""
@@ -151,8 +154,27 @@ xml_escape() {
   printf '%s' "$value"
 }
 
+runtime_config_target() {
+  [[ -f "$CONFIG_PATH" ]] || return 0
+  sed -n 's/.*"deviceTarget"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$CONFIG_PATH" | head -n 1
+}
+
+daemon_target_for_plist() {
+  if [[ -n "$TARGET" ]]; then
+    printf '%s\n' "$TARGET"
+    return 0
+  fi
+  runtime_config_target
+}
+
 write_plist() {
-  local daemon_args=("$BIN_PATH" "daemon" "--interval" "30s" "--transport" "wifi" "--target" "$TARGET" "--api-addr" "$ADDR")
+  local daemon_target
+  daemon_target="$(daemon_target_for_plist)"
+
+  local daemon_args=("$BIN_PATH" "daemon" "--interval" "30s" "--transport" "wifi" "--api-addr" "$ADDR")
+  if [[ -n "$daemon_target" ]]; then
+    daemon_args+=("--target" "$daemon_target")
+  fi
   if [[ -n "$DEV_ORIGIN" ]]; then
     daemon_args+=("--api-dev-origin" "$DEV_ORIGIN")
   fi
@@ -349,8 +371,22 @@ retryable_repair_failure() {
   return 1
 }
 
+recover_connected_device_from_status() {
+  local response connected paired known_target
+  response="$(local_api_json GET "/v1/status")" || return 1
+  connected="$(printf '%s' "$response" | status_bool_field "device" "connected")"
+  paired="$(printf '%s' "$response" | status_bool_field "device" "paired")"
+  known_target="$(printf '%s' "$response" | json_device_target)"
+  if [[ "$connected" == "true" && "$paired" == "true" && -n "$known_target" ]]; then
+    TARGET="$known_target"
+    log "vibetv: VibeTV is already connected at ${TARGET}"
+    return 0
+  fi
+  return 1
+}
+
 connect_vibetv() {
-  local payload response discovered_target
+  local payload response discovered_target saved_response saved_status saved_stderr
   if [[ "$TARGET_EXPLICIT" == "1" ]]; then
     payload="{\"target\":\"$(json_escape "$TARGET")\",\"forcePair\":true}"
     log "vibetv: connecting VibeTV at ${TARGET}"
@@ -359,16 +395,25 @@ connect_vibetv() {
     log "vibetv: discovering VibeTV on this WiFi"
   fi
 
-  for attempt in 1 2 3; do
+  for attempt in $(seq 1 "$REPAIR_MAX_ATTEMPTS"); do
     if response="$(local_api_json POST "/v1/device/repair" "$payload")"; then
       break
     fi
-    if [[ "$attempt" == "3" ]] || ! retryable_repair_failure; then
+    if [[ "$attempt" == "$REPAIR_MAX_ATTEMPTS" ]] || ! retryable_repair_failure; then
+      saved_response="$(cat "${TMPDIR_INSTALL}/api-response.json" 2>/dev/null || true)"
+      saved_status="$(cat "${TMPDIR_INSTALL}/api-status.txt" 2>/dev/null || true)"
+      saved_stderr="$(cat "${TMPDIR_INSTALL}/api-stderr.txt" 2>/dev/null || true)"
+      if recover_connected_device_from_status; then
+        return 0
+      fi
+      printf '%s' "$saved_response" > "${TMPDIR_INSTALL}/api-response.json"
+      printf '%s' "$saved_status" > "${TMPDIR_INSTALL}/api-status.txt"
+      printf '%s' "$saved_stderr" > "${TMPDIR_INSTALL}/api-stderr.txt"
       print_local_api_error POST "/v1/device/repair"
       die "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
     fi
-    log "vibetv: VibeTV did not answer yet; retrying (${attempt}/3)"
-    sleep 2
+    log "vibetv: VibeTV did not answer yet; retrying (${attempt}/${REPAIR_MAX_ATTEMPTS})"
+    sleep "$REPAIR_RETRY_DELAY"
   done
 
   discovered_target="$(printf '%s' "$response" | json_device_target)"
@@ -378,6 +423,14 @@ connect_vibetv() {
     die "VibeTV connected, but the Mac App did not return the device address. Rerun setup or use --target http://<device-ip>."
   fi
   log "vibetv: VibeTV is connected at ${TARGET}"
+}
+
+restart_service_with_discovered_target() {
+  [[ -n "$TARGET" ]] || return 0
+  log "vibetv: saving VibeTV address ${TARGET} for the background service"
+  restart_service
+  wait_for_api
+  verify_companion_version
 }
 
 update_vibetv_firmware() {
@@ -440,6 +493,7 @@ verify_final_status() {
 
 finish_device_setup() {
   connect_vibetv
+  restart_service_with_discovered_target
   update_vibetv_firmware
   verify_final_status
 }

--- a/scripts/test-control-center-companion-legacy-installer.sh
+++ b/scripts/test-control-center-companion-legacy-installer.sh
@@ -99,6 +99,17 @@ respond() {
   fi
 }
 
+repair_not_found() {
+  if [[ -n "$out" ]]; then
+    printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Make sure VibeTV is powered on and run device discovery again."}}' > "$out"
+  else
+    printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Make sure VibeTV is powered on and run device discovery again."}}'
+  fi
+  if [[ "$write_status" == "1" ]]; then
+    printf '404'
+  fi
+}
+
 case "$*" in
   *"/v1/status"*)
     if [[ -n "${FAKE_STATUS_OLD_ONCE:-}" && "$write_status" == "1" && ! -f "$FAKE_STATUS_OLD_ONCE" ]]; then
@@ -106,30 +117,31 @@ case "$*" in
       respond '{"ok":true,"companion":{"status":"ready","version":"9.9.8","features":{"themeInstallEnabled":true}},"device":{"target":"http://192.168.178.72","connected":true,"paired":true}}'
       exit 0
     fi
+    if [[ -n "${FAKE_STATUS_DEVICE_DISCONNECTED:-}" ]]; then
+      respond '{"ok":true,"companion":{"status":"ready","version":"9.9.9","features":{"themeInstallEnabled":true}},"device":{"target":"http://192.168.178.72","connected":false,"paired":true}}'
+      exit 0
+    fi
     respond '{"ok":true,"companion":{"status":"ready","version":"9.9.9","features":{"themeInstallEnabled":true}},"device":{"target":"http://192.168.178.72","connected":true,"paired":true}}'
     ;;
   *"/v1/device/repair"*)
     if [[ -n "${FAKE_REPAIR_ALWAYS_FAIL:-}" ]]; then
-      if [[ -n "$out" ]]; then
-        printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Make sure VibeTV is powered on and run device discovery again."}}' > "$out"
-      else
-        printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Make sure VibeTV is powered on and run device discovery again."}}'
-      fi
-      if [[ "$write_status" == "1" ]]; then
-        printf '404'
-      fi
+      repair_not_found
       exit 0
+    fi
+    if [[ -n "${FAKE_REPAIR_FAIL_COUNT:-}" && -n "${FAKE_REPAIR_COUNTER:-}" ]]; then
+      count=0
+      if [[ -f "$FAKE_REPAIR_COUNTER" ]]; then
+        count="$(cat "$FAKE_REPAIR_COUNTER" 2>/dev/null || printf '0')"
+      fi
+      if [[ "$count" -lt "$FAKE_REPAIR_FAIL_COUNT" ]]; then
+        printf '%s\n' "$((count + 1))" > "$FAKE_REPAIR_COUNTER"
+        repair_not_found
+        exit 0
+      fi
     fi
     if [[ -n "${FAKE_REPAIR_FAIL_ONCE:-}" && ! -f "$FAKE_REPAIR_FAIL_ONCE" ]]; then
       touch "$FAKE_REPAIR_FAIL_ONCE"
-      if [[ -n "$out" ]]; then
-        printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Make sure VibeTV is powered on and run device discovery again."}}' > "$out"
-      else
-        printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Make sure VibeTV is powered on and run device discovery again."}}'
-      fi
-      if [[ "$write_status" == "1" ]]; then
-        printf '404'
-      fi
+      repair_not_found
       exit 0
     fi
     respond '{"ok":true,"device":{"connected":true,"paired":true,"target":"http://192.168.178.72"}}'
@@ -232,7 +244,12 @@ run_installer() {
       FAKE_CURL_LOG="${root}/curl.log" \
       FAKE_REPAIR_FAIL_ONCE="${FAKE_REPAIR_FAIL_ONCE:-}" \
       FAKE_REPAIR_ALWAYS_FAIL="${FAKE_REPAIR_ALWAYS_FAIL:-}" \
+      FAKE_REPAIR_FAIL_COUNT="${FAKE_REPAIR_FAIL_COUNT:-}" \
+      FAKE_REPAIR_COUNTER="${FAKE_REPAIR_COUNTER:-}" \
       FAKE_STATUS_OLD_ONCE="${FAKE_STATUS_OLD_ONCE:-}" \
+      FAKE_STATUS_DEVICE_DISCONNECTED="${FAKE_STATUS_DEVICE_DISCONNECTED:-}" \
+      VIBETV_COMPANION_REPAIR_ATTEMPTS="${VIBETV_COMPANION_REPAIR_ATTEMPTS:-3}" \
+      VIBETV_COMPANION_REPAIR_RETRY_DELAY="${VIBETV_COMPANION_REPAIR_RETRY_DELAY:-0}" \
       VIBETV_COMPANION_GLOBAL_PLIST="${root}/global/Library/LaunchAgents/com.codexbar-display.companion-api.plist" \
       "$INSTALLER" "$@" \
       2>&1
@@ -268,6 +285,7 @@ run_restart_updates_daemon_launchagent() {
   assert_contains "$daemon_plist_body" "<string>daemon</string>"
   assert_contains "$daemon_plist_body" "<string>--api-addr</string>"
   assert_contains "$daemon_plist_body" "<string>127.0.0.1:47832</string>"
+  assert_not_contains "$daemon_plist_body" "<string></string>"
   assert_not_contains "$daemon_plist_body" "<string>api</string>"
   assert_contains "$launch_log" "bootout gui/$(id -u)/com.codexbar-display.companion-api"
   assert_contains "$launch_log" "bootout gui/$(id -u)/com.codexbar-display.daemon"
@@ -332,6 +350,9 @@ run_install_writes_integrated_daemon_launchagent() {
   assert_contains "$daemon_plist_body" "<string>daemon</string>"
   assert_contains "$daemon_plist_body" "<string>--api-addr</string>"
   assert_contains "$daemon_plist_body" "<string>127.0.0.1:47832</string>"
+  assert_contains "$daemon_plist_body" "<string>--target</string>"
+  assert_contains "$daemon_plist_body" "<string>http://192.168.178.72</string>"
+  assert_not_contains "$daemon_plist_body" "<string></string>"
   assert_not_contains "$daemon_plist_body" "<string>api</string>"
   assert_contains "$launch_log" "bootout gui/$(id -u)/com.codexbar-display.companion-api"
   assert_contains "$launch_log" "bootout gui/$(id -u)/com.codexbar-display.daemon"
@@ -393,6 +414,52 @@ run_install_retries_transient_repair_failure() {
   assert_contains "$output" "setup verified; Mac App ready, VibeTV connected, firmware 9.9.9"
 }
 
+run_install_waits_for_slow_repair_recovery() {
+  local root output repair_calls
+  root="${TMP_WORK_DIR}/slow-repair-recovery"
+  write_fake_commands "${root}/fake-bin"
+  prepare_home "${root}/home"
+  : > "${root}/launchctl.log"
+  : > "${root}/curl.log"
+  : > "${root}/api.log"
+
+  output="$(
+    FAKE_REPAIR_FAIL_COUNT=4 \
+      FAKE_REPAIR_COUNTER="${root}/repair-counter" \
+      VIBETV_COMPANION_REPAIR_ATTEMPTS=5 \
+      run_installer "$root" --version 9.9.9 --terminal-session
+  )" || {
+    printf '%s\n' "$output" >&2
+    die "expected install to pass after slow repair recovery"
+  }
+
+  repair_calls="$(grep -c "/v1/device/repair" "${root}/curl.log")"
+  [[ "$repair_calls" == "5" ]] || die "expected five repair calls, got ${repair_calls}"
+  assert_contains "$output" "VibeTV did not answer yet; retrying (4/5)"
+  assert_contains "$output" "VibeTV is connected at http://192.168.178.72"
+  assert_contains "$output" "setup verified; Mac App ready, VibeTV connected, firmware 9.9.9"
+}
+
+run_install_uses_connected_status_after_repair_timeout() {
+  local root output repair_calls
+  root="${TMP_WORK_DIR}/repair-timeout-connected-status"
+  write_fake_commands "${root}/fake-bin"
+  prepare_home "${root}/home"
+  : > "${root}/launchctl.log"
+  : > "${root}/curl.log"
+  : > "${root}/api.log"
+
+  output="$(FAKE_REPAIR_ALWAYS_FAIL=1 run_installer "$root" --version 9.9.9 --terminal-session)" || {
+    printf '%s\n' "$output" >&2
+    die "expected install to continue when status is already connected"
+  }
+
+  repair_calls="$(grep -c "/v1/device/repair" "${root}/curl.log")"
+  [[ "$repair_calls" == "3" ]] || die "expected three repair calls, got ${repair_calls}"
+  assert_contains "$output" "VibeTV is already connected at http://192.168.178.72"
+  assert_contains "$output" "setup verified; Mac App ready, VibeTV connected, firmware 9.9.9"
+}
+
 run_install_prints_repair_failure_details() {
   local root output status repair_calls
   root="${TMP_WORK_DIR}/repair-fail"
@@ -403,7 +470,7 @@ run_install_prints_repair_failure_details() {
   : > "${root}/api.log"
 
   set +e
-  output="$(FAKE_REPAIR_ALWAYS_FAIL=1 run_installer "$root" --version 9.9.9 --terminal-session)"
+  output="$(FAKE_REPAIR_ALWAYS_FAIL=1 FAKE_STATUS_DEVICE_DISCONNECTED=1 run_installer "$root" --version 9.9.9 --terminal-session)"
   status=$?
   set -e
   [[ "$status" != "0" ]] || die "expected install to fail when repair never succeeds"
@@ -434,12 +501,14 @@ run_install_restarts_when_old_api_version_answers() {
   assert_contains "$output" "Mac App answered with version 9.9.8; restarting once"
   assert_contains "$output" "setup verified; Mac App ready, VibeTV connected, firmware 9.9.9"
   kickstarts="$(grep -c "kickstart -k gui/$(id -u)/com.codexbar-display.daemon" "${root}/launchctl.log")"
-  [[ "$kickstarts" == "2" ]] || die "expected initial start plus one restart, got ${kickstarts}"
+  [[ "$kickstarts" == "3" ]] || die "expected initial start, version restart, and target restart, got ${kickstarts}"
 }
 
 run_install_writes_integrated_daemon_launchagent
 run_install_disables_global_legacy_launchagent
 run_install_retries_transient_repair_failure
+run_install_waits_for_slow_repair_recovery
+run_install_uses_connected_status_after_repair_timeout
 run_install_prints_repair_failure_details
 run_install_restarts_when_old_api_version_answers
 run_restart_updates_daemon_launchagent


### PR DESCRIPTION
## Summary
- avoid writing `--target ""` into the Mac App LaunchAgent
- persist the discovered VibeTV IP by restarting the service after repair/discovery
- wait longer for transient `device_not_found` during setup and continue if `/v1/status` already reports the device connected
- preserve the original repair API error details when the final fallback does not recover

## Tests
- `scripts/test-control-center-companion-legacy-installer.sh`
- `go test ./cmd/codexbar-display ./internal/companionapi ./internal/setup`
- `scripts/test-control-center-release-workflow.sh`
- `scripts/test-control-center-customer-ready-gate.sh`
- `scripts/test-install-sh-control-center-migration.sh`
- `git diff --check`