### PR TITLE
CODEX: Repin DMG validation for outer ticket check

### DIFF
--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  CODEX_VALIDATION_SOURCE_SHA: "73eb6461621cf59efc9ab0325999ba3c8f22d61f"
+  CODEX_VALIDATION_SOURCE_SHA: "5d367e7619e4c13d9d509b75057069d315ef673e"
   CODEX_VALIDATION_VERSION: "1.0.42"
 
 jobs:
@@ -193,7 +193,7 @@ jobs:
             scripts/build-macos-control-center-app.sh
           verify_hash 2cb1c86cb6d45a3b93539861a25ad0298b60abb6138c3a737142a4dcfa724eba \
             scripts/build-macos-control-center-dmg.sh
-          verify_hash c67232b586049c6080a4fa992f1aa90054e73817e7500fbf86f2aeefcb135196 \
+          verify_hash 69eb6aa8d08e3eb6bb88efc6b4cd931a4d2270ac8b3c378b1fdb68e56e1523ee \
             scripts/verify-macos-control-center-dmg.sh
           verify_hash f4cb5afb06a2d0f12377492bb240e5b3edc23f64e106575d5fe8a2197d532ed7 \
             macos/VibeTVControlCenter/VibeTVControlCenter.entitlements
@@ -252,7 +252,7 @@ jobs:
           test "$(shasum -a 256 scripts/sign-notarize-macos-control-center.sh | awk '{print $1}')" = \
             d2c68b71bbbbb62af41804b8706a48646e4a578c898e8bf6d3496da0fa4de6b2
           test "$(shasum -a 256 scripts/verify-macos-control-center-dmg.sh | awk '{print $1}')" = \
-            c67232b586049c6080a4fa992f1aa90054e73817e7500fbf86f2aeefcb135196
+            69eb6aa8d08e3eb6bb88efc6b4cd931a4d2270ac8b3c378b1fdb68e56e1523ee
 
       - name: Sign, notarize, and staple DMG
         env:


### PR DESCRIPTION
## Summary

- pin the validation-only workflow to feature commit `5d367e7619e4c13d9d509b75057069d315ef673e`
- repin the shared DMG verifier hash after narrowly handling Apple's known outer-container ticket diagnostic
- keep the signing script, builders, entitlements, bundle version, permissions, and artifact policy unchanged

## Why

Validation run 4 completed Developer ID signing and Apple notarization successfully (`Accepted`, submission `0b23686f-349b-44b7-acf0-1d5dad0f7376`, no notary issues). The remaining failure was `syspolicy_check distribution` reporting `Notary Ticket Missing` for the app inside an already notarized and stapled outer DMG. Apple documents that the outermost distributed container carries the ticket and that this diagnostic is not always fatal.

The pinned verifier allows only the exact JSON diagnostic (exit 70, empty stderr, one matching app diagnostic, no extra fields/messages), then still requires the mounted app to pass Gatekeeper with `source=Notarized Developer ID`. Every other policy error remains fatal.

## Validation

- `actionlint` v1.7.7
- workflow YAML parse and all embedded Bash syntax
- immutable source and all five trusted-file hashes
- no-publish / read-only permissions scan
- `scripts/test-macos-control-center-app-bundle.sh`
- `scripts/test-control-center-release-workflow.sh`
- `npm run test:customer-flows` from `apps/control-center`
- `git diff --check`
- independent review: no P1/P2 findings

## Safety

Validation-only: no tag, release, deployment, public DMG upload, or hardware write.
