### PR TITLE
[codex] Add Mac app release status reporting

### DIFF
--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -207,6 +207,10 @@ async function main() {
     );
     await testSettingsStayCustomerOnly(browser, appContext.appUrl);
     await testUpdatesShowCustomerCompanionAction(browser, appContext.appUrl);
+    await testUpdatesShowLegacyCompanionReleaseFallback(
+      browser,
+      appContext.appUrl,
+    );
     await testOverviewSeparatesMacAppAndFirmwareVersions(
       browser,
       appContext.appUrl,
@@ -941,6 +945,33 @@ async function testUpdatesShowCustomerCompanionAction(browser, appUrl) {
     parseJSON(macAppUpdateRequests[0])?.version === "1.0.99",
     `Mac App update should request latest version, got ${macAppUpdateRequests[0]}`,
   );
+  assertNoInstallRequests(installRequests);
+  await assertNoMobileOverflow(page);
+  await page.close();
+}
+
+async function testUpdatesShowLegacyCompanionReleaseFallback(browser, appUrl) {
+  const page = await newCustomerPage(browser, appUrl, { viewport });
+  const installRequests = [];
+  await routeCompanionOnline(page, installRequests, () => {}, {
+    legacyCompanionRelease: true,
+  });
+
+  await page.goto(appUrl, { waitUntil: "networkidle" });
+  await page.getByRole("button", { name: "Updates" }).click();
+  await page.getByRole("button", { name: "Update now" }).waitFor({
+    timeout: 10_000,
+  });
+  const macAppSection = page.locator("section.border-b").filter({
+    has: page.getByRole("heading", { name: "Mac App" }),
+  });
+  await macAppSection
+    .getByText("1.0.32", { exact: true })
+    .waitFor({ timeout: 10_000 });
+  await macAppSection
+    .getByText("1.0.99", { exact: true })
+    .waitFor({ timeout: 10_000 });
+
   assertNoInstallRequests(installRequests);
   await assertNoMobileOverflow(page);
   await page.close();
@@ -2022,6 +2053,7 @@ async function routeCompanionOnline(
       macAppSelfUpdateEnabled: true,
     },
     companionVersion = "1.0.32",
+    legacyCompanionRelease = false,
     device = companionDevice,
     onDiscover,
     onPair,
@@ -2380,10 +2412,11 @@ async function routeCompanionOnline(
         contentType: "application/json",
         body: JSON.stringify({
           ok: true,
-          companion: {
-            version: currentCompanionVersion,
-            features: companionFeatures,
-          },
+          companion: companionPayload(
+            currentCompanionVersion,
+            companionFeatures,
+            legacyCompanionRelease,
+          ),
           device: currentDevice,
         }),
       });
@@ -2407,10 +2440,11 @@ async function routeCompanionOnline(
         contentType: "application/json",
         body: JSON.stringify({
           ok: true,
-          companion: {
-            version: currentCompanionVersion,
-            features: companionFeatures,
-          },
+          companion: companionPayload(
+            currentCompanionVersion,
+            companionFeatures,
+            legacyCompanionRelease,
+          ),
           device: currentDevice,
         }),
       });
@@ -2444,10 +2478,11 @@ async function routeCompanionOnline(
         body: JSON.stringify({
           ok: true,
           generatedAt: "2026-06-19T12:00:00.000Z",
-          companion: {
-            version: currentCompanionVersion,
-            features: companionFeatures,
-          },
+          companion: companionPayload(
+            currentCompanionVersion,
+            companionFeatures,
+            legacyCompanionRelease,
+          ),
           device: currentDevice,
           checks: [
             {
@@ -2558,6 +2593,56 @@ function companionPath(route) {
     return `/${pathname.slice(proxyPrefix.length)}`;
   }
   return pathname;
+}
+
+function companionPayload(version, features, legacyRelease = false) {
+  const payload = {
+    version,
+    features,
+  };
+  if (!legacyRelease) {
+    payload.update = macAppReleaseInfo(version);
+  }
+  return payload;
+}
+
+function macAppReleaseInfo(installedVersion) {
+  const latestVersion = "1.0.99";
+  const updateAvailable = compareSemver(latestVersion, installedVersion) > 0;
+  return {
+    checkedAt: "2026-06-23T12:00:00.000Z",
+    status: "available",
+    release: `v${latestVersion}`,
+    latestVersion,
+    installedVersion,
+    updateAvailable,
+    message: updateAvailable
+      ? "Mac App update is available."
+      : "Mac App is up to date.",
+  };
+}
+
+function compareSemver(left, right) {
+  const leftParts = parseSemver(left);
+  const rightParts = parseSemver(right);
+  for (let index = 0; index < 3; index += 1) {
+    const diff = leftParts[index] - rightParts[index];
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+function parseSemver(version) {
+  const match = String(version || "")
+    .trim()
+    .replace(/^v/i, "")
+    .match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    return [0, 0, 0];
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
 async function startFixtureServer() {

--- a/apps/control-center/src/components/control-center-app.tsx
+++ b/apps/control-center/src/components/control-center-app.tsx
@@ -17,6 +17,7 @@ import {
   type SupportDiagnostics,
   type UsageSnapshot,
 } from "./control-center-types";
+import { useCompanionRelease } from "./companion-installer-actions";
 import { LogsScreen } from "./logs-screen";
 import { OverviewScreen } from "./overview-screen";
 import { SetupScreen } from "./setup-screen";
@@ -1226,15 +1227,39 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
     },
     [deviceBoard, deviceFirmware],
   );
+  const hasCompanionReleaseInfo = Boolean(companionInfo?.update);
+  const shouldUseLegacyCompanionRelease = Boolean(
+    companionStatus === "online" &&
+      companionInfo?.version &&
+      !hasCompanionReleaseInfo,
+  );
+  const {
+    refresh: refreshLegacyCompanionRelease,
+    release: legacyCompanionRelease,
+  } = useCompanionRelease(companionInfo?.version, {
+    enabled: shouldUseLegacyCompanionRelease,
+  });
 
-  const checkFirmwareUpdates = useCallback(async () => {
+  const checkUpdates = useCallback(async () => {
     setBusyAction("firmware-check");
     try {
-      await refreshFirmwareUpdate();
+      const checks: Array<Promise<unknown>> = [
+        checkCompanion({ quiet: true }),
+        refreshFirmwareUpdate(),
+      ];
+      if (shouldUseLegacyCompanionRelease) {
+        checks.push(refreshLegacyCompanionRelease());
+      }
+      await Promise.all(checks);
     } finally {
       setBusyAction(null);
     }
-  }, [refreshFirmwareUpdate]);
+  }, [
+    checkCompanion,
+    refreshFirmwareUpdate,
+    refreshLegacyCompanionRelease,
+    shouldUseLegacyCompanionRelease,
+  ]);
 
   const installMacAppUpdate = useCallback(
     async (version?: string) => {
@@ -1664,6 +1689,11 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
       ? firmwareUpdate
       : null;
   const firmwareUpdateAvailable = hasFirmwareUpdate(effectiveFirmwareUpdate);
+  const companionRelease = companionInfo?.update || legacyCompanionRelease || null;
+  const macAppUpdateAvailable = Boolean(
+    companionRelease?.updateAvailable && macAppUpdateStatus?.phase !== "complete",
+  );
+  const anyUpdateAvailable = firmwareUpdateAvailable || macAppUpdateAvailable;
   const imageNeedsReload = deviceImageIsStuck(device);
   const setupComplete = Boolean(
     !setupPreviewStep &&
@@ -1721,7 +1751,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
       activeTab={activeShellTab}
       disabledTabs={disabledTabs}
       device={device}
-      firmwareUpdateAvailable={firmwareUpdateAvailable}
+      updateAvailable={anyUpdateAvailable}
       onTabChange={(tab) => {
         if (disabledTabs.includes(tab)) {
           return;
@@ -1752,6 +1782,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
       {activeShellTab === "overview" ? (
         <OverviewScreen
           busyAction={busyAction}
+          companionRelease={companionRelease}
           companionVersion={companionInfo?.version}
           companionStatus={companionStatus}
           device={device}
@@ -1805,6 +1836,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
       {activeShellTab === "updates" ? (
         <UpdatesScreen
           busyAction={busyAction}
+          companionRelease={companionRelease}
           companionStatus={companionStatus}
           companionVersion={companionInfo?.version}
           device={device}
@@ -1813,7 +1845,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
             companionInfo?.features?.macAppSelfUpdateEnabled,
           )}
           macAppUpdateStatus={macAppUpdateStatus}
-          onCheckUpdates={checkFirmwareUpdates}
+          onCheckUpdates={checkUpdates}
           onCreateReport={() => {
             setActiveTab("logs");
             void loadSupportDiagnostics();

--- a/apps/control-center/src/components/control-center-shell.tsx
+++ b/apps/control-center/src/components/control-center-shell.tsx
@@ -24,7 +24,7 @@ type ControlCenterShellProps = {
   children: ReactNode;
   device: DeviceInfo | null;
   disabledTabs?: ActiveTab[];
-  firmwareUpdateAvailable?: boolean;
+  updateAvailable?: boolean;
 };
 
 const NAV_ITEMS: ShellNavItem[] = [
@@ -71,7 +71,7 @@ export function ControlCenterShell({
   children,
   device,
   disabledTabs = [],
-  firmwareUpdateAvailable = false,
+  updateAvailable = false,
 }: ControlCenterShellProps) {
   const imageStuck = deviceImageIsStuck(device);
   const setupConnected = deviceSetupIsUsable(device);
@@ -104,7 +104,7 @@ export function ControlCenterShell({
                 disabled={isTabDisabled(item.id)}
                 item={item}
                 key={item.id}
-                notify={item.id === "updates" && firmwareUpdateAvailable}
+                notify={item.id === "updates" && updateAvailable}
                 onClick={() => onTabChange(item.id)}
               />
             ))}
@@ -152,7 +152,7 @@ export function ControlCenterShell({
                   <span className="sr-only min-[560px]:not-sr-only">
                     {item.label}
                   </span>
-                  {item.id === "updates" && firmwareUpdateAvailable ? (
+                  {item.id === "updates" && updateAvailable ? (
                     <span
                       aria-label="Update available"
                       className={`size-2.5 rounded-full ${

--- a/apps/control-center/src/components/control-center-types.ts
+++ b/apps/control-center/src/components/control-center-types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { CompanionReleaseInfo } from "@/lib/companion-release";
 export type { ThemeProduct } from "@/lib/themes";
 
 export const VIBETV_COLORS = {
@@ -24,6 +25,7 @@ export type CompanionStatus = "unknown" | "online" | "missing";
 export type CompanionInfo = {
   status?: string;
   version?: string;
+  update?: CompanionReleaseInfo;
   features?: {
     themeInstallEnabled?: boolean;
     macAppSelfUpdateEnabled?: boolean;

--- a/apps/control-center/src/components/overview-screen.tsx
+++ b/apps/control-center/src/components/overview-screen.tsx
@@ -10,6 +10,7 @@ import {
   Wifi,
 } from "lucide-react";
 import type { ReactNode } from "react";
+import type { CompanionReleaseInfo } from "@/lib/companion-release";
 import { hasFirmwareUpdate, type FirmwareUpdateInfo } from "@/lib/firmware";
 import {
   deviceImageIsStuck,
@@ -23,6 +24,7 @@ import { LiveVibeTVPreview } from "./live-vibetv-preview";
 
 type OverviewScreenProps = {
   companionVersion?: string;
+  companionRelease?: CompanionReleaseInfo | null;
   companionStatus: CompanionStatus;
   deviceState: DeviceState;
   device: DeviceInfo | null;
@@ -35,6 +37,7 @@ type OverviewScreenProps = {
 export function OverviewScreen({
   busyAction,
   companionVersion,
+  companionRelease,
   companionStatus,
   deviceState,
   device,
@@ -52,6 +55,7 @@ export function OverviewScreen({
     reloadingImage,
   });
   const firmwareUpdateAvailable = hasFirmwareUpdate(firmwareUpdate);
+  const macAppUpdateAvailable = Boolean(companionRelease?.updateAvailable);
 
   return (
     <div className="mx-auto max-w-[1180px]">
@@ -68,6 +72,7 @@ export function OverviewScreen({
 
           <dl className="mt-9 max-w-[420px]">
             <StatusRow
+              badge={macAppUpdateAvailable ? "Update" : undefined}
               icon={<Wifi size={18} aria-hidden />}
               label="Mac App"
               value={labelForCompanion(companionStatus, companionVersion)}

--- a/apps/control-center/src/components/updates-screen.tsx
+++ b/apps/control-center/src/components/updates-screen.tsx
@@ -13,7 +13,6 @@ import {
 import { useMemo, useState, type ReactNode } from "react";
 import type { CompanionReleaseInfo } from "@/lib/companion-release";
 import { hasFirmwareUpdate, type FirmwareUpdateInfo } from "@/lib/firmware";
-import { useCompanionRelease } from "./companion-installer-actions";
 import {
   buildMacAppTerminalCommand,
   currentControlCenterOrigin,
@@ -58,6 +57,7 @@ export type UpdatesScreenProps = {
   companionStatus: UpdatesCompanionStatus;
   device: UpdatesDeviceInfo | null;
   companionVersion?: string;
+  companionRelease?: CompanionReleaseInfo | null;
   macAppSelfUpdateEnabled?: boolean;
   firmwareUpdate?: FirmwareUpdateInfo | null;
   onCheckUpdates?: () => Promise<void> | void;
@@ -73,6 +73,7 @@ export function UpdatesScreen({
   companionStatus,
   device,
   companionVersion,
+  companionRelease = null,
   macAppSelfUpdateEnabled = false,
   firmwareUpdate,
   onCheckUpdates,
@@ -83,11 +84,6 @@ export function UpdatesScreen({
   macAppUpdateStatus,
   updateStatus,
 }: UpdatesScreenProps) {
-  const {
-    busy: companionCheckBusy,
-    refresh: refreshCompanionRelease,
-    release: companionRelease,
-  } = useCompanionRelease(companionVersion);
   const [macAppCommandCopied, setMacAppCommandCopied] = useState(false);
   const macAppTerminalCommand = useMemo(
     () => buildMacAppTerminalCommand(currentControlCenterOrigin()),
@@ -99,7 +95,7 @@ export function UpdatesScreen({
   const checking = Boolean(canCheckFirmware && !firmwareUpdate);
   const macAppRunning = companionStatus === "online";
   const checkingMacApp = Boolean(macAppRunning && !companionRelease);
-  const checkingUpdates = checking || checkingMacApp || companionCheckBusy;
+  const checkingUpdates = checking || checkingMacApp;
   const latestFirmware =
     firmwareUpdate?.latestFirmware || (checking ? "Checking" : "Not available");
   const updateAvailable = hasFirmwareUpdate(firmwareUpdate);
@@ -119,7 +115,9 @@ export function UpdatesScreen({
     macAppUpdateStatus?.phase === "installing";
   const installingAnyUpdate = installingUpdate || installingMacAppUpdate;
   const creatingReport = busyAction === "diagnostics";
-  const checkFailed = firmwareUpdate?.status === "check_failed";
+  const macAppCheckFailed =
+    macAppRunning && companionRelease?.status === "check_failed";
+  const checkFailed = firmwareUpdate?.status === "check_failed" || macAppCheckFailed;
   const title = checkingUpdates
     ? "Checking updates"
     : checkFailed
@@ -172,10 +170,7 @@ export function UpdatesScreen({
     }
 
     if (!anyUpdateAvailable) {
-      await Promise.all([
-        refreshCompanionRelease(),
-        onCheckUpdates ? Promise.resolve(onCheckUpdates()) : Promise.resolve(),
-      ]);
+      await onCheckUpdates?.();
       return;
     }
 
@@ -225,10 +220,7 @@ export function UpdatesScreen({
             onClick={runPrimaryUpdate}
             updateAvailable={anyUpdateAvailable}
             updateReady={Boolean(
-              primaryCopyCommand ||
-                anyUpdateAvailable ||
-                onCheckUpdates ||
-                refreshCompanionRelease,
+              primaryCopyCommand || anyUpdateAvailable || onCheckUpdates,
             )}
           />
         </div>
@@ -605,6 +597,9 @@ function companionReleaseLabel({
   if (macAppRunning) {
     if (release?.updateAvailable) {
       return "Update available";
+    }
+    if (release?.status === "check_failed") {
+      return "Check failed";
     }
     return "Ready";
   }

--- a/apps/control-center/src/lib/companion-release.ts
+++ b/apps/control-center/src/lib/companion-release.ts
@@ -1,6 +1,7 @@
 export type CompanionReleaseStatus =
   | "available"
   | "missing_asset"
+  | "disabled"
   | "check_failed";
 
 export type CompanionReleaseInfo = {

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -50,6 +50,10 @@ const (
 	macAppUpdateJobTime     = 8 * time.Minute
 	usageFallbackFetchTime  = 15 * time.Second
 	macAppInstallerURL      = "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install-control-center-companion.sh"
+	macAppReleaseAPIEnvVar  = "CODEXBAR_DISPLAY_MAC_APP_RELEASE_API_URL"
+	macAppReleaseAPIURL     = "https://api.github.com/repos/DreamyTalesPAN/CodexBar-Display/releases/latest"
+	macAppReleaseCheckGap   = 6 * time.Hour
+	macAppReleaseTimeout    = 5 * time.Second
 )
 
 type Options struct {
@@ -61,31 +65,36 @@ type Options struct {
 }
 
 type Server struct {
-	addr             string
-	home             string
-	allowedOrigins   map[string]struct{}
-	client           *http.Client
-	loadConfig       func(string) (runtimeconfig.Config, error)
-	saveConfig       func(string, runtimeconfig.Config) error
-	installTheme     func(context.Context, themeinstall.Options) (themeinstall.Result, error)
-	runSetup         func(context.Context, setup.Options) error
-	subnetTargets    func() []string
-	streamStatus     func(context.Context, string) displayStreamInfo
-	waitStream       func(context.Context, string) displayStreamInfo
-	refreshStream    func(context.Context, string) error
-	loadUsage        func(time.Time) (daemon.PersistedUsage, bool)
-	fetchUsage       func(context.Context) ([]codexbar.ParsedFrame, error)
-	updateFirmware   func(context.Context, string, runtimeconfig.Config, firmwareUpdateRequest, io.Writer) error
-	updateMacApp     func(context.Context, string, string, macAppUpdateRequest, io.Writer) error
-	installJobsMu    sync.Mutex
-	installJobs      map[string]*themeInstallJob
-	nextInstallJob   uint64
-	updateJobsMu     sync.Mutex
-	updateJobs       map[string]*firmwareUpdateJob
-	nextUpdateJob    uint64
-	macAppUpdateMu   sync.Mutex
-	macAppUpdateJobs map[string]*macAppUpdateJob
-	nextMacAppUpdate uint64
+	addr                   string
+	home                   string
+	allowedOrigins         map[string]struct{}
+	client                 *http.Client
+	loadConfig             func(string) (runtimeconfig.Config, error)
+	saveConfig             func(string, runtimeconfig.Config) error
+	installTheme           func(context.Context, themeinstall.Options) (themeinstall.Result, error)
+	runSetup               func(context.Context, setup.Options) error
+	subnetTargets          func() []string
+	streamStatus           func(context.Context, string) displayStreamInfo
+	waitStream             func(context.Context, string) displayStreamInfo
+	refreshStream          func(context.Context, string) error
+	loadUsage              func(time.Time) (daemon.PersistedUsage, bool)
+	fetchUsage             func(context.Context) ([]codexbar.ParsedFrame, error)
+	updateFirmware         func(context.Context, string, runtimeconfig.Config, firmwareUpdateRequest, io.Writer) error
+	updateMacApp           func(context.Context, string, string, macAppUpdateRequest, io.Writer) error
+	fetchMacAppRelease     func(context.Context) (githubRelease, error)
+	installJobsMu          sync.Mutex
+	installJobs            map[string]*themeInstallJob
+	nextInstallJob         uint64
+	updateJobsMu           sync.Mutex
+	updateJobs             map[string]*firmwareUpdateJob
+	nextUpdateJob          uint64
+	macAppUpdateMu         sync.Mutex
+	macAppUpdateJobs       map[string]*macAppUpdateJob
+	nextMacAppUpdate       uint64
+	macAppReleaseMu        sync.Mutex
+	macAppReleaseChecked   bool
+	macAppReleaseCheckedAt time.Time
+	macAppReleaseCache     companionReleaseInfo
 }
 
 type apiError struct {
@@ -291,14 +300,29 @@ type diagnosticCheck struct {
 }
 
 type companion struct {
-	Status   string            `json:"status"`
-	Version  string            `json:"version"`
-	Features companionFeatures `json:"features"`
+	Status   string               `json:"status"`
+	Version  string               `json:"version"`
+	Update   companionReleaseInfo `json:"update"`
+	Features companionFeatures    `json:"features"`
 }
 
 type companionFeatures struct {
 	ThemeInstallEnabled     bool `json:"themeInstallEnabled"`
 	MacAppSelfUpdateEnabled bool `json:"macAppSelfUpdateEnabled"`
+}
+
+type companionReleaseInfo struct {
+	CheckedAt        string `json:"checkedAt"`
+	Status           string `json:"status"`
+	Release          string `json:"release,omitempty"`
+	LatestVersion    string `json:"latestVersion,omitempty"`
+	InstalledVersion string `json:"installedVersion,omitempty"`
+	UpdateAvailable  bool   `json:"updateAvailable"`
+	Message          string `json:"message"`
+}
+
+type githubRelease struct {
+	TagName string `json:"tag_name"`
 }
 
 type settingsResponse struct {
@@ -465,25 +489,26 @@ func New(opts Options) (*Server, error) {
 		}
 	}
 	return &Server{
-		addr:             addr,
-		home:             home,
-		allowedOrigins:   origins,
-		client:           client,
-		loadConfig:       runtimeconfig.Load,
-		saveConfig:       runtimeconfig.Save,
-		installTheme:     themeinstall.Install,
-		runSetup:         setup.Run,
-		subnetTargets:    localSubnetTargets,
-		streamStatus:     inspectDisplayStream,
-		waitStream:       waitForDisplayStream,
-		refreshStream:    opts.RefreshDisplayStream,
-		loadUsage:        daemon.LoadPersistedUsage,
-		fetchUsage:       codexbar.FetchAllProviders,
-		updateFirmware:   runFirmwareUpdateCommand,
-		updateMacApp:     runMacAppUpdateCommand,
-		installJobs:      make(map[string]*themeInstallJob),
-		updateJobs:       make(map[string]*firmwareUpdateJob),
-		macAppUpdateJobs: make(map[string]*macAppUpdateJob),
+		addr:               addr,
+		home:               home,
+		allowedOrigins:     origins,
+		client:             client,
+		loadConfig:         runtimeconfig.Load,
+		saveConfig:         runtimeconfig.Save,
+		installTheme:       themeinstall.Install,
+		runSetup:           setup.Run,
+		subnetTargets:      localSubnetTargets,
+		streamStatus:       inspectDisplayStream,
+		waitStream:         waitForDisplayStream,
+		refreshStream:      opts.RefreshDisplayStream,
+		loadUsage:          daemon.LoadPersistedUsage,
+		fetchUsage:         codexbar.FetchAllProviders,
+		updateFirmware:     runFirmwareUpdateCommand,
+		updateMacApp:       runMacAppUpdateCommand,
+		fetchMacAppRelease: fetchLatestMacAppRelease,
+		installJobs:        make(map[string]*themeInstallJob),
+		updateJobs:         make(map[string]*firmwareUpdateJob),
+		macAppUpdateJobs:   make(map[string]*macAppUpdateJob),
 	}, nil
 }
 
@@ -605,7 +630,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, statusResponse{
 		OK:        true,
-		Companion: s.companionInfo(),
+		Companion: s.companionInfo(r.Context()),
 		Device:    device,
 	})
 }
@@ -768,7 +793,7 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, diagnosticsResponse{
 			OK:          true,
 			GeneratedAt: time.Now().UTC().Format(time.RFC3339),
-			Companion:   s.companionInfo(),
+			Companion:   s.companionInfo(r.Context()),
 			Device:      device,
 			Checks:      checks,
 		})
@@ -792,7 +817,7 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, diagnosticsResponse{
 			OK:          true,
 			GeneratedAt: time.Now().UTC().Format(time.RFC3339),
-			Companion:   s.companionInfo(),
+			Companion:   s.companionInfo(r.Context()),
 			Device:      device,
 			Checks:      checks,
 		})
@@ -868,21 +893,182 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, diagnosticsResponse{
 		OK:          true,
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
-		Companion:   s.companionInfo(),
+		Companion:   s.companionInfo(r.Context()),
 		Device:      device,
 		Checks:      checks,
 	})
 }
 
-func (s *Server) companionInfo() companion {
+func (s *Server) companionInfo(ctx context.Context) companion {
 	return companion{
 		Status:  "ready",
 		Version: buildinfo.NormalizedVersion(),
+		Update:  s.macAppReleaseInfo(ctx),
 		Features: companionFeatures{
 			ThemeInstallEnabled:     themeInstallEnabled(),
 			MacAppSelfUpdateEnabled: true,
 		},
 	}
+}
+
+func (s *Server) macAppReleaseInfo(ctx context.Context) companionReleaseInfo {
+	installedVersion := normalizeMacAppReleaseVersion(buildinfo.NormalizedVersion())
+	now := time.Now().UTC()
+
+	s.macAppReleaseMu.Lock()
+	if s.macAppReleaseChecked &&
+		s.macAppReleaseCache.InstalledVersion == installedVersion &&
+		now.Sub(s.macAppReleaseCheckedAt) >= 0 &&
+		now.Sub(s.macAppReleaseCheckedAt) < macAppReleaseCheckGap {
+		cached := s.macAppReleaseCache
+		s.macAppReleaseMu.Unlock()
+		return cached
+	}
+	s.macAppReleaseMu.Unlock()
+
+	checkedAt := now.Format(time.RFC3339)
+	info := companionReleaseInfo{
+		CheckedAt:        checkedAt,
+		Status:           "check_failed",
+		InstalledVersion: installedVersion,
+		UpdateAvailable:  false,
+		Message:          "Mac App check failed.",
+	}
+
+	if macAppReleaseCheckDisabled() {
+		info.Status = "disabled"
+		info.Message = "Mac App update check is disabled."
+		s.cacheMacAppReleaseInfo(now, info)
+		return info
+	}
+
+	fetch := s.fetchMacAppRelease
+	if fetch == nil {
+		fetch = fetchLatestMacAppRelease
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, macAppReleaseTimeout)
+	defer cancel()
+	release, err := fetch(checkCtx)
+	if err != nil {
+		s.cacheMacAppReleaseInfo(now, info)
+		return info
+	}
+
+	releaseTag := strings.TrimSpace(release.TagName)
+	latestVersion := normalizeMacAppReleaseVersion(releaseTag)
+	if latestVersion == "" {
+		info.Release = releaseTag
+		s.cacheMacAppReleaseInfo(now, info)
+		return info
+	}
+
+	updateAvailable := installedVersion != "" && compareMacAppReleaseVersions(latestVersion, installedVersion) > 0
+	info = companionReleaseInfo{
+		CheckedAt:        checkedAt,
+		Status:           "available",
+		Release:          releaseTag,
+		LatestVersion:    latestVersion,
+		InstalledVersion: installedVersion,
+		UpdateAvailable:  updateAvailable,
+		Message:          "Mac App is up to date.",
+	}
+	if updateAvailable {
+		info.Message = "Mac App update is available."
+	}
+	s.cacheMacAppReleaseInfo(now, info)
+	return info
+}
+
+func (s *Server) cacheMacAppReleaseInfo(checkedAt time.Time, info companionReleaseInfo) {
+	s.macAppReleaseMu.Lock()
+	defer s.macAppReleaseMu.Unlock()
+	s.macAppReleaseChecked = true
+	s.macAppReleaseCheckedAt = checkedAt
+	s.macAppReleaseCache = info
+}
+
+func macAppReleaseCheckDisabled() bool {
+	value := strings.TrimSpace(os.Getenv(macAppReleaseAPIEnvVar))
+	return value == "-" || strings.EqualFold(value, "off") || strings.EqualFold(value, "disabled")
+}
+
+func fetchLatestMacAppRelease(ctx context.Context) (githubRelease, error) {
+	releaseURL := strings.TrimSpace(os.Getenv(macAppReleaseAPIEnvVar))
+	if releaseURL == "" {
+		releaseURL = macAppReleaseAPIURL
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releaseURL, nil)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("build mac app release request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "vibetv-mac-app")
+
+	client := http.Client{Timeout: macAppReleaseTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("fetch mac app release: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return githubRelease{}, fmt.Errorf("fetch mac app release: status=%d body=%q", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 128*1024)).Decode(&release); err != nil {
+		return githubRelease{}, fmt.Errorf("decode mac app release: %w", err)
+	}
+	return release, nil
+}
+
+func normalizeMacAppReleaseVersion(raw string) string {
+	version := strings.TrimSpace(raw)
+	version = strings.TrimPrefix(version, "v")
+	version = strings.TrimPrefix(version, "V")
+	if !macAppUpdateVersionPattern.MatchString(version) {
+		return ""
+	}
+	return version
+}
+
+func compareMacAppReleaseVersions(left, right string) int {
+	leftParts, leftOK := parseMacAppReleaseVersion(left)
+	rightParts, rightOK := parseMacAppReleaseVersion(right)
+	if !leftOK || !rightOK {
+		return 0
+	}
+	for i := 0; i < 3; i++ {
+		if leftParts[i] > rightParts[i] {
+			return 1
+		}
+		if leftParts[i] < rightParts[i] {
+			return -1
+		}
+	}
+	return 0
+}
+
+func parseMacAppReleaseVersion(version string) ([3]int, bool) {
+	var parts [3]int
+	normalized := normalizeMacAppReleaseVersion(version)
+	if normalized == "" {
+		return parts, false
+	}
+	core := strings.SplitN(normalized, "-", 2)[0]
+	segments := strings.Split(core, ".")
+	if len(segments) != 3 {
+		return parts, false
+	}
+	for i, segment := range segments {
+		value, err := strconv.Atoi(segment)
+		if err != nil {
+			return parts, false
+		}
+		parts[i] = value
+	}
+	return parts, true
 }
 
 func usageResponseFromPersisted(now time.Time, usage daemon.PersistedUsage) usageResponse {
@@ -1363,7 +1549,7 @@ func (s *Server) handleSetupReset(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, statusResponse{
 		OK:        true,
-		Companion: s.companionInfo(),
+		Companion: s.companionInfo(r.Context()),
 		Device:    deviceInfo{Connected: false},
 	})
 }

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -67,6 +67,62 @@ func TestStatusReportsThemeInstallDisableFlag(t *testing.T) {
 	}
 }
 
+func TestStatusReportsCachedMacAppUpdateState(t *testing.T) {
+	server := newTestServer(t, runtimeconfig.Config{})
+	calls := 0
+	server.fetchMacAppRelease = func(context.Context) (githubRelease, error) {
+		calls++
+		return githubRelease{TagName: "v1.0.99"}, nil
+	}
+
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/status", nil)
+		server.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		var got statusResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if !got.Companion.Update.UpdateAvailable {
+			t.Fatalf("expected Mac App update available, got %+v", got.Companion.Update)
+		}
+		if got.Companion.Update.LatestVersion != "1.0.99" || got.Companion.Update.InstalledVersion != "1.0.0" {
+			t.Fatalf("unexpected Mac App update versions: %+v", got.Companion.Update)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("expected cached Mac App release check, got %d calls", calls)
+	}
+}
+
+func TestStatusReportsMacAppUpdateCheckFailure(t *testing.T) {
+	server := newTestServer(t, runtimeconfig.Config{})
+	server.fetchMacAppRelease = func(context.Context) (githubRelease, error) {
+		return githubRelease{}, errors.New("release api unavailable")
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/status", nil)
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got statusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Companion.Update.Status != "check_failed" || got.Companion.Update.UpdateAvailable {
+		t.Fatalf("expected Mac App check failure without update, got %+v", got.Companion.Update)
+	}
+	if got.Companion.Update.Message != "Mac App check failed." {
+		t.Fatalf("unexpected Mac App check failure message: %+v", got.Companion.Update)
+	}
+}
+
 func TestUsageReturnsPersistedProviderSnapshots(t *testing.T) {
 	server := newTestServer(t, runtimeconfig.Config{})
 	collectedAt := time.Date(2026, 6, 26, 11, 59, 0, 0, time.UTC)
@@ -2218,6 +2274,9 @@ func newTestServer(t *testing.T, cfg runtimeconfig.Config) *Server {
 	}
 	server.updateMacApp = func(context.Context, string, string, macAppUpdateRequest, io.Writer) error {
 		return nil
+	}
+	server.fetchMacAppRelease = func(context.Context) (githubRelease, error) {
+		return githubRelease{TagName: "v1.0.0"}, nil
 	}
 	server.subnetTargets = func() []string {
 		return nil

--- a/docs/control-center-ui-review-checkpoint.md
+++ b/docs/control-center-ui-review-checkpoint.md
@@ -13,6 +13,11 @@ To reset the gate:
 
 ## Last Review Notes
 
+- Reviewed scope: Mac App release status in Companion `/v1/status`, Overview and Updates Mac App update indicators, the navigation update badge, legacy hosted release fallback, and Vercel Preview monorepo root configuration.
+- Customer rule: Mac App update availability can appear as a short `Update` badge, `Update available`, or one primary update action, but the UI must not expose GitHub releases, local API details, daemon wording, package assets, or separate technical check steps.
+- Simplifications accepted: no new tab, setup branch, diagnostic panel, or customer troubleshooting choice was added; the Updates primary action now checks Mac App and VibeTV firmware together, while old Mac Apps keep the existing hosted fallback invisibly.
+- Verification: UI was reviewed against `docs/control-center-ui-principles.md`; `check:customer-ui-copy`, `vercel build --yes` from the monorepo root with Vercel Root Directory `apps/control-center`, and PR checks for Vercel Preview, Companion, Control Center, firmware, theme pack, and Theme Studio passed before this checkpoint update.
+
 - Reviewed scope: Overview VibeTV device preview data source, local Mac App `display-frame/latest` read path, Preview deployment inputs, and customer-flow browser coverage for the rendered ThemeSpec preview.
 - Customer rule: the existing preview should show the same frame customers see on VibeTV without adding setup choices, diagnostics text, or server-side file errors. The browser asks the local Mac App for the last good frame; when that frame is unavailable, the preview still falls back to usage data instead of surfacing internal file-state wording.
 - Simplifications accepted: no new visible UI, buttons, tabs, or explanatory text were added; the stale Vercel-side display-frame dependency was removed from the browser flow, and the test mock now follows the same local Mac App contract.

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs",
-  "installCommand": "cd apps/control-center && npm ci",
-  "buildCommand": "cd apps/control-center && npm run build",
-  "outputDirectory": "apps/control-center/.next"
+  "framework": "nextjs"
 }


### PR DESCRIPTION
## What changed

- Adds Mac App release status to the local Companion `/v1/status` response as `companion.update`.
- Caches the Mac App GitHub release check in the Companion so newer Mac Apps can self-report update availability.
- Keeps the hosted Control Center compatible with existing Mac Apps by falling back to `/api/companion/latest` when `companion.update` is missing.
- Shows Mac App update availability in Overview, Updates, and the navigation update badge.
- Extends customer-flow fixtures and tests for both new Companion status responses and old Mac Apps without `companion.update`.

## Why

Existing customers only reliably saw firmware update availability through the Control Center. Mac App update detection depended on browser-side release checks, while the long-term direction is for the Mac App to know and report its own release state. This PR adds that path without breaking old installed Mac Apps.

## Validation

- `cd companion && go test ./...`
- `cd apps/control-center && npm run lint`
- `cd apps/control-center && npm run check:customer-ui-copy`
- `cd apps/control-center && npm run test:customer-flows`
- `git diff --check`

## Release notes

No merge, tag, release, or hardware write action is included in this PR.
