### PR TITLE
CODEX Pin macOS DMG validation run 8

### DIFF
--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  CODEX_VALIDATION_SOURCE_SHA: "a736044c9a43d888c637ef6504ec5169dc5aca60"
-  CODEX_VALIDATION_VERSION: "1.0.43"
+  CODEX_VALIDATION_SOURCE_SHA: "d6f352aadf0b6a3c010192af2019e618e82f5614"
+  CODEX_VALIDATION_VERSION: "1.0.44"
 
 jobs:
   build-unsigned-macos-app:


### PR DESCRIPTION
## Was sich ändert

- pinnt den manuellen macOS-DMG-Prüflauf auf die aktuelle Endfassung von PR #160 (`d6f352a`)
- verwendet `1.0.44` ausschließlich als Bundle-Version für diesen Prüflauf

## Warum

Validation 7 hat eine ältere Fassung von PR #160 erfolgreich signiert und notarisiert. Die beiden letzten Korrekturen sollen vor dem Merge von PR #160 noch einmal exakt so durch Developer-ID-Signierung, Apple-Notarisierung und Gatekeeper-Prüfung laufen.

## Auswirkung

Dieser PR veröffentlicht keine DMG, erstellt keinen Tag und mergt PR #160 nicht. Er ändert nur, welchen unveränderlichen Commit der manuell gestartete Validation-Lauf prüft.

## Prüfung

- `git diff --check`
- `./scripts/test-control-center-release-workflow.sh`