### PR TITLE
Pin macOS DMG validation run 7

### DIFF
--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  CODEX_VALIDATION_SOURCE_SHA: "5d367e7619e4c13d9d509b75057069d315ef673e"
-  CODEX_VALIDATION_VERSION: "1.0.42"
+  CODEX_VALIDATION_SOURCE_SHA: "ed9ab698f18dc508d77bb3016ad4cfb58f210fca"
+  CODEX_VALIDATION_VERSION: "1.0.43"
 
 jobs:
   build-unsigned-macos-app:

--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  CODEX_VALIDATION_SOURCE_SHA: "ed9ab698f18dc508d77bb3016ad4cfb58f210fca"
+  CODEX_VALIDATION_SOURCE_SHA: "a736044c9a43d888c637ef6504ec5169dc5aca60"
   CODEX_VALIDATION_VERSION: "1.0.43"
 
 jobs:


### PR DESCRIPTION
## Summary

- pin CODEX Validate macOS DMG to immutable source ed9ab698f18dc508d77bb3016ad4cfb58f210fca
- set the validation-only bundle version to 1.0.43
- leave every trusted signing, notarization, verification, and encryption hash unchanged

## Validation

- scripts/test-macos-dmg-validation-workflow.sh
- scripts/test-macos-dmg-validation-artifact.sh
- verified the pinned source commit is published on the feature branch
- verified the PR changes only the source SHA and validation version