### PR TITLE
CODEX: Repin DMG validation to stable JSON parser

### DIFF
--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  CODEX_VALIDATION_SOURCE_SHA: "03d50b8cc2a79a153d856b5e90082a795fbdff4c"
+  CODEX_VALIDATION_SOURCE_SHA: "73eb6461621cf59efc9ab0325999ba3c8f22d61f"
   CODEX_VALIDATION_VERSION: "1.0.42"
 
 jobs:
@@ -187,7 +187,7 @@ jobs:
             fi
           }
 
-          verify_hash 18ce94f778732ddf546cac95c95d5d2c85d6f325a655a900696aea97698b05a1 \
+          verify_hash d2c68b71bbbbb62af41804b8706a48646e4a578c898e8bf6d3496da0fa4de6b2 \
             scripts/sign-notarize-macos-control-center.sh
           verify_hash 7c5237b4cf8c9f43e0b387e3a46b8b11d86403c8a1c922fd73fc1bc6978a7ba9 \
             scripts/build-macos-control-center-app.sh
@@ -250,7 +250,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$(shasum -a 256 scripts/sign-notarize-macos-control-center.sh | awk '{print $1}')" = \
-            18ce94f778732ddf546cac95c95d5d2c85d6f325a655a900696aea97698b05a1
+            d2c68b71bbbbb62af41804b8706a48646e4a578c898e8bf6d3496da0fa4de6b2
           test "$(shasum -a 256 scripts/verify-macos-control-center-dmg.sh | awk '{print $1}')" = \
             c67232b586049c6080a4fa992f1aa90054e73817e7500fbf86f2aeefcb135196
 


### PR DESCRIPTION
## What changed

- repins validation to feature commit `73eb6461621cf59efc9ab0325999ba3c8f22d61f`
- updates the immutable signing-script hash to `d2c68b71bbbbb62af41804b8706a48646e4a578c898e8bf6d3496da0fa4de6b2`

## Why

Run 3 returned exactly one expected `Internal Xprotect Error` JSON object with exit 70 and empty stderr. The previous classifier still rejected it because it used `plutil -p`, whose human-readable output is explicitly not stable for machine parsing across macOS versions.

The feature fix now uses Python's JSON parser and whole-object equality. It is key-order independent but still rejects every additional root or nested key, additional diagnostic, changed value, wrong type, malformed JSON, non-70 exit, or non-empty stderr.

## Safety

- validation-only exception remains opt-in and limited to `--sign-app-only`
- release workflow does not enable it
- real Apple `Accepted` plus issue-free Notary log, stapling, DMG/app policy, and Gatekeeper gates remain mandatory
- no signed DMG or full Notary-log artifact upload
- no tag, release, deployment, or hardware action

## Validation

- macOS bundle and release workflow tests
- exact Run-3 key-order fixture plus combined-error, extra-root, wrong-type, stderr, and wrong-exit negative tests
- `actionlint` 1.7.7, YAML, 12 embedded Bash blocks, hash pins, and forbidden-action scan
- independent review: no P1/P2 findings
