### PR TITLE
CODEX: Pin macOS DMG validation 9 to 1.0.45

### DIFF
--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  CODEX_VALIDATION_SOURCE_SHA: "3cfeab01fc36d32c808b89b517a8955a71b041c7"
+  CODEX_VALIDATION_SOURCE_SHA: "7053be7aca79c20ae0d8f8dc8a81d31f34f43249"
   CODEX_VALIDATION_VERSION: "1.0.45"
 
 jobs:

--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  CODEX_VALIDATION_SOURCE_SHA: "d6f352aadf0b6a3c010192af2019e618e82f5614"
-  CODEX_VALIDATION_VERSION: "1.0.44"
+  CODEX_VALIDATION_SOURCE_SHA: "3cfeab01fc36d32c808b89b517a8955a71b041c7"
+  CODEX_VALIDATION_VERSION: "1.0.45"
 
 jobs:
   build-unsigned-macos-app:


### PR DESCRIPTION
## Purpose

Pin the validation-only macOS DMG workflow to source commit 3cfeab01fc36d32c808b89b517a8955a71b041c7 from PR #163 and bundle version 1.0.45.

This changes only the immutable validation source/version. It does not merge PR #163, create a release, create a tag, deploy production, or publish a plaintext DMG.

## Checks

- scripts/test-macos-dmg-validation-workflow.sh
- scripts/test-control-center-release-workflow.sh
- git diff --check