### PR TITLE
Use frame theme specs in VibeTV overview preview

### DIFF
--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -1417,6 +1417,87 @@ async function testOverviewRendersThemeSpecAssetTypes(browser, appUrl) {
     await assertNoMobileOverflow(page);
     await page.close();
   }
+
+  const page = await newCustomerPage(browser, appUrl, {
+    viewport: desktopViewport,
+  });
+  const installRequests = [];
+  await routeCompanionOnline(page, installRequests, () => {}, {
+    companionVersion: "1.0.33",
+    device: {
+      ...companionDevice,
+      activeTheme: "mini-classic",
+      firmware: "1.0.32",
+      stream: {
+        healthy: true,
+        running: true,
+      },
+      display: {
+        themeSpec: {
+          active: true,
+          renderOk: true,
+        },
+      },
+    },
+    displayFrameOverride: {
+      provider: "codex",
+      label: "Codex",
+      session: 73,
+      weekly: 37,
+      resetSecs: 5400,
+      usageMode: "remaining",
+      activity: "coding",
+      themeSpec: {
+        v: 1,
+        id: "frame-spec",
+        rev: 9,
+        bg: "#000000",
+        p: [
+          {
+            t: "tx",
+            x: 20,
+            y: 18,
+            w: 200,
+            v: "FRAME SPEC",
+            s: 2,
+            al: "center",
+            c: "#CCFF00",
+          },
+          {
+            t: "tx",
+            x: 20,
+            y: 58,
+            v: "{session}% {usageMode}",
+            s: 2,
+            c: "#FFFFFF",
+          },
+          {
+            t: "p",
+            x: 20,
+            y: 96,
+            w: 160,
+            h: 14,
+            b: "session",
+            c: "#CCFF00",
+            bg: "#111111",
+          },
+        ],
+      },
+    },
+  });
+
+  await page.goto(appUrl, { waitUntil: "networkidle" });
+  const renderedFrameSpec = page.getByRole("img", {
+    name: /Rendered VibeTV theme frame-spec showing Codex, 73% session remaining, 37% weekly remaining/,
+  });
+  await renderedFrameSpec.waitFor({ timeout: 10_000 });
+  await renderedFrameSpec.getByText("FRAME SPEC").waitFor({ timeout: 10_000 });
+  await renderedFrameSpec
+    .getByText("73% remaining")
+    .waitFor({ timeout: 10_000 });
+  assertNoInstallRequests(installRequests);
+  await assertNoMobileOverflow(page);
+  await page.close();
 }
 
 async function testInstallLinkKeepsRequestedTheme(browser, appUrl) {
@@ -2036,6 +2117,7 @@ async function routeCompanionOnline(
     usageResponse,
     usageStatus = 200,
     displayFrameStatus = 200,
+    displayFrameOverride,
     repairError = false,
   } = {},
 ) {
@@ -2258,7 +2340,7 @@ async function routeCompanionOnline(
         });
         return;
       }
-      const frame = displayFrameFromUsageResponse(usageResponse);
+      const frame = displayFrameOverride || displayFrameFromUsageResponse(usageResponse);
       if (!frame) {
         await route.fulfill({
           status: 404,

--- a/apps/control-center/src/app/api/display-frame/latest/route.ts
+++ b/apps/control-center/src/app/api/display-frame/latest/route.ts
@@ -21,6 +21,7 @@ type RawDisplayFrame = {
   sessionTokens?: unknown;
   weekTokens?: unknown;
   totalTokens?: unknown;
+  themeSpec?: unknown;
 };
 
 type DisplayFrame = {
@@ -34,6 +35,7 @@ type DisplayFrame = {
   sessionTokens?: number;
   weekTokens?: number;
   totalTokens?: number;
+  themeSpec?: Record<string, unknown>;
 };
 
 export async function GET() {
@@ -86,6 +88,7 @@ function sanitizeFrame(raw: RawDisplayFrame | undefined): DisplayFrame | null {
   const sessionTokens = nonNegativeInteger(raw.sessionTokens);
   const weekTokens = nonNegativeInteger(raw.weekTokens);
   const totalTokens = nonNegativeInteger(raw.totalTokens);
+  const themeSpec = sanitizedThemeSpec(raw.themeSpec);
 
   if (defaultedToRemaining) {
     // Legacy Companion frames stored used percents, while the device renders them as remaining.
@@ -120,6 +123,9 @@ function sanitizeFrame(raw: RawDisplayFrame | undefined): DisplayFrame | null {
   if (totalTokens != null) {
     frame.totalTokens = totalTokens;
   }
+  if (themeSpec) {
+    frame.themeSpec = themeSpec;
+  }
 
   return frame;
 }
@@ -148,4 +154,24 @@ function nonNegativeInteger(value: unknown): number | null {
     return null;
   }
   return Math.round(value);
+}
+
+function sanitizedThemeSpec(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  try {
+    const raw = JSON.stringify(value);
+    if (!raw || raw.length > 4096) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
 }

--- a/apps/control-center/src/components/live-vibetv-preview.tsx
+++ b/apps/control-center/src/components/live-vibetv-preview.tsx
@@ -51,6 +51,7 @@ type DisplayFrame = {
   sessionTokens?: number;
   weekTokens?: number;
   totalTokens?: number;
+  themeSpec?: ThemeSpec | null;
 };
 
 type LocalDisplayFrameRequestInit = RequestInit & {
@@ -141,10 +142,11 @@ type SpriteRect = {
 
 export function LiveVibeTVPreview({ device, usage }: LiveVibeTVPreviewProps) {
   const provider = currentUsageProvider(usage);
-  const themeId = activeThemeId(device);
   const [displayFrame, setDisplayFrame] = useState<DisplayFrameSnapshot | null>(
     null,
   );
+  const frameSpec = displayFrame?.frame?.themeSpec || null;
+  const themeId = activeThemeId(device) || themeIdFromSpec(frameSpec);
   const frame = buildFrameData(
     provider,
     displayFrame?.savedAt || usage?.generatedAt,
@@ -157,6 +159,9 @@ export function LiveVibeTVPreview({ device, usage }: LiveVibeTVPreviewProps) {
     : packState?.themeId === themeId
       ? packState.status
       : "loading";
+  const renderedSpec = frameSpec || pack?.spec || null;
+  const renderedThemeId =
+    themeIdFromSpec(frameSpec) || pack?.themeId || themeId;
 
   useEffect(() => {
     if (!themeId) {
@@ -228,12 +233,12 @@ export function LiveVibeTVPreview({ device, usage }: LiveVibeTVPreviewProps) {
   return (
     <figure className="w-full max-w-[540px]">
       <VibeTVCaseShell>
-        {pack?.spec ? (
+        {renderedSpec ? (
           <ThemeSpecSVG
-            assets={pack.assets || {}}
+            assets={pack?.assets || {}}
             frame={frame}
-            spec={pack.spec}
-            themeId={pack.themeId || themeId}
+            spec={renderedSpec}
+            themeId={renderedThemeId}
           />
         ) : (
           <ThemeSpecLoading status={packStatus} themeId={themeId} />
@@ -701,6 +706,16 @@ function activeThemeId(device: DeviceInfo | null): string {
     return theme;
   }
   return "";
+}
+
+function themeIdFromSpec(spec: ThemeSpec | null | undefined): string {
+  const rawId =
+    typeof spec?.themeId === "string"
+      ? spec.themeId
+      : typeof spec?.id === "string"
+        ? spec.id
+        : "";
+  return rawId.trim().toLowerCase();
 }
 
 function renderTextPrimitive(primitive: ThemePrimitive, frame: FrameData): string {


### PR DESCRIPTION
## Summary
- keep sanitized `themeSpec` data in the Control Center display-frame API
- render frame-provided ThemeSpecs before falling back to local theme packs
- add a browser-flow check that proves Overview uses the frame ThemeSpec when it differs from the local active theme pack

## Verification
- `npm run lint`
- `npm run test:customer-flows`

## Hardware check
- read-only checks only: local Companion status/device and VibeTV `/assets` list
- connected device reported firmware `1.0.35`, active theme `synthwave`, render ok
- no hardware writes, theme switches, installs, firmware updates, or main/release actions performed