### PR TITLE
Fix local companion installer command origin

### DIFF
--- a/apps/control-center/public/install-control-center-companion.sh
+++ b/apps/control-center/public/install-control-center-companion.sh
@@ -857,7 +857,7 @@ connect_vibetv() {
       printf '%s' "$saved_status" > "${TMPDIR_INSTALL}/api-status.txt"
       printf '%s' "$saved_stderr" > "${TMPDIR_INSTALL}/api-stderr.txt"
       print_local_api_error POST "/v1/device/repair"
-      die "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
+      die "VibeTV did not answer on this WiFi. Restart VibeTV, wait until it shows WiFi connected, then rerun setup."
     fi
     log "vibetv: VibeTV did not answer yet; retrying (${attempt}/${REPAIR_MAX_ATTEMPTS})"
     sleep "$REPAIR_RETRY_DELAY"

--- a/apps/control-center/src/components/mac-app-install-command.ts
+++ b/apps/control-center/src/components/mac-app-install-command.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_CONTROL_CENTER_ORIGIN = "https://app.vibetv.shop";
 export const INSTALLER_SCRIPT_PATH = "/install-control-center-companion.sh";
+const LOCAL_COMPANION_PORT = "47832";
 const PREVIEW_INSTALL_VERSION =
   process.env.NEXT_PUBLIC_VIBETV_PREVIEW_INSTALL_VERSION?.trim() || "";
 
@@ -7,10 +8,11 @@ export function buildMacAppTerminalCommand(
   origin: string,
   localControlCenterPath = "/control-center",
 ) {
-  const installerUrl = `${origin}${INSTALLER_SCRIPT_PATH}`;
+  const installerOrigin = installCommandOrigin(origin);
+  const installerUrl = `${installerOrigin}${INSTALLER_SCRIPT_PATH}`;
   const args: string[] = [];
-  if (origin !== DEFAULT_CONTROL_CENTER_ORIGIN) {
-    args.push("--dev-origin", shellQuote(origin));
+  if (installerOrigin !== DEFAULT_CONTROL_CENTER_ORIGIN) {
+    args.push("--dev-origin", shellQuote(installerOrigin));
     if (PREVIEW_INSTALL_VERSION) {
       args.push("--version", shellQuote(PREVIEW_INSTALL_VERSION));
     }
@@ -26,6 +28,23 @@ export function currentControlCenterOrigin() {
   return typeof window === "undefined"
     ? DEFAULT_CONTROL_CENTER_ORIGIN
     : window.location.origin;
+}
+
+function installCommandOrigin(origin: string) {
+  return isLocalCompanionOrigin(origin) ? DEFAULT_CONTROL_CENTER_ORIGIN : origin;
+}
+
+function isLocalCompanionOrigin(origin: string) {
+  try {
+    const url = new URL(origin);
+    return (
+      url.protocol === "http:" &&
+      url.port === LOCAL_COMPANION_PORT &&
+      ["127.0.0.1", "localhost", "[::1]"].includes(url.hostname)
+    );
+  } catch {
+    return false;
+  }
 }
 
 function shellQuote(value: string) {

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -3628,7 +3628,7 @@ func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 }
 
 func writeDeviceNotFound(w http.ResponseWriter) {
-	writeError(w, http.StatusNotFound, "device_not_found", "No VibeTV device was found.", "Make sure VibeTV is powered on and run device discovery again.")
+	writeError(w, http.StatusNotFound, "device_not_found", "No VibeTV device was found.", "Restart VibeTV, wait until it shows WiFi connected, then run setup again.")
 }
 
 func writeDiscoveryError(w http.ResponseWriter, err error) {

--- a/docs/control-center-ui-review-checkpoint.md
+++ b/docs/control-center-ui-review-checkpoint.md
@@ -13,6 +13,25 @@ To reset the gate:
 
 ## Last Review Notes
 
+- Reviewed scope: local Companion-served setup command generation, hosted
+  installer fallback, and migration hardening for the local Control Center
+  install path.
+- Customer rule: the setup screen must still show one simple Mac App
+  install/update command. Customers should not see or need to understand local
+  deployment metadata, Preview origins, Companion API routes, or `127.0.0.1`
+  setup internals.
+- Simplifications accepted: no new visible screen, button, tab, paragraph, or
+  customer decision was added. Local Companion origins now reuse the hosted
+  `app.vibetv.shop` installer command instead of exposing a broken local
+  `--dev-origin`, while real Preview URLs keep the existing Preview command
+  behavior.
+- Verification: UI was reviewed against `docs/control-center-ui-principles.md`;
+  `npm run lint`, `npm run build`, `npm run test:customer-smoke`, and direct
+  command assertions passed locally. Production `app.vibetv.shop` was checked
+  with local Companion requests intercepted and showed
+  `curl -fsSL https://app.vibetv.shop/install-control-center-companion.sh | bash`
+  with no local `--dev-origin`.
+
 - Reviewed scope: VibeTV setup captive portal WiFi list rendering, setup
   scan retry fallback, and the Control Center setup/installer changes already
   present on this branch.

--- a/scripts/install-control-center-companion-release.sh
+++ b/scripts/install-control-center-companion-release.sh
@@ -857,7 +857,7 @@ connect_vibetv() {
       printf '%s' "$saved_status" > "${TMPDIR_INSTALL}/api-status.txt"
       printf '%s' "$saved_stderr" > "${TMPDIR_INSTALL}/api-stderr.txt"
       print_local_api_error POST "/v1/device/repair"
-      die "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
+      die "VibeTV did not answer on this WiFi. Restart VibeTV, wait until it shows WiFi connected, then rerun setup."
     fi
     log "vibetv: VibeTV did not answer yet; retrying (${attempt}/${REPAIR_MAX_ATTEMPTS})"
     sleep "$REPAIR_RETRY_DELAY"

--- a/scripts/test-control-center-companion-legacy-installer.sh
+++ b/scripts/test-control-center-companion-legacy-installer.sh
@@ -101,9 +101,9 @@ respond() {
 
 repair_not_found() {
   if [[ -n "$out" ]]; then
-    printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Make sure VibeTV is powered on and run device discovery again."}}' > "$out"
+    printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Restart VibeTV, wait until it shows WiFi connected, then run setup again."}}' > "$out"
   else
-    printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Make sure VibeTV is powered on and run device discovery again."}}'
+    printf '%s\n' '{"ok":false,"error":{"code":"device_not_found","message":"No VibeTV device was found.","nextAction":"Restart VibeTV, wait until it shows WiFi connected, then run setup again."}}'
   fi
   if [[ "$write_status" == "1" ]]; then
     printf '404'
@@ -579,7 +579,7 @@ run_install_prints_repair_failure_details() {
   setup_log="$(support_log "$root")"
   [[ "$repair_calls" == "3" ]] || die "expected three repair calls, got ${repair_calls}"
   assert_contains "$output" "VIBETV setup needs attention."
-  assert_contains "$output" "VibeTV could not connect. Keep VibeTV powered on and on the same WiFi, then rerun setup."
+  assert_contains "$output" "VibeTV did not answer on this WiFi. Restart VibeTV, wait until it shows WiFi connected, then rerun setup."
   assert_contains "$output" "Support log:"
   assert_contains "$output" "For full details, rerun with --verbose."
   assert_not_contains "$output" "error code: device_not_found"
@@ -587,7 +587,7 @@ run_install_prints_repair_failure_details() {
   assert_contains "$setup_log" "api status=404"
   assert_contains "$setup_log" "api code=device_not_found"
   assert_contains "$setup_log" "api detail=No VibeTV device was found."
-  assert_contains "$setup_log" "api next step=Make sure VibeTV is powered on and run device discovery again."
+  assert_contains "$setup_log" "api next step=Restart VibeTV, wait until it shows WiFi connected, then run setup again."
 }
 
 run_install_uses_terminal_fallback_when_launchagent_lacks_local_network() {


### PR DESCRIPTION
## What changed
- Treat local Companion origins (`127.0.0.1:47832`, `localhost:47832`, `[::1]:47832`) as installed Control Center pages, not deployment metadata sources.
- Build installer commands from `https://app.vibetv.shop` when the UI is served by the local Companion.
- Preserve `--dev-origin` for real preview origins.

## Why
The local Companion serves `/install-control-center-companion.sh` but does not serve `/api/deployment`. When the local Control Center generated `--dev-origin http://127.0.0.1:47832`, the installer queried `/api/deployment` on the Companion, got `404`, and stopped at "Preparing Mac app".

## Validation
- `npm run lint`
- `npm run build`
- `npm run test:customer-smoke`
- Direct command assertion: local Companion origin now outputs `curl -fsSL https://app.vibetv.shop/install-control-center-companion.sh | bash`, while preview origins still keep `--dev-origin`.
