### PR TITLE
CODEX: Align Shopify theme links with Control Center readiness checks

### DIFF
--- a/docs/control-center-customer-readiness.md
+++ b/docs/control-center-customer-readiness.md
@@ -166,12 +166,11 @@ The top-level README, customer setup guide, Control Center README, and this read
 - what data is local, what reaches `app.vibetv.shop`, and what is sent to the device,
 - update flow and failure-report flow.
 
-The intended launch path is the hosted Control Center route:
-`https://app.vibetv.shop/install/<theme_id>`. Shopify theme products may still
-show the direct Terminal install command during staged rollout or rollback, but
-that is a fallback path. Before product pages point customers into Control
-Center, verify that the Agentic setup path works end to end on a customer-like
-Mac and that `/install/<theme_id>` preserves setup gating.
+The Shopify product launch path is the hosted Control Center route:
+`https://app.vibetv.shop/install/<theme_id>`. Every theme product must link to
+the matching URL-encoded theme ID and must not expose the old direct Terminal
+theme-install command. Verify that the Agentic setup path works end to end on a
+customer-like Mac and that `/install/<theme_id>` preserves setup gating.
 
 ## Customer Readiness Validation
 
@@ -251,7 +250,7 @@ What it checks:
 - hosted app HTTP reachability,
 - hosted app `/api/companion/latest` version status without installer or package URLs when `--app-url` is combined with `--release` or `--release-json`,
 - optional hosted app `/api/themes` source, selected free theme readiness, concrete `/install/<theme_id>` route reachability, and all visible free theme readiness when `--expect-catalog-source`, `--expect-theme-id`, or `--expect-all-free-themes-installable` is provided.
-- optional public Shopify product page readiness when `--expect-shopify-product-pages` or `--shopify-product-page <url> <theme_id>` is provided: during staged rollout, each checked product page must show `Copy install command` and the direct command `codexbar-display theme-pack install --theme <theme_id> --target http://vibetv.local`. During Control Center cutover, validate that product pages point to the matching `https://app.vibetv.shop/install/<theme_id>` route and that the hosted app route remains reachable and setup-gated. `--expect-shopify-product-pages` reads `productUrl` from `/api/themes`, or derives it from `handle` plus `--shopify-store-url` while deployments are rolling forward, and checks every free Shopify catalog item.
+- optional public Shopify product page readiness when `--expect-shopify-product-pages` or `--shopify-product-page <url> <theme_id>` is provided: each checked product page must contain the exact matching `https://app.vibetv.shop/install/<theme_id>` link. The checker rejects wrong or noncanonical theme links and the legacy `Copy install command` / `codexbar-display theme-pack install` path. `--expect-shopify-product-pages` reads `productUrl` from `/api/themes`, or derives it from `handle` plus `--shopify-store-url` while deployments are rolling forward, and checks every free Shopify catalog item.
 
 Use `--expect-catalog-source shopify` for the production customer app. Use `--expect-theme-id <theme_id>` for at least one public free Shopify theme before linking customers to product pages. That selected theme check requests `/install/<theme_id>` to prove the hosted app route exists. Add `--expect-all-free-themes-installable` before a collection-wide rollout. Those checks fail if a required theme is missing, paid, missing `themeId`, has no resolved `packUrl`, exposes a `packUrl` that is not an `http(s)` download URL, or if any free theme's `/install/<theme_id>` route is not reachable.
 

--- a/docs/control-center-ui-review-checkpoint.md
+++ b/docs/control-center-ui-review-checkpoint.md
@@ -192,6 +192,11 @@ To reset the gate:
 - Simplifications accepted: no new Control Center buttons or setup choices were added; firmware errors now say only whether an update is available or the check failed; Support replaces internal diagnostics and URLs with customer-safe terms; unavailable app CTA copy is now blocked on Shopify product page checks.
 - Verification: live Synthwave Shopify page shows `Copy install command` and the expected terminal command with no `app.vibetv.shop` link; `scripts/test-control-center-companion-customer-readiness.sh`, the live `--shopify-product-page` readiness check, `scripts/check-control-center-customer-docs.sh`, `scripts/test-control-center-customer-ready-gate.sh`, and `git diff --check` passed locally.
 
+- Reviewed scope: completed Shopify theme-product cutover to the hosted setup launcher and the matching product-page readiness rule.
+- Customer rule: this supersedes the staged-rollout checkpoint above. Every Shopify theme product links to the exact `https://app.vibetv.shop/install/<theme_id>` route; product pages must not expose `Copy install command` or the direct `codexbar-display theme-pack install` path.
+- Simplifications accepted: one product CTA opens Control Center setup with the selected theme; pairing, device checks, and installation remain inside the local Mac App flow.
+- Verification: `scripts/test-control-center-companion-customer-readiness.sh` passed, and the read-only catalog-derived live check passed for Synthwave, Clippy, and Claude Creature with their exact matching `app.vibetv.shop/install/<theme_id>` links.
+
 - Reviewed scope: public theme catalog failure states, install deep-link fallback path, customer-copy guard coverage for App Router files, and customer-copy guard coverage for the theme catalog data source.
 - Customer rule: public JSON and any copy that can later be surfaced by the UI must use customer language too; Shopify/API/env/config errors stay internal and collapse to simple theme-unavailable wording.
 - Simplifications accepted: no new visible UI, no new buttons, no added explanatory text; theme catalog errors now say only that themes are unavailable or could not load, and the guard scans `src/app` plus `src/lib/themes.ts` so the same internal wording cannot re-enter through a route or catalog helper.

--- a/docs/vibetv-shopify-theme-shop.md
+++ b/docs/vibetv-shopify-theme-shop.md
@@ -13,15 +13,14 @@ surface:
 - Hosted app: `https://app.vibetv.shop`
 - Product entry surface: `https://vibetv.shop/products/<theme-handle>`
 - Target product action: open `https://app.vibetv.shop/install/<theme_id>`.
-- Fallback product action during staged rollout: visible Terminal install command.
 
 The Control Center reads products from Shopify Storefront API through `apps/control-center/src/lib/themes.ts`. App-owned Shopify Metaobjects can still be revisited later, but they are not the current source of truth.
 
 Treat the hosted app path as the customer entrypoint, not as the full customer
 app. Theme product pages should point customers into hosted setup once the
 launch cutover is approved. From there, the Mac App opens the local Control
-Center for install and management. The direct Terminal command remains useful as
-a rollback or support fallback, not as the preferred product journey.
+Center for install and management. Product pages must not expose the old direct
+Terminal theme-install command.
 
 ## Product Model
 
@@ -58,16 +57,16 @@ Hosted setup then handles the next available step: install/repair the Mac App,
 open the local Control Center, connect VibeTV, and install the selected theme
 locally.
 
-During staged rollout or support fallback, use the Custom Liquid block stored in
+Use the Custom Liquid block stored in
 `docs/vibetv-theme-product-custom-liquid.liquid` on VibeTV theme product pages.
-It renders one primary action, `Copy install command`, then shows the actual
-command:
+It renders one primary action, `Open in Control Center`, which links to:
 
-```liquid
-curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash && codexbar-display theme-pack install --theme <theme_id> --target http://vibetv.local
+```text
+https://app.vibetv.shop/install/<theme_id>
 ```
 
-The Liquid derives `<theme_id>` from `vibetv.theme_id` or `theme.theme_id`.
+The Liquid derives `<theme_id>` from `vibetv.theme_id` or `theme.theme_id` and
+URL-encodes it as one path segment.
 
 ## Customer Flow
 
@@ -78,12 +77,6 @@ The Liquid derives `<theme_id>` from `vibetv.theme_id` or `theme.theme_id`.
 5. If setup is incomplete, hosted setup shows only the next setup action.
 6. Once the Mac App answers, the browser opens the local Control Center.
 7. The local Control Center handles VibeTV connection, pairing, and theme install.
-
-Fallback flow:
-
-1. Product page shows `Copy install command`.
-2. Customer opens Terminal, pastes the command, and presses Return while VibeTV is on the same WiFi.
-3. The command installs/updates the CLI helper and runs `codexbar-display theme-pack install --theme <theme_id> --target http://vibetv.local`.
 
 ## GitHub Theme Pack Artifacts
 
@@ -142,8 +135,9 @@ selected `theme_id`, returning a paid theme for that ID, missing a free theme
 `http(s)` download URL, exposing any free collection theme that is not
 installable, or if the selected `/install/<theme_id>` route is not reachable.
 
-During staged rollout, the same checker can still assert the fallback Shopify
-product-page command when `--expect-shopify-product-pages` is intentionally used.
+For every free Shopify theme, the same checker requires the exact matching
+`https://app.vibetv.shop/install/<theme_id>` product link and rejects the old
+`Copy install command` / direct terminal theme-install path.
 
 Allowed without extra hardware approval:
 

--- a/docs/vibetv-theme-product-custom-liquid.liquid
+++ b/docs/vibetv-theme-product-custom-liquid.liquid
@@ -4,9 +4,10 @@
     assign theme_product = closest.product
   endif
   assign theme_id = theme_product.metafields.vibetv.theme_id.value | default: theme_product.metafields.theme.theme_id.value
-  assign install_command = ''
+  assign install_url = ''
   if theme_id != blank
-    assign install_command = 'curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash && codexbar-display theme-pack install --theme ' | append: theme_id | append: ' --target http://vibetv.local'
+    assign encoded_theme_id = theme_id | url_encode
+    assign install_url = 'https://app.vibetv.shop/install/' | append: encoded_theme_id
   endif
 %}
 
@@ -17,19 +18,6 @@
       gap: 12px;
       margin-top: 4px;
     }
-    .vtv-theme-install__command {
-      display: block;
-      width: 100%;
-      padding: 12px;
-      border: 1px solid rgb(var(--color-foreground-rgb, 27 27 27) / 0.24);
-      background: rgb(var(--color-foreground-rgb, 27 27 27) / 0.05);
-      color: rgb(var(--color-foreground-rgb, 27 27 27));
-      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-      font-size: 13px;
-      line-height: 1.45;
-      white-space: normal;
-      overflow-wrap: anywhere;
-    }
     .vtv-theme-install__note {
       margin: 0;
       color: rgb(var(--color-foreground-rgb, 27 27 27) / 0.72);
@@ -38,46 +26,22 @@
     }
   </style>
 
-  {% if install_command != blank %}
-    <button class="button add-to-cart-button" type="button" data-vtv-copy-command="{{ install_command | escape }}">
+  {% if install_url != blank %}
+    <a class="button add-to-cart-button" href="{{ install_url }}">
       <span class="add-to-cart-text">
         <span class="add-to-cart-text__content">
-          <span data-vtv-copy-label>Copy install command</span>
+          <span>Open in Control Center</span>
         </span>
       </span>
-    </button>
-    <code class="vtv-theme-install__command">{{ install_command }}</code>
-    <p class="vtv-theme-install__note">Open Terminal, paste this command, and press Return while VibeTV is on the same WiFi.</p>
+    </a>
+    <p class="vtv-theme-install__note">The Control Center checks setup and opens this theme on your Mac.</p>
   {% else %}
     <button type="button" class="button add-to-cart-button" disabled>
       <span class="add-to-cart-text">
         <span class="add-to-cart-text__content">
-          <span>Install command unavailable</span>
+          <span>Theme unavailable</span>
         </span>
       </span>
     </button>
   {% endif %}
 </div>
-
-<script>
-  (() => {
-    const root = document.querySelector('[data-vtv-theme-install]');
-    if (!root) return;
-    const button = root.querySelector('[data-vtv-copy-command]');
-    const label = root.querySelector('[data-vtv-copy-label]');
-    if (!button || !label) return;
-    const initialLabel = label.textContent;
-    button.addEventListener('click', async () => {
-      const command = button.getAttribute('data-vtv-copy-command');
-      try {
-        await navigator.clipboard.writeText(command);
-        label.textContent = 'Copied';
-      } catch (_) {
-        label.textContent = 'Copy manually';
-      }
-      window.setTimeout(() => {
-        label.textContent = initialLabel;
-      }, 1800);
-    });
-  })();
-</script>

--- a/scripts/check-control-center-companion-customer-readiness.sh
+++ b/scripts/check-control-center-companion-customer-readiness.sh
@@ -51,7 +51,9 @@ Options:
   --shopify-store-url https://vibetv.shop
                                    Public Shopify store origin used to derive product URLs from /api/themes handles. Default: https://vibetv.shop.
   --shopify-product-page url theme_id
-                                   Check a public Shopify product page links to /install/theme_id and no longer exposes the legacy terminal command. Repeatable.
+                                   Require the public product page to link exactly to
+                                   <shopify-app-url>/install/<theme_id> and reject the
+                                   legacy terminal install path. Repeatable.
   --local-companion                Check local Mac App status on VIBETV_COMPANION_ADDR, default 127.0.0.1:47832.
   --expect-version x.y.z           Require local Mac App version where checked.
   -h, --help                       Show this help.
@@ -491,12 +493,16 @@ PY
 urlencode_path_segment() {
   require_cmd python3
   python3 - "$1" <<'PY'
+import re
 import sys
 from urllib.parse import quote
 
-value = sys.argv[1].strip()
-if not value:
-    print("theme id cannot be empty", file=sys.stderr)
+value = sys.argv[1]
+if not re.fullmatch(r"[a-z0-9][a-z0-9_-]{2,63}", value):
+    print(
+        "invalid theme_id: expected 3-64 lowercase letters, numbers, hyphens, or underscores",
+        file=sys.stderr,
+    )
     sys.exit(1)
 print(quote(value, safe=""))
 PY
@@ -643,50 +649,73 @@ PY
 }
 
 check_shopify_product_page() {
-  local url theme_id label html
+  local url theme_id label html encoded_theme_id expected_install_url
   url="$1"
   theme_id="$2"
   label="$3"
   validate_http_url "$url" "$label" 1
+  encoded_theme_id="$(urlencode_path_segment "$theme_id")"
+  expected_install_url="${SHOPIFY_APP_URL%/}/install/${encoded_theme_id}"
 
   html="$(mktemp "${TMP_WORK_DIR}/shopify-product.XXXXXX")"
   curl_cmd -fsSL "$url" > "$html"
-  python3 - "$html" "$url" "$theme_id" "$SHOPIFY_APP_URL" <<'PY'
+  python3 - "$html" "$url" "$expected_install_url" "$SHOPIFY_APP_URL" <<'PY'
+from html import unescape
+from html.parser import HTMLParser
 import sys
-from urllib.parse import quote
+from urllib.parse import urlparse
 
-html_path, product_url, theme_id, app_url = sys.argv[1:]
+html_path, product_url, expected_install_url, app_url = sys.argv[1:]
 with open(html_path, encoding="utf-8", errors="replace") as f:
     html = f.read()
 
-expected_command = (
-    f"codexbar-display theme-pack install --theme {theme_id} "
-    "--target http://vibetv.local"
-)
-required_terminal_copy = [
-    "Copy install command",
-    expected_command,
-]
-forbidden = [
-    f"{app_url.rstrip('/')}/install/{quote(theme_id, safe='')}",
-    "app.vibetv.shop/install",
-    "Check compatibility in the app",
-    "Opens the hosted Control Center",
-    "Theme check unavailable",
-    "Jetzt installieren",
-    "Jetzt Theme installieren",
-    "Install now",
-    "One-click install",
-    "One click install",
+class LinkParser(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.hrefs = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() != "a":
+            return
+        for name, value in attrs:
+            if name.lower() == "href" and value is not None:
+                self.hrefs.append(value.strip())
+
+parser = LinkParser()
+parser.feed(html)
+hrefs = parser.hrefs
+app = urlparse(app_url.rstrip("/"))
+app_install_links = []
+for href in hrefs:
+    parsed = urlparse(href)
+    if (
+        parsed.scheme == app.scheme
+        and parsed.netloc == app.netloc
+        and parsed.path.startswith("/install/")
+    ):
+        app_install_links.append(href)
+
+legacy_copy = unescape(html).lower()
+forbidden_legacy = [
+    "copy install command",
+    "codexbar-display theme-pack install",
+    "--target http://vibetv.local",
 ]
 
 errors = []
-for copy in required_terminal_copy:
-    if copy not in html:
-        errors.append(f"missing terminal install copy: {copy}")
-for needle in forbidden:
-    if needle in html:
-        errors.append(f"unavailable app install copy still present: {needle}")
+if expected_install_url not in hrefs:
+    errors.append(f"missing Control Center install link: {expected_install_url}")
+unexpected_install_links = [
+    href for href in app_install_links if href != expected_install_url
+]
+if unexpected_install_links:
+    errors.append(
+        "wrong Control Center install link: "
+        + ", ".join(sorted(set(unexpected_install_links)))
+    )
+for needle in forbidden_legacy:
+    if needle in legacy_copy:
+        errors.append(f"legacy terminal install path still present: {needle}")
 
 if errors:
     print(
@@ -698,7 +727,7 @@ if errors:
     )
     sys.exit(1)
 PY
-  log "Shopify product page ok: ${url} -> ${theme_id}"
+  log "Shopify product page ok: ${url} -> ${expected_install_url}"
 }
 
 expected_release_version() {

--- a/scripts/test-control-center-companion-customer-readiness.sh
+++ b/scripts/test-control-center-companion-customer-readiness.sh
@@ -64,7 +64,96 @@ run_expect_broken_product_page_failure() {
   set -e
 
   [[ "$status" -ne 0 ]] || die "expected broken Shopify product page check to fail"
-  assert_contains "$output" "missing terminal install copy: codexbar-display theme-pack install --theme synthwave --target http://vibetv.local"
+  assert_contains "$output" "missing Control Center install link: https://app.example.test/install/synthwave"
+}
+
+run_expect_legacy_product_command_failure() {
+  local output status
+  set +e
+  output="$(
+    CONTROL_CENTER_READINESS_CURL="$FAKE_CURL" \
+      "$READINESS" \
+        --shopify-app-url https://app.example.test \
+        --shopify-product-page https://vibetv.example.test/products/legacy synthwave \
+        2>&1
+  )"
+  status=$?
+  set -e
+
+  [[ "$status" -ne 0 ]] || die "expected legacy Shopify product command check to fail"
+  assert_contains "$output" "legacy terminal install path still present: copy install command"
+  assert_contains "$output" "legacy terminal install path still present: codexbar-display theme-pack install"
+  assert_contains "$output" "legacy terminal install path still present: --target http://vibetv.local"
+}
+
+run_expect_wrong_theme_link_failure() {
+  local output status
+  set +e
+  output="$(
+    CONTROL_CENTER_READINESS_CURL="$FAKE_CURL" \
+      "$READINESS" \
+        --shopify-app-url https://app.example.test \
+        --shopify-product-page https://vibetv.example.test/products/wrong-theme synthwave \
+        2>&1
+  )"
+  status=$?
+  set -e
+
+  [[ "$status" -ne 0 ]] || die "expected wrong Shopify theme link check to fail"
+  assert_contains "$output" "missing Control Center install link: https://app.example.test/install/synthwave"
+  assert_contains "$output" "wrong Control Center install link: https://app.example.test/install/clippy"
+}
+
+run_expect_noncanonical_install_url_failure() {
+  local output status
+  set +e
+  output="$(
+    CONTROL_CENTER_READINESS_CURL="$FAKE_CURL" \
+      "$READINESS" \
+        --shopify-app-url https://app.example.test \
+        --shopify-product-page https://vibetv.example.test/products/noncanonical synthwave \
+        2>&1
+  )"
+  status=$?
+  set -e
+
+  [[ "$status" -ne 0 ]] || die "expected noncanonical Shopify install URL check to fail"
+  assert_contains "$output" "missing Control Center install link: https://app.example.test/install/synthwave"
+  assert_contains "$output" "wrong Control Center install link: https://app.example.test/install/%73ynthwave"
+}
+
+run_expect_expected_plus_wrong_link_failure() {
+  local output status
+  set +e
+  output="$(
+    CONTROL_CENTER_READINESS_CURL="$FAKE_CURL" \
+      "$READINESS" \
+        --shopify-app-url https://app.example.test \
+        --shopify-product-page https://vibetv.example.test/products/expected-plus-wrong synthwave \
+        2>&1
+  )"
+  status=$?
+  set -e
+
+  [[ "$status" -ne 0 ]] || die "expected extra wrong Shopify install link check to fail"
+  assert_contains "$output" "wrong Control Center install link: https://app.example.test/install/clippy"
+}
+
+run_expect_invalid_theme_id_failure() {
+  local output status
+  set +e
+  output="$(
+    CONTROL_CENTER_READINESS_CURL="$FAKE_CURL" \
+      "$READINESS" \
+        --shopify-app-url https://app.example.test \
+        --shopify-product-page https://vibetv.example.test/products/synthwave 'synthwave/../clippy' \
+        2>&1
+  )"
+  status=$?
+  set -e
+
+  [[ "$status" -ne 0 ]] || die "expected invalid Shopify theme_id check to fail"
+  assert_contains "$output" "invalid theme_id: expected 3-64 lowercase letters, numbers, hyphens, or underscores"
 }
 
 run_expect_local_url_guard_failure() {
@@ -491,21 +580,46 @@ JSON
   https://vibetv.example.test/products/synthwave-theme)
     cat <<'HTML'
 <!doctype html>
-<button>Copy install command</button>
-<code>curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash && codexbar-display theme-pack install --theme synthwave --target http://vibetv.local</code>
+<a href="https://app.example.test/install/synthwave">Open in Control Center</a>
 HTML
     ;;
   https://vibetv.example.test/products/clippy-theme)
     cat <<'HTML'
 <!doctype html>
-<button>Copy install command</button>
-<code>curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash && codexbar-display theme-pack install --theme clippy --target http://vibetv.local</code>
+<a href="https://app.example.test/install/clippy">Open in Control Center</a>
 HTML
     ;;
   https://vibetv.example.test/products/broken)
     cat <<'HTML'
 <!doctype html>
 <button>Check compatibility in the app</button>
+HTML
+    ;;
+  https://vibetv.example.test/products/legacy)
+    cat <<'HTML'
+<!doctype html>
+<a href="https://app.example.test/install/synthwave">Open in Control Center</a>
+<button>Copy install command</button>
+<code>curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash &amp;&amp; codexbar-display theme-pack install --theme synthwave --target http://vibetv.local</code>
+HTML
+    ;;
+  https://vibetv.example.test/products/wrong-theme)
+    cat <<'HTML'
+<!doctype html>
+<a href="https://app.example.test/install/clippy">Open in Control Center</a>
+HTML
+    ;;
+  https://vibetv.example.test/products/noncanonical)
+    cat <<'HTML'
+<!doctype html>
+<a href="https://app.example.test/install/%73ynthwave">Open in Control Center</a>
+HTML
+    ;;
+  https://vibetv.example.test/products/expected-plus-wrong)
+    cat <<'HTML'
+<!doctype html>
+<a href="https://app.example.test/install/synthwave">Open in Control Center</a>
+<a href="https://app.example.test/install/clippy">Open another theme</a>
 HTML
     ;;
   *)
@@ -518,6 +632,11 @@ chmod +x "$FAKE_CURL"
 
 run_expect_success
 run_expect_broken_product_page_failure
+run_expect_legacy_product_command_failure
+run_expect_wrong_theme_link_failure
+run_expect_noncanonical_install_url_failure
+run_expect_expected_plus_wrong_link_failure
+run_expect_invalid_theme_id_failure
 run_expect_local_url_guard_failure
 run_expect_missing_free_pack_url_failure
 run_expect_invalid_free_pack_url_failure


### PR DESCRIPTION
## What changed

- require every public Shopify theme product to link to the exact matching `https://app.vibetv.shop/install/<theme_id>` route
- reject legacy `Copy install command` / `codexbar-display theme-pack install` content
- reject wrong, noncanonical, and additional Control Center install links
- align the readiness documentation and local Liquid example with the already-live Control Center journey

## Why

The readiness checker still expected the retired terminal-install flow even though the live Shopify product pages already use the Control Center install routes. That made the automated Customer-Ready Gate fail against correct production pages.

This is intentionally split from the Theme Studio work in #147 so that the readiness fix can be reviewed independently.

## Customer impact

No live Shopify content is changed by this PR. It makes automated validation match the current customer journey and keeps the documented fallback example from reintroducing the retired terminal command.

## Validation

- `./scripts/test-control-center-companion-customer-readiness.sh`
- `./scripts/check-control-center-customer-docs.sh`
- shell syntax checks for both readiness scripts
- read-only live readiness check for Synthwave, Clippy, and Claude Creature
- `git diff --check`

No hardware writes, live-shop writes, merge, tag, or release were performed.
