### PR TITLE
Fix Mac App update reconnect state

### DIFF
--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -240,6 +240,10 @@ async function main() {
     );
     await testSettingsStayCustomerOnly(browser, appContext.appUrl);
     await testUpdatesShowCustomerCompanionAction(browser, appContext.appUrl);
+    await testUpdatesCompletesMacAppUpdateAfterLocalRestart(
+      browser,
+      appContext.appUrl,
+    );
     await testUpdatesShowLegacyCompanionReleaseFallback(
       browser,
       appContext.appUrl,
@@ -1224,6 +1228,39 @@ async function testUpdatesShowCustomerCompanionAction(browser, appUrl) {
     parseJSON(macAppUpdateRequests[0])?.version === "1.0.99",
     `Mac App update should request latest version, got ${macAppUpdateRequests[0]}`,
   );
+  assertNoInstallRequests(installRequests);
+  await assertNoMobileOverflow(page);
+  await page.close();
+}
+
+async function testUpdatesCompletesMacAppUpdateAfterLocalRestart(
+  browser,
+  appUrl,
+) {
+  const page = await newCustomerPage(browser, appUrl, { viewport });
+  const installRequests = [];
+  const macAppUpdateRequests = [];
+  await routeCompanionOnline(page, installRequests, () => {}, {
+    device: { ...companionDevice, firmware: "1.0.33" },
+    onMacAppUpdate: (postData) => {
+      macAppUpdateRequests.push(postData);
+    },
+    macAppUpdateStatusFailures: 1,
+    macAppUpdateReconnectVersion: "1.0.99",
+  });
+
+  await page.goto(appUrl, { waitUntil: "networkidle" });
+  await page.getByRole("button", { name: "Updates" }).click();
+  await page.getByRole("button", { name: "Update now" }).click();
+  await page
+    .getByRole("status")
+    .filter({ hasText: "Mac App updated" })
+    .waitFor({ timeout: 10_000 });
+  await page.getByText("Mac App 1.0.99 is installed.").waitFor({
+    timeout: 10_000,
+  });
+
+  assert(macAppUpdateRequests.length === 1, "Mac App update should start once");
   assertNoInstallRequests(installRequests);
   await assertNoMobileOverflow(page);
   await page.close();
@@ -2455,6 +2492,8 @@ async function routeCompanionOnline(
     installStatusSequence,
     updateStatusSequence,
     macAppUpdateStatusSequence,
+    macAppUpdateStatusFailures = 0,
+    macAppUpdateReconnectVersion,
     dropBoardAfterFirmwareUpdate = false,
     usageResponse,
     usageStatus = 200,
@@ -2470,9 +2509,18 @@ async function routeCompanionOnline(
   let updateStatusIndex = 0;
   let activeMacAppUpdateJobId = "";
   let macAppUpdateStatusIndex = 0;
+  let macAppUpdateStatusFailuresRemaining = macAppUpdateStatusFailures;
   const handler = async (route) => {
     const pathname = companionPath(route);
     if (pathname === "/v1/mac-app/update/status") {
+      if (macAppUpdateStatusFailuresRemaining > 0) {
+        macAppUpdateStatusFailuresRemaining -= 1;
+        if (macAppUpdateReconnectVersion) {
+          currentCompanionVersion = macAppUpdateReconnectVersion;
+        }
+        await route.abort("failed");
+        return;
+      }
       const fallbackStatus = {
         phase: "complete",
         message: "Mac App updated.",

--- a/apps/control-center/src/components/control-center-app.tsx
+++ b/apps/control-center/src/components/control-center-app.tsx
@@ -50,6 +50,10 @@ const LOCAL_CONTROL_CENTER_OPENED_STORAGE_KEY =
 const COMPANION_REQUEST_TIMEOUT_MS = 45_000;
 const RECENT_COMPANION_REQUEST_MS = 5_000;
 const LOCAL_APP_LAUNCH_WAIT_MS = 1500;
+const MAC_APP_UPDATE_POLL_INTERVAL_MS = 500;
+const MAC_APP_UPDATE_MAX_POLLS = 960;
+const MAC_APP_UPDATE_RECONNECT_GRACE_MS = 45_000;
+const MAC_APP_UPDATE_INITIAL_GRACE_MS = 60_000;
 
 type LocalNetworkRequestInit = RequestInit & {
   targetAddressSpace?: "loopback";
@@ -2249,20 +2253,20 @@ async function pollMacAppUpdateJob({
   runCompanion: RunCompanion;
   targetVersion?: string;
 }): Promise<MacAppUpdateJob> {
-  for (let attempt = 0; attempt < 960; attempt += 1) {
-    await delay(500);
+  const startedAt = Date.now();
+  let disconnectedAt: number | null = null;
+  for (let attempt = 0; attempt < MAC_APP_UPDATE_MAX_POLLS; attempt += 1) {
+    await delay(MAC_APP_UPDATE_POLL_INTERVAL_MS);
+    let payload: { job: MacAppUpdateJob };
     try {
-      const payload = await runCompanion<{ job: MacAppUpdateJob }>(
+      payload = await runCompanion<{ job: MacAppUpdateJob }>(
         `/v1/mac-app/update/status?jobId=${encodeURIComponent(jobId)}`,
         undefined,
         { preserveLastError: true },
       );
-      applyUpdateJob(payload.job);
-      if (payload.job.phase === "complete" || payload.job.phase === "error") {
-        return payload.job;
-      }
-      continue;
     } catch {
+      disconnectedAt = disconnectedAt ?? Date.now();
+      applyUpdateJob(reconnectingMacAppUpdateJob(jobId));
       const reconnected = await readMacAppVersion(runCompanion);
       if (
         reconnected &&
@@ -2277,14 +2281,68 @@ async function pollMacAppUpdateJob({
           result: { version: normalizeVersion(reconnected) },
         };
       }
+      if (Date.now() - disconnectedAt >= MAC_APP_UPDATE_RECONNECT_GRACE_MS) {
+        throw macAppUpdateManualStepError(
+          "mac_app_update_reconnect_timeout",
+          "Mac App update needs attention.",
+        );
+      }
+      continue;
+    }
+    disconnectedAt = null;
+    applyUpdateJob(payload.job);
+    if (payload.job.phase === "complete" || payload.job.phase === "error") {
+      return payload.job;
+    }
+    if (
+      macAppUpdateStillPreparing(payload.job) &&
+      Date.now() - startedAt >= MAC_APP_UPDATE_INITIAL_GRACE_MS
+    ) {
+      throw macAppUpdateManualStepError(
+        "mac_app_update_start_timeout",
+        "Mac App update did not start.",
+      );
     }
   }
-  throw {
-    code: "mac_app_update_timeout",
-    message: "Mac App update is taking longer than expected.",
+  throw macAppUpdateManualStepError(
+    "mac_app_update_timeout",
+    "Mac App update is taking longer than expected.",
+  );
+}
+
+function reconnectingMacAppUpdateJob(jobId: string): MacAppUpdateJob {
+  return {
+    id: jobId,
+    phase: "installing",
+    message: "Restarting Mac App.",
+    progress: 85,
+    logs: [
+      "Preparing Mac App update.",
+      "Installing Mac App.",
+      "Restarting Mac App.",
+    ],
+  };
+}
+
+function macAppUpdateStillPreparing(job: MacAppUpdateJob): boolean {
+  const logs = customerMacAppUpdateLogs(job.logs);
+  return (
+    clampProgress(job.progress) <= 5 &&
+    logs.length === 1 &&
+    logs[0] === "Preparing Mac App update."
+  );
+}
+
+function macAppUpdateManualStepError(
+  code: string,
+  message: string,
+): ApiError {
+  return {
+    code,
+    message,
     nextAction:
       "Copy the update command and run it in Terminal, then try again.",
-  } satisfies ApiError;
+  };
 }
 
 async function readMacAppVersion(runCompanion: RunCompanion): Promise<string> {


### PR DESCRIPTION
## What changed

- Shows an explicit `Restarting Mac App.` state when the local Mac App disappears during self-update polling.
- Detects successful reconnect through `/v1/status` and completes the update when the new version answers.
- Stops the UI from sitting on `Preparing Mac App update.` indefinitely by falling back to the manual update command after bounded waits.
- Adds a customer-flow regression test for the local restart/reconnect case.

## Why

When the Mac App self-update restarts the local service, `127.0.0.1:47832` can briefly stop answering. The UI kept polling the old update job and could stay stuck at the early update state, leaving the user with no clear next step.

## Validation

- `npm run lint`
- `go test ./internal/companionapi`
- `npm run test:customer-flows`
- `git diff --check`
