### PR TITLE
Fix VibeTV repair when target is lost

### DIFF
--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -267,6 +267,7 @@ async function main() {
       appContext.appUrl,
     );
     await testVibeTVAddressCopyStaysCustomerOnly(browser, appContext.appUrl);
+    await testMissingAddressAutoRepairsInSetup(browser, appContext.appUrl);
     await testSavedAddressDoesNotBlockAutomaticVibeTVSearch(
       browser,
       appContext.appUrl,
@@ -1541,6 +1542,48 @@ async function testVibeTVAddressCopyStaysCustomerOnly(browser, appUrl) {
     );
   }
 
+  assertNoInstallRequests(installRequests);
+  await assertNoMobileOverflow(page);
+  await page.close();
+}
+
+async function testMissingAddressAutoRepairsInSetup(browser, appUrl) {
+  const page = await newCustomerPage(browser, appUrl, { viewport });
+  const installRequests = [];
+  const repairRequests = [];
+  await routeCompanionOnline(page, installRequests, () => {}, {
+    device: {
+      target: "",
+      connected: false,
+      paired: false,
+    },
+    onRepair: (postData) => {
+      repairRequests.push(postData || "");
+      return {
+        ...companionDevice,
+        target: "http://192.168.178.163",
+        connected: true,
+        paired: true,
+      };
+    },
+  });
+
+  await page.goto(appUrl, { waitUntil: "networkidle" });
+  await waitForCondition(
+    () => repairRequests.length >= 1,
+    "expected missing-address setup to auto-repair",
+  );
+  await page.getByText("VibeTV is connected").waitFor({ timeout: 10_000 });
+
+  const repairPayload = JSON.parse(repairRequests[0] || "{}");
+  assert(
+    repairPayload.target == null,
+    `missing-address auto repair should let the Mac App recover the target, got ${repairRequests[0]}`,
+  );
+  assert(
+    repairPayload.forcePair === true,
+    `missing-address auto repair should force pairing, got ${repairRequests[0]}`,
+  );
   assertNoInstallRequests(installRequests);
   await assertNoMobileOverflow(page);
   await page.close();

--- a/apps/control-center/src/components/control-center-app.tsx
+++ b/apps/control-center/src/components/control-center-app.tsx
@@ -1265,14 +1265,18 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
   }, [checkCompanion, hostedSetup, setupPreviewStep]);
 
   useEffect(() => {
+    const needsKnownTargetRepair =
+      Boolean(device?.target) && !deviceSetupIsUsable(device);
+    const needsMissingTargetRepair =
+      !device?.target &&
+      (deviceState === "unknown" || deviceState === "offline");
     if (
       hostedSetup ||
       setupPreviewStep ||
       didRunAutoRepair.current ||
       busyAction ||
       companionStatus !== "online" ||
-      !device?.target ||
-      deviceSetupIsUsable(device) ||
+      (!needsKnownTargetRepair && !needsMissingTargetRepair) ||
       isLocalNetworkAccessError(lastError)
     ) {
       return;
@@ -1283,6 +1287,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
     busyAction,
     companionStatus,
     device,
+    deviceState,
     hostedSetup,
     lastError,
     repairConnection,

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -1885,12 +1885,12 @@ func (s *Server) repairDevice(ctx context.Context, requestedTarget string, force
 	if forcePair {
 		discoveryCfg.DeviceToken = ""
 	}
-	target, hello, err := s.discoverForRepair(ctx, discoveryCfg, requestedTarget)
+	target, hello, err := s.discoverRepairTarget(ctx, discoveryCfg, requestedTarget)
 	tokenStale := false
 	if err != nil && !forcePair && strings.TrimSpace(cfg.DeviceToken) != "" {
 		discoveryCfg = cfg
 		discoveryCfg.DeviceToken = ""
-		target, hello, err = s.discoverForRepair(ctx, discoveryCfg, requestedTarget)
+		target, hello, err = s.discoverRepairTarget(ctx, discoveryCfg, requestedTarget)
 		if err == nil {
 			tokenStale = true
 		}
@@ -1926,10 +1926,37 @@ func (s *Server) repairDevice(ctx context.Context, requestedTarget string, force
 	return device, nil
 }
 
+func (s *Server) discoverRepairTarget(ctx context.Context, cfg runtimeconfig.Config, requestedTarget string) (string, protocol.DeviceHello, error) {
+	var lastErr error
+	for _, candidate := range s.repairTargetCandidates(cfg, requestedTarget) {
+		target, hello, err := s.discoverForRepair(ctx, cfg, candidate)
+		if err == nil {
+			return target, hello, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = errors.New("no device candidates")
+	}
+	return "", protocol.DeviceHello{}, lastErr
+}
+
+func (s *Server) repairTargetCandidates(cfg runtimeconfig.Config, requestedTarget string) []string {
+	requestedTarget = strings.TrimSpace(requestedTarget)
+	if requestedTarget != "" {
+		return []string{requestedTarget}
+	}
+	candidates := []string{strings.TrimSpace(cfg.DeviceTarget)}
+	if strings.TrimSpace(cfg.DeviceTarget) == "" {
+		candidates = append(candidates, s.recoveredDeviceTargets()...)
+	}
+	return append(uniqueStrings(candidates...), "")
+}
+
 func (s *Server) discoverForRepair(ctx context.Context, cfg runtimeconfig.Config, requestedTarget string) (string, protocol.DeviceHello, error) {
 	requestedTarget = strings.TrimSpace(requestedTarget)
 	attempts := 1
-	if requestedTarget == "" && strings.TrimSpace(cfg.DeviceToken) == "" {
+	if requestedTarget != "" || strings.TrimSpace(cfg.DeviceToken) == "" {
 		attempts = repairDiscoveryAttempts
 	}
 
@@ -1950,6 +1977,86 @@ func (s *Server) discoverForRepair(ctx context.Context, cfg runtimeconfig.Config
 		}
 	}
 	return "", protocol.DeviceHello{}, lastErr
+}
+
+func (s *Server) recoveredDeviceTargets() []string {
+	candidates := []string{}
+	if _, target := lastDisplayStreamFrame(s.recoveryDisplayStreamOutLogPath()); strings.TrimSpace(target) != "" {
+		candidates = append(candidates, target)
+	}
+	candidates = append(candidates, s.recoveredConfigDeviceTargets()...)
+	normalized := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		target, err := normalizeExplicitDeviceTarget(candidate)
+		if err == nil {
+			normalized = append(normalized, target)
+		}
+	}
+	return uniqueStrings(normalized...)
+}
+
+func (s *Server) recoveryDisplayStreamOutLogPath() string {
+	if path := strings.TrimSpace(os.Getenv(displayStreamOutLogEnv)); path != "" {
+		return path
+	}
+	home := strings.TrimSpace(s.home)
+	if home == "" {
+		return displayStreamOutLogPath()
+	}
+	return filepath.Join(home, "Library", "Application Support", "codexbar-display", "logs", displayStreamOutLog)
+}
+
+func (s *Server) recoveredConfigDeviceTargets() []string {
+	home := strings.TrimSpace(s.home)
+	if home == "" {
+		return nil
+	}
+	configDir := filepath.Dir(runtimeconfig.ConfigPath(home))
+	patterns := []string{
+		"config.before-*.json",
+		"config.backup-*.json",
+		"config.json.backup-*",
+	}
+	type candidateFile struct {
+		path    string
+		modTime time.Time
+	}
+	files := []candidateFile{}
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(filepath.Join(configDir, pattern))
+		if err != nil {
+			continue
+		}
+		for _, match := range matches {
+			info, err := os.Stat(match)
+			if err != nil || info.IsDir() {
+				continue
+			}
+			files = append(files, candidateFile{path: match, modTime: info.ModTime()})
+		}
+	}
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].modTime.Equal(files[j].modTime) {
+			return files[i].path > files[j].path
+		}
+		return files[i].modTime.After(files[j].modTime)
+	})
+
+	targets := make([]string, 0, len(files))
+	for _, file := range files {
+		raw, err := os.ReadFile(file.path)
+		if err != nil {
+			continue
+		}
+		var cfg runtimeconfig.Config
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			continue
+		}
+		if strings.TrimSpace(cfg.DeviceTarget) != "" {
+			targets = append(targets, cfg.DeviceTarget)
+		}
+	}
+	return uniqueStrings(targets...)
 }
 
 func repairDiscoveryErrorIsRetryable(err error) bool {

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -1627,6 +1627,97 @@ func TestDeviceRepairRetriesTransientDiscoveryMiss(t *testing.T) {
 	}
 }
 
+func TestDeviceRepairRetriesExplicitTargetTransientMiss(t *testing.T) {
+	var helloCalls int
+	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			helloCalls++
+			if helloCalls < 3 {
+				http.Error(w, "warming up", http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.31","capabilities":{"transport":{"active":"wifi"}}}`))
+		case "/api/pair":
+			if r.Method != http.MethodPost {
+				t.Fatalf("expected POST pair, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"token":"new-token"}`))
+		case "/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"display":{"activeTheme":"mini-classic","themeSpec":{"active":true,"renderOk":true}},"settings":{"display":{"brightnessPercent":40}}}`))
+		default:
+			t.Fatalf("unexpected device path %s", r.URL.Path)
+		}
+	}))
+	defer device.Close()
+
+	server := newTestServer(t, runtimeconfig.Config{})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/device/repair", strings.NewReader(`{"target":"`+device.URL+`","forcePair":true}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200 after explicit retry, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if helloCalls < 3 {
+		t.Fatalf("expected explicit target retry, got %d hello calls", helloCalls)
+	}
+	var got deviceActionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !got.OK || !got.Device.Connected || !got.Device.Paired || got.Device.Target != device.URL {
+		t.Fatalf("unexpected repair response after explicit retry: %+v", got)
+	}
+}
+
+func TestDeviceRepairRecoversLastLogTargetWhenConfigIsEmpty(t *testing.T) {
+	device := newRepairableDeviceServer(t)
+	defer device.Close()
+
+	logPath := filepath.Join(t.TempDir(), "daemon.out.log")
+	t.Setenv(displayStreamOutLogEnv, logPath)
+	if err := os.WriteFile(logPath, []byte("2026-07-09T07:44:45Z sent frame -> "+device.URL+" transport=wifi source=oauth\n"), 0o644); err != nil {
+		t.Fatalf("write display stream log: %v", err)
+	}
+
+	server := newTestServer(t, runtimeconfig.Config{})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/device/repair", strings.NewReader(`{"forcePair":true}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200 after recovering log target, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got deviceActionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !got.OK || !got.Device.Connected || !got.Device.Paired || got.Device.Target != device.URL {
+		t.Fatalf("unexpected repair response after log target recovery: %+v", got)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/status", nil)
+	server.Handler().ServeHTTP(rec, req)
+	var status statusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &status); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if status.Device.Target != device.URL || !status.Device.Paired {
+		t.Fatalf("expected recovered target to be persisted, got %+v", status.Device)
+	}
+}
+
 func TestDeviceRepairExplicitVibetvLocalFallsBackToSubnet(t *testing.T) {
 	device := newRepairableDeviceServer(t)
 	defer device.Close()

--- a/docs/control-center-ui-review-checkpoint.md
+++ b/docs/control-center-ui-review-checkpoint.md
@@ -13,6 +13,24 @@ To reset the gate:
 
 ## Last Review Notes
 
+- Reviewed scope: setup recovery when the Mac App has lost the saved VibeTV
+  address, automatic repair from an empty device target, and Companion recovery
+  from the last display-stream target or saved config backups.
+- Customer rule: setup should recover the VibeTV connection automatically in
+  the background. Customers should not need to understand IP addresses,
+  discovery, pairing, saved targets, display-stream logs, or config backups.
+- Simplifications accepted: no new visible Control Center screen, button,
+  label, paragraph, tab, or customer choice was added. The existing setup
+  repair path now also runs once when no target is saved, while the manual
+  address field remains only a fallback for customers who already have the
+  VibeTV address.
+- Verification: UI was reviewed against `docs/control-center-ui-principles.md`;
+  `go test ./internal/companionapi`, `npm run lint`, `npm run
+  test:customer-flows`, and `git diff --check` passed locally. Vercel Preview
+  for PR #150 loaded without browser errors, and with local-network permission
+  handed off to the local Control Center showing VibeTV connected at
+  `192.168.178.163`.
+
 - Reviewed scope: local Companion-served setup command generation, hosted
   installer fallback, and migration hardening for the local Control Center
   install path.


### PR DESCRIPTION
## Summary
- auto-run setup repair even when the Mac App has no saved VibeTV target
- recover lost device targets from the last display-stream log entry or config backups
- retry explicit target repair probes before reporting device_not_found

## Tests
- go test ./internal/companionapi
- npm run lint
- npm run test:customer-flows
- git diff --check