### PR TITLE
CODEX: Bootstrap macOS DMG validation 10

### DIFF
--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  CODEX_VALIDATION_SOURCE_SHA: "7053be7aca79c20ae0d8f8dc8a81d31f34f43249"
-  CODEX_VALIDATION_VERSION: "1.0.45"
+  CODEX_VALIDATION_SOURCE_SHA: "9a211c2c15039fd3b065dc6439fe2a7869b1c7a2"
+  CODEX_VALIDATION_VERSION: "1.0.46"
 
 jobs:
   build-unsigned-macos-app:
@@ -203,6 +203,8 @@ jobs:
             scripts/build-macos-control-center-dmg.sh
           verify_hash 69eb6aa8d08e3eb6bb88efc6b4cd931a4d2270ac8b3c378b1fdb68e56e1523ee \
             scripts/verify-macos-control-center-dmg.sh
+          verify_hash 416d95644a545c76c2ba8671f8910c5e48f40242a1f58ac35d763a929faedc2f \
+            scripts/validate-macos-control-center-runtime.sh
           verify_hash f4cb5afb06a2d0f12377492bb240e5b3edc23f64e106575d5fe8a2197d532ed7 \
             macos/VibeTVControlCenter/VibeTVControlCenter.entitlements
 
@@ -261,6 +263,8 @@ jobs:
             d2c68b71bbbbb62af41804b8706a48646e4a578c898e8bf6d3496da0fa4de6b2
           test "$(shasum -a 256 scripts/verify-macos-control-center-dmg.sh | awk '{print $1}')" = \
             69eb6aa8d08e3eb6bb88efc6b4cd931a4d2270ac8b3c378b1fdb68e56e1523ee
+          test "$(shasum -a 256 scripts/validate-macos-control-center-runtime.sh | awk '{print $1}')" = \
+            416d95644a545c76c2ba8671f8910c5e48f40242a1f58ac35d763a929faedc2f
 
       - name: Sign, notarize, and staple DMG
         env:
@@ -281,6 +285,32 @@ jobs:
         run: |
           ./scripts/verify-macos-control-center-dmg.sh \
             --dmg "dist/macos/VibeTV-Control-Center.dmg"
+
+      - name: Validate installed runtime from notarized DMG
+        run: |
+          set -euo pipefail
+          mount_dir="$(mktemp -d "${RUNNER_TEMP}/vibetv-runtime-mount.XXXXXX")"
+          mounted=0
+          cleanup() {
+            if [[ "${mounted}" == "1" ]]; then
+              hdiutil detach "${mount_dir}" -force >/dev/null 2>&1 || true
+            fi
+            rmdir "${mount_dir}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          hdiutil attach "dist/macos/VibeTV-Control-Center.dmg" \
+            -readonly -nobrowse -mountpoint "${mount_dir}"
+          mounted=1
+          test -d "${mount_dir}/VibeTV Control Center.app"
+          CODEX_ALLOW_MACOS_RUNTIME_VALIDATION=1 \
+            ./scripts/validate-macos-control-center-runtime.sh \
+              --real \
+              --app "${mount_dir}/VibeTV Control Center.app" \
+              --expected-version "${CODEX_VALIDATION_VERSION}"
+
+          cleanup
+          trap - EXIT
 
       - name: Record validation evidence without publishing the DMG
         run: |

--- a/scripts/test-macos-dmg-validation-workflow.sh
+++ b/scripts/test-macos-dmg-validation-workflow.sh
@@ -72,8 +72,9 @@ main() {
 
   local trigger_block trigger_block_lower permissions_block build_job signing_job
   local checkout_step encrypt_step encrypt_run upload_step summary_step
+  local trusted_files_step reverify_step runtime_step runtime_run
   local event_count permissions_count uses_line
-  local verifier_line evidence_line checkout_line encrypt_line upload_line summary_line
+  local verifier_line runtime_line evidence_line checkout_line encrypt_line upload_line summary_line
   local actual_encryptor_sha256
 
   actual_encryptor_sha256="$(shasum -a 256 "$ENCRYPTOR" | awk '{print $1}')"
@@ -90,6 +91,40 @@ main() {
   encrypt_run="$(run_block "Encrypt signed DMG test artifact")"
   upload_step="$(step_block "Upload encrypted signed DMG test artifact")"
   summary_step="$(step_block "Record encrypted test artifact evidence")"
+  trusted_files_step="$(step_block "Verify trusted signing files")"
+  reverify_step="$(step_block "Reverify notarization tools")"
+  runtime_step="$(step_block "Validate installed runtime from notarized DMG")"
+  runtime_run="$(run_block "Validate installed runtime from notarized DMG")"
+
+  assert_contains "$(cat "$WORKFLOW")" \
+    'CODEX_VALIDATION_SOURCE_SHA: "9a211c2c15039fd3b065dc6439fe2a7869b1c7a2"' \
+    "validation 10 must pin the reviewed source commit"
+  assert_contains "$(cat "$WORKFLOW")" \
+    'CODEX_VALIDATION_VERSION: "1.0.46"' \
+    "validation 10 must use the isolated validation version"
+  assert_contains "$trusted_files_step" \
+    '416d95644a545c76c2ba8671f8910c5e48f40242a1f58ac35d763a929faedc2f' \
+    "runtime validator must be pinned before signing"
+  assert_contains "$reverify_step" \
+    'scripts/validate-macos-control-center-runtime.sh' \
+    "runtime validator must be reverified after the DMG build"
+  assert_contains "$runtime_run" \
+    'hdiutil attach "dist/macos/VibeTV-Control-Center.dmg"' \
+    "runtime validation must mount the notarized DMG"
+  assert_contains "$runtime_run" \
+    'CODEX_ALLOW_MACOS_RUNTIME_VALIDATION=1' \
+    "real runtime validation must use the explicit safety opt-in"
+  assert_contains "$runtime_run" \
+    './scripts/validate-macos-control-center-runtime.sh \' \
+    "workflow must execute the pinned runtime validator"
+  assert_contains "$runtime_run" \
+    '--app "${mount_dir}/VibeTV Control Center.app"' \
+    "runtime validation must use the app inside the notarized DMG"
+  assert_contains "$runtime_run" \
+    '--expected-version "${CODEX_VALIDATION_VERSION}"' \
+    "runtime validation must verify the validation bundle version"
+  assert_not_contains "$runtime_run" 'vibetv.local' \
+    "runtime validation must not target physical hardware"
 
   event_count="$(printf '%s\n' "$trigger_block" | grep -Ec '^  [A-Za-z0-9_-]+:')"
   [[ "$event_count" == "1" ]] || die "validation workflow must only use workflow_dispatch"
@@ -199,15 +234,16 @@ main() {
     "action outputs must not be interpolated directly into shell code"
 
   verifier_line="$(line_number "Verify notarized DMG for distribution")"
+  runtime_line="$(line_number "Validate installed runtime from notarized DMG")"
   evidence_line="$(line_number "Record validation evidence without publishing the DMG")"
   checkout_line="$(line_number "Checkout current workflow orchestration")"
   encrypt_line="$(line_number "Encrypt signed DMG test artifact")"
   upload_line="$(line_number "Upload encrypted signed DMG test artifact")"
   summary_line="$(line_number "Record encrypted test artifact evidence")"
-  [[ -n "$verifier_line" && -n "$evidence_line" && -n "$checkout_line" && \
+  [[ -n "$verifier_line" && -n "$runtime_line" && -n "$evidence_line" && -n "$checkout_line" && \
      -n "$encrypt_line" && -n "$upload_line" && -n "$summary_line" ]] \
     || die "validation workflow is missing required ordered steps"
-  (( verifier_line < evidence_line && evidence_line < checkout_line && \
+  (( verifier_line < runtime_line && runtime_line < evidence_line && evidence_line < checkout_line && \
      checkout_line < encrypt_line && encrypt_line < upload_line && upload_line < summary_line )) \
     || die "validation evidence, encryption, and upload steps are in an unsafe order"
 


### PR DESCRIPTION
## Zweck

Validiert Source `9a211c2c15039fd3b065dc6439fe2a7869b1c7a2` isoliert als Version `1.0.46`.

Zusätzlich wird die fertig signierte und notarisierte DMG gemountet und die App daraus auf einem sauberen macOS-Runner installiert. Der Lauf prüft SMAppService, Port 47832, Status, ersten Frame und das Weiterlaufen nach Schließen der UI gegen ein Loopback-Testgerät.

## Grenzen

- kein Release und kein Tag
- kein Klartext-DMG-Upload
- kein Zugriff auf echtes VibeTV
- verschlüsseltes Testartefakt nur bei öffentlichem Empfängerzertifikat

## Lokal geprüft

- `./scripts/test-macos-dmg-validation-workflow.sh`
- `./scripts/test-control-center-release-workflow.sh`
- Runtime-Validator-Contract auf dem gepinnten Source-Commit
- `git diff --check`