### PR TITLE
CODEX Add encrypted macOS validation artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
       - name: Test Control Center release workflow
         run: ./scripts/test-control-center-release-workflow.sh
 
+      - name: Test macOS DMG validation workflow
+        run: ./scripts/test-macos-dmg-validation-workflow.sh
+
+      - name: Test macOS DMG encrypted artifact helper
+        run: ./scripts/test-macos-dmg-validation-artifact.sh
+
       - name: Test legacy install.sh Control Center migration
         run: ./scripts/test-install-sh-control-center-migration.sh
 

--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -2,6 +2,12 @@ name: CODEX Validate macOS DMG
 
 on:
   workflow_dispatch:
+    inputs:
+      dmg_recipient_certificate_base64:
+        description: Base64-encoded PEM PUBLIC RSA certificate for an encrypted one-day test artifact
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -17,6 +23,7 @@ env:
 jobs:
   build-unsigned-macos-app:
     if: >-
+      github.event_name == 'workflow_dispatch' &&
       github.repository == 'DreamyTalesPAN/CodexBar-Display' &&
       github.ref == 'refs/heads/main' &&
       github.actor == github.repository_owner &&
@@ -111,6 +118,7 @@ jobs:
   sign-and-notarize-macos-dmg:
     needs: build-unsigned-macos-app
     if: >-
+      github.event_name == 'workflow_dispatch' &&
       needs.build-unsigned-macos-app.result == 'success' &&
       github.repository == 'DreamyTalesPAN/CodexBar-Display' &&
       github.ref == 'refs/heads/main' &&
@@ -295,5 +303,72 @@ jobs:
             echo "- Apple notarization: \`${notary_status}\`"
             echo "- Apple submission: \`${submission_id}\`"
             echo "- DMG SHA-256: \`${dmg_sha256}\`"
-            echo "- Signed DMG upload: intentionally disabled for validation-only"
+            echo "- Plaintext signed DMG upload: disabled"
+            echo "- Notary-log upload: disabled"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Checkout current workflow orchestration
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.dmg_recipient_certificate_base64 != ''
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.sha }}
+          path: tmp/workflow-orchestration
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Encrypt signed DMG test artifact
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.dmg_recipient_certificate_base64 != ''
+        env:
+          CODEX_DMG_RECIPIENT_CERTIFICATE_BASE64: ${{ inputs.dmg_recipient_certificate_base64 }}
+        run: |
+          set -euo pipefail
+          orchestration_dir="tmp/workflow-orchestration"
+          actual_sha="$(git -C "${orchestration_dir}" rev-parse HEAD)"
+          if [[ "${actual_sha}" != "${GITHUB_SHA}" ]]; then
+            echo "error: checked out workflow orchestration ${actual_sha}, expected ${GITHUB_SHA}" >&2
+            exit 1
+          fi
+
+          encryptor="${orchestration_dir}/scripts/encrypt-macos-dmg-test-artifact.sh"
+          expected_encryptor_sha256="7d9af43633794a50762762fa90bd1d79466bb47adbc5461e2a57645c73bbe3c2"
+          actual_encryptor_sha256="$(shasum -a 256 "${encryptor}" | awk '{print $1}')"
+          if [[ "${actual_encryptor_sha256}" != "${expected_encryptor_sha256}" ]]; then
+            echo "error: untrusted encrypted-artifact helper hash ${actual_encryptor_sha256}" >&2
+            exit 1
+          fi
+
+          "${encryptor}" \
+            --dmg "dist/macos/VibeTV-Control-Center.dmg" \
+            --output-dir "tmp/macos-validation/encrypted-artifact"
+
+      - name: Upload encrypted signed DMG test artifact
+        id: upload_encrypted_test_dmg
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.dmg_recipient_certificate_base64 != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: CODEX-vibetv-control-center-signed-encrypted-${{ github.run_id }}
+          path: tmp/macos-validation/encrypted-artifact/VibeTV-Control-Center.dmg.cms
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          include-hidden-files: false
+
+      - name: Record encrypted test artifact evidence
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.dmg_recipient_certificate_base64 != ''
+        env:
+          CODEX_ENCRYPTED_ARTIFACT_DIGEST: ${{ steps.upload_encrypted_test_dmg.outputs.artifact-digest }}
+        run: |
+          {
+            echo "- Encrypted signed DMG test artifact: \`CODEX-vibetv-control-center-signed-encrypted-${GITHUB_RUN_ID}\`"
+            echo "- Artifact encryption: \`CMS AES-256-CBC with RSA-OAEP SHA-256\`"
+            echo "- GitHub artifact digest: \`${CODEX_ENCRYPTED_ARTIFACT_DIGEST}\`"
+            echo "- Artifact retention: \`1 day\`"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/scripts/encrypt-macos-dmg-test-artifact.sh
+++ b/scripts/encrypt-macos-dmg-test-artifact.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+umask 077
+
+readonly EXPECTED_DMG_NAME="VibeTV-Control-Center.dmg"
+readonly OPENSSL="/usr/bin/openssl"
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: encrypt-macos-dmg-test-artifact.sh --dmg PATH --output-dir PATH
+
+Requires CODEX_DMG_RECIPIENT_CERTIFICATE_BASE64 to contain a base64-encoded
+PEM X.509 certificate with an RSA public key of at least 3072 bits.
+USAGE
+  exit 2
+}
+
+sha256_file() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+dmg=""
+output_dir=""
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --dmg)
+      [[ "$#" -ge 2 ]] || usage
+      [[ -z "$dmg" ]] || die "--dmg may only be provided once"
+      dmg="$2"
+      shift 2
+      ;;
+    --output-dir)
+      [[ "$#" -ge 2 ]] || usage
+      [[ -z "$output_dir" ]] || die "--output-dir may only be provided once"
+      output_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$dmg" ]] || usage
+[[ -n "$output_dir" ]] || usage
+[[ -x "$OPENSSL" ]] || die "required OpenSSL executable is unavailable: $OPENSSL"
+[[ -n "${CODEX_DMG_RECIPIENT_CERTIFICATE_BASE64:-}" ]] \
+  || die "CODEX_DMG_RECIPIENT_CERTIFICATE_BASE64 is required"
+[[ -f "$dmg" && -r "$dmg" ]] || die "DMG is not a readable regular file: $dmg"
+[[ "$(basename "$dmg")" == "$EXPECTED_DMG_NAME" ]] \
+  || die "DMG basename must be exactly $EXPECTED_DMG_NAME"
+
+[[ ! -L "$output_dir" ]] || die "output directory must not be a symbolic link"
+if [[ -e "$output_dir" ]]; then
+  [[ -d "$output_dir" ]] || die "output path exists and is not a directory: $output_dir"
+  [[ -z "$(find "$output_dir" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
+    || die "output directory must be empty: $output_dir"
+fi
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-dmg-cms.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+decoded_certificate="$tmp_dir/recipient-certificate.decoded"
+canonical_certificate="$tmp_dir/recipient-certificate.pem"
+certificate_der="$tmp_dir/recipient-certificate.der"
+cms_artifact="$tmp_dir/${EXPECTED_DMG_NAME}.cms"
+
+printf '%s' "$CODEX_DMG_RECIPIENT_CERTIFICATE_BASE64" \
+  | "$OPENSSL" base64 -d -A >"$decoded_certificate" \
+  || die "recipient certificate is not valid base64"
+
+if LC_ALL=C grep -aFq "PRIVATE KEY" "$decoded_certificate"; then
+  die "recipient input must not contain a private key"
+fi
+
+"$OPENSSL" x509 \
+  -in "$decoded_certificate" \
+  -inform PEM \
+  -out "$canonical_certificate" \
+  -outform PEM \
+  >/dev/null 2>&1 \
+  || die "recipient input is not a valid PEM X.509 certificate"
+
+"$OPENSSL" x509 -in "$canonical_certificate" -checkend 3600 -noout >/dev/null 2>&1 \
+  || die "recipient certificate must remain valid for at least one hour"
+
+rsa_details="$tmp_dir/rsa-public-key.txt"
+if ! "$OPENSSL" x509 -in "$canonical_certificate" -pubkey -noout \
+  | "$OPENSSL" rsa -pubin -text -noout >"$rsa_details" 2>/dev/null; then
+  die "recipient certificate must contain an RSA public key"
+fi
+
+rsa_bits="$(sed -nE 's/^[[:space:]]*([^:]+[[:space:]])?Public-Key: \(([0-9]+) bit\).*$/\2/p' "$rsa_details" | head -n1)"
+[[ "$rsa_bits" =~ ^[0-9]+$ ]] || die "could not determine recipient RSA key size"
+(( rsa_bits >= 3072 )) || die "recipient RSA key must be at least 3072 bits"
+
+"$OPENSSL" x509 \
+  -in "$canonical_certificate" \
+  -outform DER \
+  -out "$certificate_der" \
+  >/dev/null 2>&1 \
+  || die "failed to canonicalize recipient certificate"
+
+"$OPENSSL" cms \
+  -encrypt \
+  -binary \
+  -aes256 \
+  -in "$dmg" \
+  -outform DER \
+  -out "$cms_artifact" \
+  -recip "$canonical_certificate" \
+  -keyopt rsa_padding_mode:oaep \
+  -keyopt rsa_oaep_md:sha256 \
+  -keyopt rsa_mgf1_md:sha256 \
+  >/dev/null 2>&1 \
+  || die "failed to encrypt DMG as CMS EnvelopedData"
+
+"$OPENSSL" cms -cmsout -inform DER -in "$cms_artifact" -noout >/dev/null 2>&1 \
+  || die "encrypted CMS artifact failed structural validation"
+
+staged_output="$tmp_dir/output"
+mkdir "$staged_output"
+mv "$cms_artifact" "$staged_output/${EXPECTED_DMG_NAME}.cms"
+printf '%s  %s\n' "$(sha256_file "$dmg")" "$EXPECTED_DMG_NAME" \
+  >"$staged_output/${EXPECTED_DMG_NAME}.sha256"
+printf '%s  %s\n' \
+  "$(sha256_file "$staged_output/${EXPECTED_DMG_NAME}.cms")" \
+  "${EXPECTED_DMG_NAME}.cms" \
+  >"$staged_output/${EXPECTED_DMG_NAME}.cms.sha256"
+printf '%s  %s\n' "$(sha256_file "$certificate_der")" "recipient-certificate.der" \
+  >"$staged_output/recipient-certificate.der.sha256"
+
+mkdir -p "$output_dir"
+mv "$staged_output"/* "$output_dir"/
+
+printf 'encrypted DMG test artifact created: %s/%s.cms\n' \
+  "$output_dir" "$EXPECTED_DMG_NAME"

--- a/scripts/test-macos-dmg-validation-artifact.sh
+++ b/scripts/test-macos-dmg-validation-artifact.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENCRYPTOR="${ROOT}/scripts/encrypt-macos-dmg-test-artifact.sh"
+OPENSSL="/usr/bin/openssl"
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+base64_file() {
+  "$OPENSSL" base64 -A -in "$1"
+}
+
+sha256_file() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+assert_hash_file() {
+  local metadata="$1"
+  local source="$2"
+  local recorded_name="$3"
+  local expected_line
+
+  expected_line="$(sha256_file "$source")  $recorded_name"
+  [[ "$(cat "$metadata")" == "$expected_line" ]] \
+    || die "incorrect SHA-256 metadata: $metadata"
+}
+
+assert_clean_failed_output() {
+  local output_dir="$1"
+  if [[ -d "$output_dir" ]]; then
+    [[ -z "$(find "$output_dir" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
+      || die "failed encryption left output files behind: $output_dir"
+  fi
+}
+
+expect_encrypt_failure() {
+  local description="$1"
+  local certificate_base64="$2"
+  local output_dir="$3"
+
+  if CODEX_DMG_RECIPIENT_CERTIFICATE_BASE64="$certificate_base64" \
+    "$ENCRYPTOR" --dmg "$DMG" --output-dir "$output_dir" >/dev/null 2>&1; then
+    die "encryption unexpectedly accepted $description"
+  fi
+  assert_clean_failed_output "$output_dir"
+}
+
+[[ -x "$OPENSSL" ]] || die "required OpenSSL executable is unavailable: $OPENSSL"
+[[ -x "$ENCRYPTOR" ]] || die "encryptor is missing or not executable: $ENCRYPTOR"
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-dmg-cms-test.XXXXXX")"
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+
+DMG="$TMP_ROOT/VibeTV-Control-Center.dmg"
+printf 'harmless VibeTV validation fixture\n' >"$DMG"
+
+recipient_key="$TMP_ROOT/recipient-key.pem"
+recipient_certificate="$TMP_ROOT/recipient-certificate.pem"
+"$OPENSSL" req -new -x509 -newkey rsa:3072 -nodes -sha256 -days 1 \
+  -subj "/CN=VibeTV DMG validation recipient" \
+  -keyout "$recipient_key" \
+  -out "$recipient_certificate" \
+  >/dev/null 2>&1
+
+output_dir="$TMP_ROOT/output"
+CODEX_DMG_RECIPIENT_CERTIFICATE_BASE64="$(base64_file "$recipient_certificate")" \
+  "$ENCRYPTOR" --dmg "$DMG" --output-dir "$output_dir" >/dev/null
+
+expected_files="$(printf '%s\n' \
+  "VibeTV-Control-Center.dmg.cms" \
+  "VibeTV-Control-Center.dmg.cms.sha256" \
+  "VibeTV-Control-Center.dmg.sha256" \
+  "recipient-certificate.der.sha256" | LC_ALL=C sort)"
+actual_files="$(find "$output_dir" -mindepth 1 -maxdepth 1 -type f -exec basename {} \; | LC_ALL=C sort)"
+[[ "$actual_files" == "$expected_files" ]] \
+  || die "output directory contains missing or unexpected files"
+
+cms="$output_dir/VibeTV-Control-Center.dmg.cms"
+decrypted="$TMP_ROOT/decrypted.dmg"
+"$OPENSSL" cms -decrypt -binary -inform DER \
+  -in "$cms" \
+  -recip "$recipient_certificate" \
+  -inkey "$recipient_key" \
+  -out "$decrypted" \
+  >/dev/null 2>&1
+cmp -s "$DMG" "$decrypted" || die "CMS roundtrip changed the DMG bytes"
+
+assert_hash_file "$output_dir/VibeTV-Control-Center.dmg.sha256" \
+  "$DMG" "VibeTV-Control-Center.dmg"
+assert_hash_file "$output_dir/VibeTV-Control-Center.dmg.cms.sha256" \
+  "$cms" "VibeTV-Control-Center.dmg.cms"
+
+recipient_der="$TMP_ROOT/recipient-certificate.der"
+"$OPENSSL" x509 -in "$recipient_certificate" -outform DER -out "$recipient_der"
+assert_hash_file "$output_dir/recipient-certificate.der.sha256" \
+  "$recipient_der" "recipient-certificate.der"
+
+cms_details="$TMP_ROOT/cms-details.txt"
+"$OPENSSL" cms -cmsout -print -inform DER -in "$cms" >"$cms_details"
+grep -Fq "rsaesOaep" "$cms_details" || die "CMS does not use RSA-OAEP"
+grep -Fq "aes-256-cbc" "$cms_details" || die "CMS does not use AES-256-CBC"
+grep -Fq "mgf1" "$cms_details" || die "CMS does not identify MGF1"
+sha256_mentions="$(grep -cF "sha256" "$cms_details" || true)"
+(( sha256_mentions >= 2 )) \
+  || die "CMS does not use SHA-256 for both OAEP and MGF1"
+
+wrong_key="$TMP_ROOT/wrong-key.pem"
+wrong_certificate="$TMP_ROOT/wrong-certificate.pem"
+"$OPENSSL" req -new -x509 -newkey rsa:3072 -nodes -sha256 -days 1 \
+  -subj "/CN=Wrong VibeTV recipient" \
+  -keyout "$wrong_key" \
+  -out "$wrong_certificate" \
+  >/dev/null 2>&1
+if "$OPENSSL" cms -decrypt -binary -inform DER \
+  -in "$cms" \
+  -recip "$wrong_certificate" \
+  -inkey "$wrong_key" \
+  -out "$TMP_ROOT/wrong-key-output.dmg" \
+  >/dev/null 2>&1; then
+  die "CMS decrypted with the wrong private key"
+fi
+
+malformed_certificate="$TMP_ROOT/malformed-certificate.txt"
+printf 'not an X.509 certificate\n' >"$malformed_certificate"
+expect_encrypt_failure \
+  "a malformed certificate" \
+  "$(base64_file "$malformed_certificate")" \
+  "$TMP_ROOT/malformed-output"
+
+ec_key="$TMP_ROOT/ec-key.pem"
+ec_certificate="$TMP_ROOT/ec-certificate.pem"
+"$OPENSSL" ecparam -name prime256v1 -genkey -noout -out "$ec_key"
+"$OPENSSL" req -new -x509 -sha256 -days 1 \
+  -subj "/CN=Unsupported EC recipient" \
+  -key "$ec_key" \
+  -out "$ec_certificate" \
+  >/dev/null 2>&1
+expect_encrypt_failure \
+  "an EC certificate" \
+  "$(base64_file "$ec_certificate")" \
+  "$TMP_ROOT/ec-output"
+
+rsa2048_key="$TMP_ROOT/rsa2048-key.pem"
+rsa2048_certificate="$TMP_ROOT/rsa2048-certificate.pem"
+"$OPENSSL" req -new -x509 -newkey rsa:2048 -nodes -sha256 -days 1 \
+  -subj "/CN=Undersized RSA recipient" \
+  -keyout "$rsa2048_key" \
+  -out "$rsa2048_certificate" \
+  >/dev/null 2>&1
+expect_encrypt_failure \
+  "a 2048-bit RSA certificate" \
+  "$(base64_file "$rsa2048_certificate")" \
+  "$TMP_ROOT/rsa2048-output"
+
+expect_encrypt_failure \
+  "a private key instead of a certificate" \
+  "$(base64_file "$recipient_key")" \
+  "$TMP_ROOT/private-key-output"
+
+nonempty_output="$TMP_ROOT/nonempty-output"
+mkdir "$nonempty_output"
+printf 'stale artifact\n' >"$nonempty_output/stale.txt"
+if CODEX_DMG_RECIPIENT_CERTIFICATE_BASE64="$(base64_file "$recipient_certificate")" \
+  "$ENCRYPTOR" --dmg "$DMG" --output-dir "$nonempty_output" >/dev/null 2>&1; then
+  die "encryption unexpectedly accepted a nonempty output directory"
+fi
+[[ "$(cat "$nonempty_output/stale.txt")" == "stale artifact" ]] \
+  || die "nonempty output directory was modified"
+[[ "$(find "$nonempty_output" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" == "1" ]] \
+  || die "nonempty output directory gained unexpected files"
+
+printf 'macOS DMG validation artifact test passed\n'

--- a/scripts/test-macos-dmg-validation-workflow.sh
+++ b/scripts/test-macos-dmg-validation-workflow.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="${ROOT}/.github/workflows/validate-macos-dmg.yml"
+ENCRYPTOR="${ROOT}/scripts/encrypt-macos-dmg-test-artifact.sh"
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="$3"
+  [[ "$haystack" == *"$needle"* ]] || die "$message"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="$3"
+  [[ "$haystack" != *"$needle"* ]] || die "$message"
+}
+
+top_level_block() {
+  local key="$1"
+  awk -v key="$key" '
+    $0 == key ":" { in_block = 1; print; next }
+    in_block && $0 ~ /^[^[:space:]]/ { exit }
+    in_block { print }
+  ' "$WORKFLOW"
+}
+
+job_block() {
+  local job="$1"
+  awk -v job="$job" '
+    $0 == "  " job ":" { in_job = 1; print; next }
+    in_job && $0 ~ /^  [A-Za-z0-9_-]+:/ { exit }
+    in_job { print }
+  ' "$WORKFLOW"
+}
+
+step_block() {
+  local step="$1"
+  awk -v step="$step" '
+    $0 == "      - name: " step { in_step = 1; print; next }
+    in_step && $0 ~ /^      - name:/ { exit }
+    in_step { print }
+  ' "$WORKFLOW"
+}
+
+run_block() {
+  local step="$1"
+  step_block "$step" | awk '
+    in_run && $0 == "" { print; next }
+    in_run && $0 ~ /^          / { sub(/^          /, ""); print; next }
+    in_run { exit }
+    $0 == "        run: |" { in_run = 1 }
+  '
+}
+
+line_number() {
+  local needle="$1"
+  grep -nF "$needle" "$WORKFLOW" | head -n1 | cut -d: -f1
+}
+
+main() {
+  [[ -f "$WORKFLOW" ]] || die "macOS DMG validation workflow is missing"
+  [[ -x "$ENCRYPTOR" ]] || die "macOS DMG encryption helper is missing or not executable"
+
+  local trigger_block trigger_block_lower permissions_block build_job signing_job
+  local checkout_step encrypt_step encrypt_run upload_step summary_step
+  local event_count permissions_count uses_line
+  local verifier_line evidence_line checkout_line encrypt_line upload_line summary_line
+  local actual_encryptor_sha256
+
+  actual_encryptor_sha256="$(shasum -a 256 "$ENCRYPTOR" | awk '{print $1}')"
+  [[ "$actual_encryptor_sha256" == "7d9af43633794a50762762fa90bd1d79466bb47adbc5461e2a57645c73bbe3c2" ]] \
+    || die "encryption helper changed without updating its reviewed workflow pin"
+
+  trigger_block="$(top_level_block "on")"
+  trigger_block_lower="$(printf '%s\n' "$trigger_block" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
+  permissions_block="$(top_level_block "permissions")"
+  build_job="$(job_block "build-unsigned-macos-app")"
+  signing_job="$(job_block "sign-and-notarize-macos-dmg")"
+  checkout_step="$(step_block "Checkout current workflow orchestration")"
+  encrypt_step="$(step_block "Encrypt signed DMG test artifact")"
+  encrypt_run="$(run_block "Encrypt signed DMG test artifact")"
+  upload_step="$(step_block "Upload encrypted signed DMG test artifact")"
+  summary_step="$(step_block "Record encrypted test artifact evidence")"
+
+  event_count="$(printf '%s\n' "$trigger_block" | grep -Ec '^  [A-Za-z0-9_-]+:')"
+  [[ "$event_count" == "1" ]] || die "validation workflow must only use workflow_dispatch"
+  assert_contains "$trigger_block" "  workflow_dispatch:" \
+    "validation workflow must use workflow_dispatch"
+  assert_contains "$trigger_block" "      dmg_recipient_certificate_base64:" \
+    "validation workflow must expose the optional public certificate input"
+  assert_contains "$trigger_block" "        required: false" \
+    "public certificate input must be optional"
+  assert_contains "$trigger_block" "        type: string" \
+    "public certificate input must be a string"
+  assert_contains "$trigger_block" '        default: ""' \
+    "public certificate input must default to empty"
+  assert_contains "$trigger_block" "PUBLIC RSA certificate" \
+    "input description must make its public-only purpose clear"
+  assert_not_contains "$trigger_block_lower" "password" \
+    "workflow_dispatch must not accept an artifact password"
+  assert_not_contains "$trigger_block_lower" "private key" \
+    "workflow_dispatch must not accept a private key"
+
+  permissions_count="$(grep -c '^permissions:' "$WORKFLOW")"
+  [[ "$permissions_count" == "1" ]] || die "workflow must have exactly one permissions block"
+  assert_contains "$permissions_block" "  contents: read" \
+    "workflow permissions must remain contents: read"
+  assert_not_contains "$permissions_block" "write" \
+    "validation workflow must not receive write permissions"
+  [[ "$(printf '%s\n' "$permissions_block" | grep -Ec '^  [A-Za-z0-9_-]+:')" == "1" ]] \
+    || die "validation workflow must not receive permissions beyond contents: read"
+
+  for job in "$build_job" "$signing_job"; do
+    assert_contains "$job" "github.event_name == 'workflow_dispatch'" \
+      "each validation job must enforce workflow_dispatch"
+    assert_contains "$job" "github.repository == 'DreamyTalesPAN/CodexBar-Display'" \
+      "each validation job must enforce the trusted repository"
+    assert_contains "$job" "github.ref == 'refs/heads/main'" \
+      "each validation job must enforce main"
+    assert_contains "$job" "github.actor == github.repository_owner" \
+      "each validation job must enforce the repository owner actor"
+    assert_contains "$job" "github.triggering_actor == github.repository_owner" \
+      "each validation job must enforce the repository owner triggering actor"
+  done
+
+  while IFS= read -r uses_line; do
+    [[ "$uses_line" =~ uses:[[:space:]]+[^[:space:]@]+@[0-9a-f]{40}([[:space:]]+#[[:space:]].*)?$ ]] \
+      || die "workflow action is not pinned to a full commit SHA: $uses_line"
+  done < <(grep -E '^[[:space:]]+uses:' "$WORKFLOW")
+
+  assert_contains "$checkout_step" "inputs.dmg_recipient_certificate_base64 != ''" \
+    "orchestration checkout must require a recipient certificate"
+  assert_contains "$checkout_step" 'ref: ${{ github.sha }}' \
+    "orchestration checkout must use the dispatched workflow commit"
+  assert_contains "$checkout_step" "path: tmp/workflow-orchestration" \
+    "orchestration checkout must remain isolated"
+  assert_contains "$checkout_step" "persist-credentials: false" \
+    "orchestration checkout must not persist credentials"
+
+  assert_contains "$encrypt_step" "inputs.dmg_recipient_certificate_base64 != ''" \
+    "encryption must require a recipient certificate"
+  assert_contains "$encrypt_step" \
+    'CODEX_DMG_RECIPIENT_CERTIFICATE_BASE64: ${{ inputs.dmg_recipient_certificate_base64 }}' \
+    "recipient certificate must enter the helper through step env"
+  assert_contains "$encrypt_run" '"${orchestration_dir}/scripts/encrypt-macos-dmg-test-artifact.sh"' \
+    "workflow must resolve the reviewed encryption helper"
+  assert_contains "$encrypt_run" \
+    'expected_encryptor_sha256="7d9af43633794a50762762fa90bd1d79466bb47adbc5461e2a57645c73bbe3c2"' \
+    "workflow must pin the reviewed encryption helper hash"
+  assert_contains "$encrypt_run" 'actual_encryptor_sha256="$(shasum -a 256 "${encryptor}" | awk' \
+    "workflow must verify the encryption helper before execution"
+  assert_contains "$encrypt_run" '"${encryptor}" \' \
+    "workflow must only execute the hash-verified encryption helper"
+  assert_contains "$encrypt_run" '--dmg "dist/macos/VibeTV-Control-Center.dmg"' \
+    "encryption helper must receive the signed DMG"
+  assert_contains "$encrypt_run" '--output-dir "tmp/macos-validation/encrypted-artifact"' \
+    "encryption helper must write to the isolated artifact directory"
+  assert_not_contains "$encrypt_run" '${{ inputs.' \
+    "workflow input must not be interpolated directly into shell code"
+
+  assert_contains "$upload_step" "inputs.dmg_recipient_certificate_base64 != ''" \
+    "encrypted artifact upload must require a recipient certificate"
+  assert_contains "$upload_step" \
+    "uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" \
+    "encrypted upload action must remain pinned"
+  assert_contains "$upload_step" \
+    "path: tmp/macos-validation/encrypted-artifact/VibeTV-Control-Center.dmg.cms" \
+    "upload must contain exactly the CMS-wrapped DMG"
+  [[ "$(printf '%s\n' "$upload_step" | grep -c '^          path:')" == "1" ]] \
+    || die "encrypted upload must contain exactly one path"
+  assert_contains "$upload_step" "retention-days: 1" \
+    "encrypted artifact retention must remain one day"
+  assert_contains "$upload_step" "compression-level: 0" \
+    "encrypted artifact must not be recompressed"
+  assert_contains "$upload_step" "include-hidden-files: false" \
+    "encrypted artifact upload must exclude hidden files"
+  assert_contains "$upload_step" "if-no-files-found: error" \
+    "encrypted artifact upload must fail closed"
+  assert_not_contains "$upload_step" "dist/macos/VibeTV-Control-Center.dmg" \
+    "plaintext DMG must never be uploaded"
+  assert_not_contains "$upload_step" "notarization-log.json" \
+    "notarization log must never be uploaded"
+  assert_not_contains "$upload_step" "*" \
+    "encrypted upload path must not use a glob"
+
+  assert_contains "$summary_step" \
+    'CODEX_ENCRYPTED_ARTIFACT_DIGEST: ${{ steps.upload_encrypted_test_dmg.outputs.artifact-digest }}' \
+    "summary must record the upload action digest through step env"
+  assert_not_contains "$(run_block "Record encrypted test artifact evidence")" '${{ ' \
+    "action outputs must not be interpolated directly into shell code"
+
+  verifier_line="$(line_number "Verify notarized DMG for distribution")"
+  evidence_line="$(line_number "Record validation evidence without publishing the DMG")"
+  checkout_line="$(line_number "Checkout current workflow orchestration")"
+  encrypt_line="$(line_number "Encrypt signed DMG test artifact")"
+  upload_line="$(line_number "Upload encrypted signed DMG test artifact")"
+  summary_line="$(line_number "Record encrypted test artifact evidence")"
+  [[ -n "$verifier_line" && -n "$evidence_line" && -n "$checkout_line" && \
+     -n "$encrypt_line" && -n "$upload_line" && -n "$summary_line" ]] \
+    || die "validation workflow is missing required ordered steps"
+  (( verifier_line < evidence_line && evidence_line < checkout_line && \
+     checkout_line < encrypt_line && encrypt_line < upload_line && upload_line < summary_line )) \
+    || die "validation evidence, encryption, and upload steps are in an unsafe order"
+
+  [[ "$(grep -cF 'uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' "$WORKFLOW")" == "2" ]] \
+    || die "workflow must have exactly one unsigned and one encrypted artifact upload"
+
+  local forbidden
+  for forbidden in \
+    "contents: write" \
+    "actions: write" \
+    "softprops/action-gh-release" \
+    "actions/create-release" \
+    "gh release" \
+    "gh workflow run" \
+    "git tag" \
+    "git push" \
+    "refs/tags" \
+    "actions/deploy-pages"
+  do
+    assert_not_contains "$(cat "$WORKFLOW")" "$forbidden" \
+      "validation workflow contains forbidden release or deployment capability: $forbidden"
+  done
+
+  printf 'macOS DMG validation workflow test passed\n'
+}
+
+main "$@"


### PR DESCRIPTION
## Warum

Der signierte/notarisierte DMG aus Validation-Lauf 5 wurde absichtlich nicht hochgeladen und ist auf dem kurzlebigen Runner nicht mehr verfügbar. Für den permanenten Test auf diesem Mac brauchen wir einen neuen Lauf, ohne die Klartext-DMG oder das Notarisierungsprotokoll zu veröffentlichen.

## Änderungen

- optionales workflow_dispatch-Input für ein base64-kodiertes öffentliches RSA-Zertifikat
- CMS-Verschlüsselung der geprüften DMG mit AES-256-CBC und RSA-OAEP SHA-256
- Upload ausschließlich der verschlüsselten VibeTV-Control-Center.dmg.cms für einen Tag
- Helper vor Ausführung auf dem Signier-Runner mit festem SHA-256 gepinnt
- keine neuen Secrets, Schreibrechte, Tags, Releases oder Deployments
- neue statische Workflow-Guards und dynamische Kryptografie-Regressionstests

## Geprüft

- RSA-3072-Ver-/Entschlüsselungs-Roundtrip
- Wrong-Key, ungültiges X.509, EC, RSA-2048, Private-Key-Eingabe und stale output fail closed
- bestehender Release-Workflow-Test
- YAML und 14 eingebettete Bash-Blöcke
- actionlint 1.7.7
- git diff --check

## Nach dem Merge

Ein Validation-Lauf mit einem einmaligen lokalen Public Certificate erzeugt genau ein kurzlebiges verschlüsseltes Artefakt. Erst nach lokaler Entschlüsselung und vollständiger DMG-/Gatekeeper-Prüfung wird die alte 1.0.40-Installation dauerhaft ersetzt.