### PR TITLE
CODEX: Transactional updates and transient reconnect recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
       APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
       APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
+      SPARKLE_ED25519_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,7 +49,8 @@ jobs:
             APPLE_SIGNING_CERTIFICATE_PASSWORD \
             APPLE_NOTARY_KEY_ID \
             APPLE_NOTARY_ISSUER_ID \
-            APPLE_NOTARY_KEY_P8_BASE64
+            APPLE_NOTARY_KEY_P8_BASE64 \
+            SPARKLE_ED25519_PRIVATE_KEY
           do
             if [[ -z "${!name:-}" ]]; then
               echo "::error::Missing required GitHub Actions secret: ${name}"
@@ -120,6 +122,22 @@ jobs:
           ./scripts/verify-macos-control-center-dmg.sh \
             --dmg "dist/macos/VibeTV-Control-Center.dmg"
 
+      - name: Build signed Sparkle appcast
+        run: |
+          set -euo pipefail
+
+          sparkle_dir="$(./scripts/fetch-sparkle.sh)"
+          printf '%s' "$SPARKLE_ED25519_PRIVATE_KEY" | \
+            "${sparkle_dir}/bin/generate_appcast" \
+              --ed-key-file - \
+              --maximum-deltas 0 \
+              --download-url-prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/" \
+              --link "https://app.vibetv.shop" \
+              -o appcast.xml \
+              dist/macos
+          test -s dist/macos/appcast.xml
+          grep -F 'sparkle:edSignature=' dist/macos/appcast.xml >/dev/null
+
       - name: Upload notarization evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -133,7 +151,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: vibetv-control-center-dmg
-          path: dist/macos/VibeTV-Control-Center.dmg
+          path: |
+            dist/macos/VibeTV-Control-Center.dmg
+            dist/macos/appcast.xml
           if-no-files-found: error
           retention-days: 7
 
@@ -355,7 +375,9 @@ jobs:
           path: dist/macos
 
       - name: Require verified Mac DMG
-        run: test -f dist/macos/VibeTV-Control-Center.dmg
+        run: |
+          test -f dist/macos/VibeTV-Control-Center.dmg
+          test -s dist/macos/appcast.xml
 
       - name: Build release checksums
         env:
@@ -382,4 +404,5 @@ jobs:
             dist/firmware/firmware-manifest.json
             dist/firmware/firmware-manifest-*.json
             dist/macos/*.dmg
+            dist/macos/appcast.xml
             dist/checksums-*.txt

--- a/apps/control-center/public/install-control-center-companion.sh
+++ b/apps/control-center/public/install-control-center-companion.sh
@@ -1339,7 +1339,12 @@ main() {
     say ""
     say "Done. The new VibeTV Mac App is ready to install."
     say "Drag VibeTV Control Center to Applications, then open it."
-    exit 20
+    # This script is also curl-loaded by older Companions. Keep their default
+    # exit status successful; only a new Companion opts into exit 20.
+    if [[ "${VIBETV_MAC_APP_ACTION_REQUIRED_EXIT_CODE:-0}" == "20" ]]; then
+      exit 20
+    fi
+    exit 0
   fi
 
   if [[ "$MODE" == "uninstall" ]]; then

--- a/apps/control-center/public/install-control-center-companion.sh
+++ b/apps/control-center/public/install-control-center-companion.sh
@@ -10,6 +10,7 @@ BIN_DIR="${APP_SUPPORT_DIR}/bin"
 BIN_PATH="${BIN_DIR}/${INSTALL_NAME}"
 USER_APPLICATIONS_DIR="${HOME}/Applications"
 APP_BUNDLE_DIR="${USER_APPLICATIONS_DIR}/VibeTV Control Center.app"
+SYSTEM_APP_BUNDLE_DIR="${VIBETV_SYSTEM_APP_BUNDLE_DIR:-/Applications/VibeTV Control Center.app}"
 LEGACY_APP_BUNDLE_DIR="${APP_SUPPORT_DIR}/VibeTV Control Center.app"
 APP_BUNDLE_CONTENTS_DIR="${APP_BUNDLE_DIR}/Contents"
 APP_BUNDLE_BIN_DIR="${APP_BUNDLE_CONTENTS_DIR}/MacOS"
@@ -565,9 +566,26 @@ restart_service() {
 }
 
 download_new_mac_app() {
-  local partial_path
+  local partial_path installed_version signature_details
   require_cmd_for curl "download the new VibeTV Mac App" "use a standard macOS Terminal with curl available, then try again."
   require_cmd_for open "open the new VibeTV Mac App DMG" "open the downloaded DMG from your Downloads folder."
+
+  if [[ -x "${SYSTEM_APP_BUNDLE_DIR}/Contents/MacOS/VibeTVControlCenter" \
+        && -f "${SYSTEM_APP_BUNDLE_DIR}/Contents/Info.plist" ]] \
+      && command -v plutil >/dev/null 2>&1 \
+      && [[ "$(plutil -extract CFBundleIdentifier raw -o - "${SYSTEM_APP_BUNDLE_DIR}/Contents/Info.plist" 2>/dev/null || true)" == "shop.vibetv.control-center" ]]; then
+    installed_version="$(plutil -extract CFBundleShortVersionString raw -o - "${SYSTEM_APP_BUNDLE_DIR}/Contents/Info.plist" 2>/dev/null || true)"
+    signature_details="$(codesign --display --verbose=2 "$SYSTEM_APP_BUNDLE_DIR" 2>&1 || true)"
+    if codesign --verify --deep --strict "$SYSTEM_APP_BUNDLE_DIR" >/dev/null 2>&1 \
+        && [[ "$signature_details" == *"Authority=Developer ID Application:"* ]] \
+        && { [[ -z "$RELEASE_VERSION" ]] || [[ "$installed_version" == "$RELEASE_VERSION" ]]; }; then
+      log "vibetv: verified native Mac App already installed version=${installed_version}"
+      open "$SYSTEM_APP_BUNDLE_DIR" >/dev/null 2>&1 \
+        || die "the verified VibeTV Control Center app could not be opened from Applications."
+      say "CODEX_MAC_APP_ACTION_REQUIRED kind=handoff version=${installed_version}"
+      return 0
+    fi
+  fi
 
   mkdir -p "$DMG_DOWNLOAD_DIR"
   partial_path="${DMG_PATH}.part"
@@ -582,6 +600,7 @@ download_new_mac_app() {
   open "$DMG_PATH" >/dev/null 2>&1 \
     || die "the DMG was downloaded to ${DMG_PATH}, but could not be opened automatically."
   log "vibetv: opened new Mac App DMG"
+  say "CODEX_MAC_APP_ACTION_REQUIRED kind=manual_install path=${DMG_PATH}"
 }
 
 verify_launchagent_loaded() {
@@ -1320,7 +1339,7 @@ main() {
     say ""
     say "Done. The new VibeTV Mac App is ready to install."
     say "Drag VibeTV Control Center to Applications, then open it."
-    exit 0
+    exit 20
   fi
 
   if [[ "$MODE" == "uninstall" ]]; then

--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -152,6 +152,19 @@ const reachableUnreadyDevice = {
   },
 };
 
+const reconnectingDevice = {
+  ...companionDevice,
+  connected: false,
+  ready: false,
+  connectionState: "reconnecting",
+  lastSeenAt: "2026-07-15T10:00:00Z",
+  stream: {
+    healthy: false,
+    running: true,
+    detail: "Display stream is reconnecting.",
+  },
+};
+
 async function main() {
   await assertCompanionRequestTimeoutContract();
   const fixtureServer = await startFixtureServer();
@@ -221,6 +234,10 @@ async function main() {
         appContext.appUrl,
       );
       await testLocalReachableWithoutFrameStaysInSetup(
+        browser,
+        appContext.appUrl,
+      );
+      await testConfiguredDeviceShowsReconnectingWithoutSetup(
         browser,
         appContext.appUrl,
       );
@@ -314,6 +331,10 @@ async function main() {
       browser,
       appContext.appUrl,
     );
+    await testConfiguredDeviceShowsReconnectingWithoutSetup(
+      browser,
+      appContext.appUrl,
+    );
     await testLocalSetupRecoversWhenDeviceBecomesReady(
       browser,
       appContext.appUrl,
@@ -348,6 +369,7 @@ async function main() {
     );
     await testSettingsStayCustomerOnly(browser, appContext.appUrl);
     await testUpdatesShowCustomerCompanionAction(browser, appContext.appUrl);
+    await testNativeMacAppUpdateUsesSparkleAction(browser, appContext.appUrl);
     await testLegacyInstallMigratesToDmgAtSameVersion(
       browser,
       appContext.appUrl,
@@ -382,6 +404,10 @@ async function main() {
       appContext.appUrl,
     );
     await testFirmwareUpdateShowsCustomerProgress(browser, appContext.appUrl);
+    await testFirmwareAttentionDoesNotOfferSecondFlash(
+      browser,
+      appContext.appUrl,
+    );
     await testSupportReportExportsAppearAfterReportLoads(
       browser,
       appContext.appUrl,
@@ -1310,6 +1336,47 @@ async function testLocalReachableWithoutFrameStaysInSetup(browser, appUrl) {
   await page.close();
 }
 
+async function testConfiguredDeviceShowsReconnectingWithoutSetup(
+  browser,
+  appUrl,
+) {
+  const page = await newCustomerPage(browser, appUrl, {
+    viewport: desktopViewport,
+  });
+  const installRequests = [];
+  const repairRequests = [];
+  await routeCompanionOnline(page, installRequests, () => {}, {
+    device: reconnectingDevice,
+    onRequest: (pathname, method) => {
+      if (pathname === "/v1/device/repair" && method === "POST") {
+        repairRequests.push(pathname);
+      }
+    },
+  });
+
+  await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+  await page.getByText("Reconnecting…", { exact: true }).first().waitFor({
+    timeout: 10_000,
+  });
+  assert(
+    (await page.getByRole("heading", { name: "Set up your VibeTV" }).count()) ===
+      0,
+    "A configured VibeTV must not return to initial Setup during an outage",
+  );
+  for (const tabName of ["Overview", "Usage", "Settings", "Theme Library", "Updates", "Support"]) {
+    assert(
+      !(await page.getByRole("button", { name: tabName }).isDisabled()),
+      `${tabName} must stay available while VibeTV reconnects`,
+    );
+  }
+  assert(
+    repairRequests.length === 0,
+    "The browser must let the Companion own bounded automatic recovery",
+  );
+  assertNoInstallRequests(installRequests);
+  await page.close();
+}
+
 async function testLocalSetupRecoversWhenDeviceBecomesReady(browser, appUrl) {
   const page = await newCustomerPage(browser, appUrl, {
     viewport: desktopViewport,
@@ -1868,7 +1935,7 @@ async function testUpdatesShowCustomerCompanionAction(browser, appUrl) {
   );
   await page.getByText("Install the new Mac App.").waitFor({ timeout: 10_000 });
   await page.getByText(/choose Replace/).waitFor({ timeout: 10_000 });
-  await page.getByText("Installed version").waitFor({ timeout: 10_000 });
+  await page.getByText("App version").waitFor({ timeout: 10_000 });
   await page.getByText("Latest version").waitFor({ timeout: 10_000 });
   assert(
     (await page.getByRole("button", { name: "Copy update command" }).count()) ===
@@ -1888,6 +1955,51 @@ async function testUpdatesShowCustomerCompanionAction(browser, appUrl) {
   assert(
     macAppUpdateRequests.length === 0,
     "DMG update must never call the legacy /v1/mac-app/update endpoint",
+  );
+  assertNoInstallRequests(installRequests);
+  await page.close();
+}
+
+async function testNativeMacAppUpdateUsesSparkleAction(browser, appUrl) {
+  const page = await newCustomerPage(browser, appUrl, { viewport });
+  const installRequests = [];
+  await routeCompanionOnline(page, installRequests, () => {}, {
+    companionVersion: "1.0.44",
+    companionApp: {
+      version: "1.0.32",
+      build: "132",
+      path: "/Applications/VibeTV Control Center.app",
+      installationMode: "dmg",
+      installedInApplications: true,
+    },
+    companionRuntime: {
+      version: "1.0.44",
+      commit: "abcdef1234567890",
+      pid: 174,
+      listenerOwner: "shop.vibetv.control-center.runtime",
+    },
+    device: { ...companionDevice, firmware: "1.0.33" },
+  });
+
+  await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+  await page.getByRole("button", { name: "Updates" }).click();
+  const updateLink = page.getByRole("link", {
+    name: "Install Mac App update",
+  });
+  await updateLink.waitFor({ timeout: 10_000 });
+  assert(
+    (await updateLink.getAttribute("href")) === "vibetv://check-for-updates",
+    "Installed native Mac Apps must hand updates to the exact Sparkle URL action",
+  );
+  await page.getByText("1.0.32").waitFor({ timeout: 10_000 });
+  await page.getByText("1.0.44 (abcdef12)").waitFor({ timeout: 10_000 });
+  await page
+    .getByText("shop.vibetv.control-center.runtime (PID 174)")
+    .waitFor({ timeout: 10_000 });
+  assert(
+    (await page.getByRole("link", { name: "Download new Mac App" }).count()) ===
+      0,
+    "Native Sparkle updates must not offer a second DMG download",
   );
   assertNoInstallRequests(installRequests);
   await page.close();
@@ -2245,6 +2357,7 @@ async function testUpdatesShowLegacyCompanionReleaseFallback(browser, appUrl) {
   });
   await macAppSection
     .getByText("1.0.32", { exact: true })
+    .first()
     .waitFor({ timeout: 10_000 });
   await macAppSection
     .getByText("1.0.99", { exact: true })
@@ -2345,6 +2458,57 @@ async function testFirmwareUpdateShowsCustomerProgress(browser, appUrl) {
 
   assertNoInstallRequests(installRequests);
   await assertNoMobileOverflow(page);
+  await page.close();
+}
+
+async function testFirmwareAttentionDoesNotOfferSecondFlash(browser, appUrl) {
+  const page = await newCustomerPage(browser, appUrl, { viewport });
+  const installRequests = [];
+  await routeCompanionOnline(page, installRequests, () => {}, {
+    companionVersion: "1.0.99",
+    updateStatusSequence: [
+      {
+        phase: "attention",
+        stage: "verifying_render",
+        outcome: "firmware_current_render_attention",
+        message: "Firmware is current, but the picture could not be verified.",
+        progress: 100,
+        logs: [
+          "Updating VibeTV.",
+          "Restarting VibeTV.",
+          "Checking the picture.",
+        ],
+        result: {
+          firmware: "1.0.33",
+          deviceId: "device-174",
+          artifactValidated: true,
+          uploadAccepted: true,
+          helloVerified: true,
+          healthVerified: true,
+          streamVerified: true,
+          renderVerified: false,
+        },
+      },
+    ],
+  });
+
+  await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+  await page.getByRole("button", { name: "Updates" }).click();
+  await page.getByRole("button", { name: "Update now" }).click();
+  await page
+    .getByText("Firmware current — attention needed")
+    .waitFor({ timeout: 10_000 });
+  await page
+    .getByText("Firmware is current, but the picture could not be verified.")
+    .waitFor({ timeout: 10_000 });
+  assert(
+    (await page.getByRole("button", { name: "Try again" }).count()) === 0,
+    "Attention after a verified firmware install must not offer a second flash",
+  );
+  await page.getByRole("button", { name: "Create report" }).waitFor({
+    timeout: 10_000,
+  });
+  assertNoInstallRequests(installRequests);
   await page.close();
 }
 
@@ -3528,6 +3692,8 @@ async function routeCompanionOnline(
       macAppSelfUpdateEnabled: false,
     },
     companionVersion = "1.0.32",
+    companionApp,
+    companionRuntime,
     installationMode = "dmg",
     legacyCompanionRelease = false,
     device = companionDevice,
@@ -3935,6 +4101,8 @@ async function routeCompanionOnline(
             companionFeatures,
             legacyCompanionRelease,
             installationMode,
+            companionApp,
+            companionRuntime,
           ),
           device: currentDevice,
         }),
@@ -3974,6 +4142,8 @@ async function routeCompanionOnline(
             companionFeatures,
             legacyCompanionRelease,
             installationMode,
+            companionApp,
+            companionRuntime,
           ),
           device: currentDevice,
         }),
@@ -4013,6 +4183,8 @@ async function routeCompanionOnline(
             companionFeatures,
             legacyCompanionRelease,
             installationMode,
+            companionApp,
+            companionRuntime,
           ),
           device: currentDevice,
           checks: [
@@ -4163,6 +4335,8 @@ function companionPayload(
   features,
   legacyRelease = false,
   installationMode = "dmg",
+  app,
+  runtime,
 ) {
   const payload = {
     version,
@@ -4170,6 +4344,12 @@ function companionPayload(
   };
   if (installationMode) {
     payload.installationMode = installationMode;
+  }
+  if (app) {
+    payload.app = app;
+  }
+  if (runtime) {
+    payload.runtime = runtime;
   }
   if (!legacyRelease) {
     payload.update = macAppReleaseInfo(version);

--- a/apps/control-center/src/components/control-center-app.tsx
+++ b/apps/control-center/src/components/control-center-app.tsx
@@ -93,11 +93,20 @@ type ThemeInstallJob = {
 type FirmwareUpdateResult = {
   firmware?: string;
   target?: string;
+  deviceId?: string;
+  artifactValidated?: boolean;
+  uploadAccepted?: boolean;
+  helloVerified?: boolean;
+  healthVerified?: boolean;
+  streamVerified?: boolean;
+  renderVerified?: boolean;
 };
 
 type FirmwareUpdateJob = {
   id: string;
-  phase: "installing" | "complete" | "error";
+  phase: "installing" | "complete" | "attention" | "error";
+  stage?: string;
+  outcome?: string;
   message?: string;
   progress?: number;
   startedAt?: string;
@@ -108,7 +117,9 @@ type FirmwareUpdateJob = {
 };
 
 type FirmwareUpdateStatus = {
-  phase: "installing" | "complete" | "error";
+  phase: "installing" | "complete" | "attention" | "error";
+  stage?: string;
+  outcome?: string;
   startedAt: string;
   finishedAt?: string;
   message?: string;
@@ -1436,7 +1447,9 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
   useEffect(() => {
     const shouldPollIncompleteSetup =
       companionStatus === "missing" ||
-      (companionStatus === "online" && !deviceSetupIsUsable(device));
+      (companionStatus === "online" &&
+        (!deviceSetupIsUsable(device) ||
+          device?.connectionState === "reconnecting"));
     if (hostedSetup || !shouldPollIncompleteSetup) {
       return;
     }
@@ -1506,7 +1519,9 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
   const {
     refresh: refreshHostedCompanionRelease,
     release: hostedCompanionRelease,
-  } = useCompanionRelease(companionInfo?.version);
+  } = useCompanionRelease(
+    companionInfo?.app?.version || companionInfo?.version,
+  );
 
   const checkUpdates = useCallback(async () => {
     setBusyAction("firmware-check");
@@ -1533,15 +1548,21 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
       const phase =
         job.phase === "complete"
           ? "complete"
+          : job.phase === "attention"
+            ? "attention"
           : job.phase === "error"
             ? "error"
             : "installing";
       const logs = customerUpdateLogs(job.logs, initialLogs);
       setFirmwareUpdateStatus({
         phase,
+        stage: job.stage,
+        outcome: job.outcome,
         startedAt,
         finishedAt:
-          phase === "complete" || phase === "error" ? formatTime() : undefined,
+          phase === "complete" || phase === "attention" || phase === "error"
+            ? formatTime()
+            : undefined,
         message:
           job.error?.nextAction ||
           job.message ||
@@ -1596,6 +1617,39 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
             nextAction: "Keep VibeTV powered on, then try again.",
           }
         );
+      }
+      if (finishedJob.phase === "attention") {
+        const logs = customerUpdateLogs(finishedJob.logs, initialLogs);
+        const finishedAt = formatTime();
+        setFirmwareUpdateStatus({
+          phase: "attention",
+          stage: finishedJob.stage,
+          outcome: finishedJob.outcome,
+          startedAt,
+          finishedAt,
+          message:
+            finishedJob.message ||
+            "The firmware is current, but VibeTV still needs attention.",
+          progress: 100,
+          logs,
+          result: finishedJob.result,
+        });
+        const installedFirmware = finishedJob.result?.firmware?.trim() || "";
+        if (installedFirmware) {
+          setDevice((current) =>
+            current ? { ...current, firmware: installedFirmware } : current,
+          );
+          setFirmwareUpdate(currentFirmwareUpdate(installedFirmware));
+        }
+        addEvent({
+          label: "VibeTV update needs attention",
+          detail:
+            finishedJob.message ||
+            "The firmware is current, but the connection or picture still needs repair.",
+          at: finishedAt,
+          tone: "attention",
+        });
+        return true;
       }
       const logs = customerUpdateLogs(finishedJob.logs, initialLogs);
       const finishedAt = formatTime();
@@ -2060,6 +2114,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
           companionRelease={companionRelease}
           companionStatus={companionStatus}
           companionVersion={companionInfo?.version}
+          companionInfo={companionInfo}
           device={device}
           firmwareUpdate={effectiveFirmwareUpdate}
           onCheckUpdates={checkUpdates}

--- a/apps/control-center/src/components/control-center-shell.tsx
+++ b/apps/control-center/src/components/control-center-shell.tsx
@@ -75,12 +75,15 @@ export function ControlCenterShell({
 }: ControlCenterShellProps) {
   const imageStuck = deviceImageIsStuck(device);
   const setupConnected = deviceSetupIsUsable(device);
-  const targetLabel = setupConnected
+  const reconnecting = device?.connectionState === "reconnecting";
+  const targetLabel = reconnecting
+    ? "Reconnecting…"
+    : setupConnected
     ? imageStuck
       ? "Image is stuck"
       : device?.target?.replace(/^https?:\/\//, "") || "VibeTV connected"
     : "Setup needed";
-  const targetDotClass = setupConnected && !imageStuck ? "bg-[#CCFF00]" : "bg-[#747A60]";
+  const targetDotClass = setupConnected && !reconnecting && !imageStuck ? "bg-[#CCFF00]" : "bg-[#747A60]";
   const disabledTabSet = new Set(disabledTabs);
   const isTabDisabled = (tab: ActiveTab) => disabledTabSet.has(tab);
 
@@ -121,7 +124,11 @@ export function ControlCenterShell({
             </div>
 
             <div className="hidden items-center gap-8 lg:flex">
-              <div className="inline-flex items-center gap-3 text-base text-[#1B1B1B]">
+              <div
+                aria-live="polite"
+                className="inline-flex items-center gap-3 text-base text-[#1B1B1B]"
+                role="status"
+              >
                 <span className={`size-2 rounded-full ${targetDotClass}`} />
                 <span>{targetLabel}</span>
               </div>

--- a/apps/control-center/src/components/control-center-types.ts
+++ b/apps/control-center/src/components/control-center-types.ts
@@ -26,6 +26,21 @@ export type CompanionInfo = {
   status?: string;
   version?: string;
   installationMode?: "legacy" | "dmg";
+  app?: {
+    version?: string;
+    build?: string;
+    path?: string;
+    installationMode?: "legacy" | "dmg";
+    installedInApplications?: boolean;
+  };
+  runtime?: {
+    version?: string;
+    commit?: string;
+    builtAt?: string;
+    executable?: string;
+    pid?: number;
+    listenerOwner?: string;
+  };
   update?: CompanionReleaseInfo;
   features?: {
     themeInstallEnabled?: boolean;
@@ -72,6 +87,8 @@ export type DeviceInfo = {
   connected: boolean;
   paired?: boolean;
   ready?: boolean;
+  connectionState?: "ready" | "reconnecting" | "setup_required";
+  lastSeenAt?: string;
   board?: string;
   firmware?: string;
   activeTheme?: string;
@@ -86,7 +103,11 @@ export type DeviceInfo = {
   };
   health?: {
     ok?: boolean;
+    bootId?: string;
+    uptimeMs?: number;
+    resetCount?: number;
     resetReason?: string;
+    lastResetAt?: string;
     error?: string;
   };
   display?: {
@@ -264,5 +285,11 @@ export function deviceStreamIsReady(device: DeviceInfo | null | undefined) {
 }
 
 export function deviceSetupIsUsable(device: DeviceInfo | null | undefined) {
+	if (device?.connectionState) {
+		return (
+			device.connectionState === "ready" ||
+			device.connectionState === "reconnecting"
+		);
+	}
   return device?.ready === true;
 }

--- a/apps/control-center/src/components/control-center-types.ts
+++ b/apps/control-center/src/components/control-center-types.ts
@@ -285,11 +285,11 @@ export function deviceStreamIsReady(device: DeviceInfo | null | undefined) {
 }
 
 export function deviceSetupIsUsable(device: DeviceInfo | null | undefined) {
-	if (device?.connectionState) {
-		return (
-			device.connectionState === "ready" ||
-			device.connectionState === "reconnecting"
-		);
-	}
+  if (device?.connectionState) {
+    return (
+      device.connectionState === "ready" ||
+      device.connectionState === "reconnecting"
+    );
+  }
   return device?.ready === true;
 }

--- a/apps/control-center/src/components/overview-screen.tsx
+++ b/apps/control-center/src/components/overview-screen.tsx
@@ -313,6 +313,9 @@ function labelForDevice(
   if (deviceImageIsStuck(device)) {
     return "Image is stuck";
   }
+  if (device?.connectionState === "reconnecting") {
+    return "Reconnecting…";
+  }
   if (device?.ready) {
     return "Connected";
   }
@@ -337,6 +340,9 @@ function deviceHealthDetail(device: DeviceInfo | null): string | undefined {
   const resetReason = device?.health?.resetReason?.trim();
   if (resetReason && resetReason.toLowerCase() === "exception") {
     return "VibeTV restarted after a firmware exception. If this keeps happening, reconnect power and run setup again.";
+  }
+  if (device?.connectionState === "reconnecting") {
+    return "VibeTV is temporarily unavailable. The Mac App is reconnecting automatically.";
   }
   if (device?.connected && device.health?.error) {
     return "VibeTV is reachable, but health details are temporarily unavailable.";

--- a/apps/control-center/src/components/updates-screen.tsx
+++ b/apps/control-center/src/components/updates-screen.tsx
@@ -17,6 +17,7 @@ import {
 import { hasFirmwareUpdate, type FirmwareUpdateInfo } from "@/lib/firmware";
 import { ControlCenterButton } from "./control-center-button";
 import { ControlCenterStatusIcon } from "./control-center-status-icon";
+import type { CompanionInfo } from "./control-center-types";
 
 export type UpdatesCompanionStatus = "unknown" | "online" | "missing";
 
@@ -27,7 +28,9 @@ export type UpdatesDeviceInfo = {
 };
 
 export type FirmwareUpdateStatus = {
-  phase: "installing" | "complete" | "error";
+  phase: "installing" | "complete" | "attention" | "error";
+  stage?: string;
+  outcome?: string;
   startedAt: string;
   finishedAt?: string;
   message?: string;
@@ -36,6 +39,13 @@ export type FirmwareUpdateStatus = {
   result?: {
     firmware?: string;
     target?: string;
+    deviceId?: string;
+    artifactValidated?: boolean;
+    uploadAccepted?: boolean;
+    helloVerified?: boolean;
+    healthVerified?: boolean;
+    streamVerified?: boolean;
+    renderVerified?: boolean;
   };
   error?: string;
 };
@@ -44,6 +54,7 @@ export type UpdatesScreenProps = {
   companionStatus: UpdatesCompanionStatus;
   device: UpdatesDeviceInfo | null;
   companionVersion?: string;
+  companionInfo?: CompanionInfo | null;
   companionRelease?: CompanionReleaseInfo | null;
   firmwareUpdate?: FirmwareUpdateInfo | null;
   onCheckUpdates?: () => Promise<void> | void;
@@ -58,6 +69,7 @@ export function UpdatesScreen({
   companionStatus,
   device,
   companionVersion,
+  companionInfo,
   companionRelease = null,
   firmwareUpdate,
   onCheckUpdates,
@@ -79,6 +91,9 @@ export function UpdatesScreen({
     firmwareUpdate?.latestFirmware || (checking ? "Checking" : "Not available");
   const updateAvailable = hasFirmwareUpdate(firmwareUpdate);
   const macAppUpdateAvailable = Boolean(companionRelease?.updateAvailable);
+  const nativeMacUpdateReady = Boolean(
+    macAppUpdateAvailable && companionInfo?.app?.installedInApplications,
+  );
   const verifiedDmgDownloadUrl = availableMacAppDmgDownloadUrl(companionRelease);
   const macAppMigrationReady = Boolean(
     requiresMacAppMigration && verifiedDmgDownloadUrl,
@@ -89,8 +104,10 @@ export function UpdatesScreen({
       : undefined;
   const macAppDownloadReady = Boolean(macAppDownloadUrl);
   const macAppDownloadAction =
-    macAppMigrationReady || macAppUpdateAvailable;
-  const anyUpdateAvailable = updateAvailable || macAppDownloadAction;
+    macAppMigrationReady || (macAppUpdateAvailable && !nativeMacUpdateReady);
+  const macAppNativeAction = nativeMacUpdateReady;
+  const anyUpdateAvailable =
+    updateAvailable || macAppDownloadAction || macAppNativeAction;
   const needsAttention = anyUpdateAvailable || requiresMacAppMigration;
   const refreshing = busyAction === "firmware-check";
   const installingUpdate =
@@ -134,7 +151,7 @@ export function UpdatesScreen({
   const companionInstalled =
     companionStatus === "missing"
       ? "Not running"
-      : companionVersion || "Unknown";
+      : companionInfo?.app?.version || companionVersion || "Unknown";
   const companionAvailable =
     companionRelease?.latestVersion || companionRelease?.release || "Checking";
 
@@ -184,6 +201,7 @@ export function UpdatesScreen({
               Boolean(busyAction && busyAction !== "firmware-check")
             }
             downloadUrl={macAppDownloadUrl}
+            nativeUpdateUrl={macAppNativeAction ? "vibetv://check-for-updates" : undefined}
             installingFirmware={installingUpdate}
             firmwareUpdateAvailable={updateAvailable}
             macAppCheckFailed={macAppCheckFailed}
@@ -211,8 +229,23 @@ export function UpdatesScreen({
         <dl className="grid gap-0 border-y border-[#747A60]">
           <FirmwareRow
             icon={<Server size={20} aria-hidden />}
-            label="Installed version"
+            label="App version"
             value={companionInstalled}
+          />
+          <FirmwareRow
+            icon={<Server size={20} aria-hidden />}
+            label="App build"
+            value={companionInfo?.app?.build || "Unknown"}
+          />
+          <FirmwareRow
+            icon={<Monitor size={20} aria-hidden />}
+            label="Runtime"
+            value={formatRuntimeValue(companionInfo)}
+          />
+          <FirmwareRow
+            icon={<ShieldCheck size={20} aria-hidden />}
+            label="Listener"
+            value={formatListenerValue(companionInfo)}
           />
           <FirmwareRow
             icon={<Download size={20} aria-hidden />}
@@ -226,7 +259,7 @@ export function UpdatesScreen({
           />
         </dl>
 
-        {requiresMacAppMigration || macAppUpdateAvailable ? (
+        {requiresMacAppMigration || (macAppUpdateAvailable && !nativeMacUpdateReady) ? (
           <MacAppDmgUpdateNote
             downloadReady={macAppDownloadReady}
             downloadStarted={macAppDownloadStarted}
@@ -278,6 +311,7 @@ function PrimaryUpdateAction({
   checking,
   disabled,
   downloadUrl,
+  nativeUpdateUrl,
   firmwareUpdateAvailable,
   installingFirmware,
   macAppCheckFailed,
@@ -291,6 +325,7 @@ function PrimaryUpdateAction({
   checking: boolean;
   disabled: boolean;
   downloadUrl?: string;
+  nativeUpdateUrl?: string;
   firmwareUpdateAvailable: boolean;
   installingFirmware: boolean;
   macAppCheckFailed: boolean;
@@ -301,6 +336,24 @@ function PrimaryUpdateAction({
   onClick: () => void | Promise<void>;
   updateReady: boolean;
 }) {
+  if (
+    !firmwareUpdateAvailable &&
+    macAppUpdateAvailable &&
+    nativeUpdateUrl &&
+    !disabled &&
+    !checking
+  ) {
+    return (
+      <a
+        className="vibetv-button vibetv-button--large vibetv-button--primary w-full sm:w-auto sm:min-w-[240px]"
+        href={nativeUpdateUrl}
+      >
+        <Download size={20} aria-hidden />
+        <span>Install Mac App update</span>
+      </a>
+    );
+  }
+
   if (
     !firmwareUpdateAvailable &&
     (macAppMigrationReady || macAppUpdateAvailable) &&
@@ -387,16 +440,22 @@ function InlineUpdateProgress({
 }) {
   const failed = status.phase === "error";
   const complete = status.phase === "complete";
+  const attention = status.phase === "attention";
   const progress = clampUpdateProgress(
-    failed || complete ? 100 : status.progress,
+    failed || complete || attention ? 100 : status.progress,
   );
   const title = failed
     ? "Update failed"
+    : attention
+      ? "Firmware current — attention needed"
     : complete
       ? "Update complete"
       : "Updating VibeTV";
   const detail = failed
     ? status.error || "Update was not installed. Try again."
+    : attention
+      ? status.message ||
+        "The firmware is current, but the connection or picture still needs repair."
     : complete
       ? status.result?.firmware
         ? `Firmware ${status.result.firmware} is installed.`
@@ -404,14 +463,15 @@ function InlineUpdateProgress({
       : status.message ||
         status.logs[status.logs.length - 1] ||
         "Preparing VibeTV update.";
-  const previousSteps = failed || complete ? [] : status.logs.slice(-4, -1);
+  const previousSteps =
+    failed || complete || attention ? [] : status.logs.slice(-4, -1);
 
   return (
     <div className="mt-6" role="status" aria-live="polite">
       <div className="h-2 overflow-hidden border border-[#747A60] bg-[#F9F9F9]">
         <div
           className={`h-full bg-[#CCFF00] transition-[width] duration-300 ${
-            failed || complete ? "" : "animate-pulse"
+            failed || complete || attention ? "" : "animate-pulse"
           }`}
           style={{ width: `${progress}%` }}
         />
@@ -421,6 +481,8 @@ function InlineUpdateProgress({
           {failed ? (
             <X className="mt-0.5 shrink-0" size={16} aria-hidden />
           ) : complete ? (
+            <ShieldCheck className="mt-0.5 shrink-0" size={16} aria-hidden />
+          ) : attention ? (
             <ShieldCheck className="mt-0.5 shrink-0" size={16} aria-hidden />
           ) : (
             <RefreshCw
@@ -443,15 +505,17 @@ function InlineUpdateProgress({
             ) : null}
           </div>
         </div>
-        {failed ? (
+        {failed || attention ? (
           <div className="flex flex-col gap-2 sm:flex-row">
-            <ControlCenterButton
-              disabled={!onRetry}
-              label="Try again"
-              onClick={onRetry}
-              size="compact"
-              variant="secondary"
-            />
+            {failed ? (
+              <ControlCenterButton
+                disabled={!onRetry}
+                label="Try again"
+                onClick={onRetry}
+                size="compact"
+                variant="secondary"
+              />
+            ) : null}
             <ControlCenterButton
               label={creatingReport ? "Creating report" : "Create report"}
               disabled={!onCreateReport || creatingReport}
@@ -464,6 +528,21 @@ function InlineUpdateProgress({
       </div>
     </div>
   );
+}
+
+function formatRuntimeValue(companion: CompanionInfo | null | undefined): string {
+  const version = companion?.runtime?.version || companion?.version || "Unknown";
+  const commit = companion?.runtime?.commit?.trim();
+  return commit ? `${version} (${commit.slice(0, 8)})` : version;
+}
+
+function formatListenerValue(companion: CompanionInfo | null | undefined): string {
+  const owner = companion?.runtime?.listenerOwner?.trim();
+  const pid = companion?.runtime?.pid;
+  if (!owner) {
+    return "Not verified";
+  }
+  return pid ? `${owner} (PID ${pid})` : owner;
 }
 
 function MacAppDmgUpdateNote({

--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -59,8 +59,31 @@ var (
 	flashReleaseFirmwareImageFn                        = flashReleaseFirmwareImage
 	uploadFirmwareOTAFn                                = uploadFirmwareOTA
 	firmwareHTTPVerifyPollInterval                     = 2 * time.Second
-	firmwareUpdateRediscoveryAfter                     = 20 * time.Second
+	firmwareUpdateRediscoveryAfter                     = 10 * time.Second
+	firmwareUpdateRediscoveryInterval                  = 5 * time.Second
 )
+
+const firmwareUpdateEventPrefix = "CODEX_FIRMWARE_UPDATE_EVENT "
+
+type firmwareUpdateEvent struct {
+	Stage             string `json:"stage"`
+	Phase             string `json:"phase,omitempty"`
+	Outcome           string `json:"outcome,omitempty"`
+	Firmware          string `json:"firmware,omitempty"`
+	Target            string `json:"target,omitempty"`
+	DeviceID          string `json:"deviceId,omitempty"`
+	ArtifactValidated bool   `json:"artifactValidated,omitempty"`
+	UploadAccepted    bool   `json:"uploadAccepted,omitempty"`
+	HelloVerified     bool   `json:"helloVerified,omitempty"`
+}
+
+func emitFirmwareUpdateEvent(event firmwareUpdateEvent) {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+	fmt.Printf("%s%s\n", firmwareUpdateEventPrefix, payload)
+}
 
 const launchAgentLabel = "com.codexbar-display.daemon.plist"
 
@@ -470,6 +493,14 @@ func runInstallUpdate(args []string) (retErr error) {
 		}
 	}
 	caps := protocol.CapabilitiesFromHello(hello)
+	deviceID := strings.TrimSpace(hello.DeviceID)
+	emitFirmwareUpdateEvent(firmwareUpdateEvent{
+		Stage:         "validating_artifact",
+		Phase:         "installing",
+		Target:        base,
+		DeviceID:      deviceID,
+		HelloVerified: true,
+	})
 	fmt.Println("Checking device...")
 	fmt.Printf("Device: %s firmware %s\n", caps.Board, caps.Firmware)
 
@@ -494,6 +525,16 @@ func runInstallUpdate(args []string) (retErr error) {
 	}
 	if current.Compare(next) >= 0 && !*force {
 		fmt.Printf("Firmware: already current (%s)\n", caps.Firmware)
+		emitFirmwareUpdateEvent(firmwareUpdateEvent{
+			Stage:             "verifying_health",
+			Phase:             "complete",
+			Outcome:           "already_current",
+			Firmware:          caps.Firmware,
+			Target:            base,
+			DeviceID:          deviceID,
+			ArtifactValidated: true,
+			HelloVerified:     true,
+		})
 		return nil
 	}
 	fmt.Printf("Updating firmware: %s -> %s\n", caps.Firmware, targetVersion)
@@ -514,6 +555,15 @@ func runInstallUpdate(args []string) (retErr error) {
 	if *verbose {
 		fmt.Printf("Firmware downloaded: %s sha256=%s\n", imagePath, strings.TrimSpace(artifact.SHA256))
 	}
+	emitFirmwareUpdateEvent(firmwareUpdateEvent{
+		Stage:             "uploading",
+		Phase:             "installing",
+		Firmware:          targetVersion,
+		Target:            base,
+		DeviceID:          deviceID,
+		ArtifactValidated: true,
+		HelloVerified:     true,
+	})
 
 	deviceToken, err := ensureFirmwareUpdateDeviceToken(ctx, home, base, false)
 	if err != nil {
@@ -551,9 +601,19 @@ func runInstallUpdate(args []string) (retErr error) {
 			}
 		}
 	}
+	emitFirmwareUpdateEvent(firmwareUpdateEvent{
+		Stage:             "rebooting",
+		Phase:             "installing",
+		Firmware:          targetVersion,
+		Target:            base,
+		DeviceID:          deviceID,
+		ArtifactValidated: true,
+		UploadAccepted:    true,
+		HelloVerified:     true,
+	})
 	fmt.Println("Restarting VibeTV...")
 
-	verifiedBase, err := waitForHTTPFirmwareVersionWithDiscovery(ctx, home, base, targetVersion, 90*time.Second)
+	verifiedBase, err := waitForHTTPFirmwareVersionWithDiscovery(ctx, home, base, targetVersion, deviceID, 120*time.Second)
 	if err != nil {
 		return &commandError{
 			Op:   "post-update-verify",
@@ -562,6 +622,25 @@ func runInstallUpdate(args []string) (retErr error) {
 			Hint: "wait one minute, then open http://<device-ip>/health",
 		}
 	}
+	verifiedHello, helloErr := fetchDeviceHelloHTTP(ctx, verifiedBase)
+	if helloErr != nil || !strings.EqualFold(strings.TrimSpace(verifiedHello.DeviceID), deviceID) {
+		return &commandError{
+			Op:   "post-update-device-identity",
+			Code: errcode.UpgradeFlashFirmware,
+			Err:  fmt.Errorf("updated VibeTV identity changed: expected=%q got=%q: %v", deviceID, strings.TrimSpace(verifiedHello.DeviceID), helloErr),
+			Hint: "do not retry the flash; verify the saved VibeTV device identity",
+		}
+	}
+	emitFirmwareUpdateEvent(firmwareUpdateEvent{
+		Stage:             "verifying_health",
+		Phase:             "installing",
+		Firmware:          targetVersion,
+		Target:            verifiedBase,
+		DeviceID:          deviceID,
+		ArtifactValidated: true,
+		UploadAccepted:    true,
+		HelloVerified:     true,
+	})
 	if verifiedBase != base {
 		base = verifiedBase
 		if _, err := ensureFirmwareUpdateDeviceToken(ctx, home, base, false); err != nil {
@@ -610,7 +689,8 @@ func shouldStoreFirmwareUpdateTarget(current, next string) bool {
 	return true
 }
 
-func waitForHTTPFirmwareVersionWithDiscovery(ctx context.Context, home, base, version string, timeout time.Duration) (string, error) {
+func waitForHTTPFirmwareVersionWithDiscovery(ctx context.Context, home, base, version, deviceID string, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
 	firstTimeout := timeout
 	if firmwareUpdateRediscoveryAfter > 0 && firmwareUpdateRediscoveryAfter < timeout {
 		firstTimeout = firmwareUpdateRediscoveryAfter
@@ -620,26 +700,41 @@ func waitForHTTPFirmwareVersionWithDiscovery(ctx context.Context, home, base, ve
 		return base, nil
 	}
 
-	discovered, discoverErr := discoverInstallUpdateTarget(ctx, home, base)
-	if discoverErr != nil {
-		if firstTimeout < timeout {
-			if retryErr := waitForHTTPFirmwareVersion(ctx, base, version, timeout-firstTimeout); retryErr == nil {
-				return base, nil
+	var lastDiscoveryErr error
+	for time.Now().Before(deadline) {
+		discovered, discoverErr := discoverInstallUpdateTarget(ctx, home, base, deviceID)
+		if discoverErr == nil && strings.TrimSpace(discovered) != "" {
+			remaining := time.Until(deadline)
+			verifyFor := 30 * time.Second
+			if remaining < verifyFor {
+				verifyFor = remaining
 			}
+			if verifyFor > 0 {
+				if verifyErr := waitForHTTPFirmwareVersion(ctx, discovered, version, verifyFor); verifyErr == nil {
+					if strings.TrimRight(discovered, "/") != strings.TrimRight(base, "/") {
+						fmt.Printf("Using rediscovered VibeTV address: %s\n", discovered)
+					}
+					return discovered, nil
+				} else {
+					lastDiscoveryErr = verifyErr
+				}
+			}
+		} else if discoverErr != nil {
+			lastDiscoveryErr = discoverErr
 		}
-		return "", fmt.Errorf("%w; rediscovery failed: %v", err, discoverErr)
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(firmwareUpdateRediscoveryInterval):
+		}
 	}
-	if strings.TrimSpace(discovered) == "" || strings.TrimRight(discovered, "/") == strings.TrimRight(base, "/") {
-		return "", err
+	if lastDiscoveryErr != nil {
+		return "", fmt.Errorf("%w; rediscovery failed: %v", err, lastDiscoveryErr)
 	}
-	fmt.Printf("Using rediscovered VibeTV address: %s\n", discovered)
-	if verifyErr := waitForHTTPFirmwareVersion(ctx, discovered, version, 30*time.Second); verifyErr != nil {
-		return "", fmt.Errorf("%w; rediscovered target %s also failed: %v", err, discovered, verifyErr)
-	}
-	return discovered, nil
+	return "", err
 }
 
-func discoverInstallUpdateTarget(ctx context.Context, home, base string) (string, error) {
+func discoverInstallUpdateTarget(ctx context.Context, home, base, deviceID string) (string, error) {
 	candidates := []string{base, setup.DefaultWiFiTarget()}
 	if cfg, err := runtimeconfig.Load(home); err == nil {
 		candidates = append(candidates, cfg.DeviceTarget)
@@ -648,6 +743,7 @@ func discoverInstallUpdateTarget(ctx context.Context, home, base string) (string
 		Candidates:         candidates,
 		IncludeNetworkScan: true,
 		Timeout:            8 * time.Second,
+		ExpectedDeviceID:   strings.TrimSpace(deviceID),
 	})
 	if err != nil {
 		return "", err

--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/errcode"
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/firmwareupdate"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/runtimeconfig"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/setup"
@@ -63,26 +64,14 @@ var (
 	firmwareUpdateRediscoveryInterval                  = 5 * time.Second
 )
 
-const firmwareUpdateEventPrefix = "CODEX_FIRMWARE_UPDATE_EVENT "
-
-type firmwareUpdateEvent struct {
-	Stage             string `json:"stage"`
-	Phase             string `json:"phase,omitempty"`
-	Outcome           string `json:"outcome,omitempty"`
-	Firmware          string `json:"firmware,omitempty"`
-	Target            string `json:"target,omitempty"`
-	DeviceID          string `json:"deviceId,omitempty"`
-	ArtifactValidated bool   `json:"artifactValidated,omitempty"`
-	UploadAccepted    bool   `json:"uploadAccepted,omitempty"`
-	HelloVerified     bool   `json:"helloVerified,omitempty"`
-}
+type firmwareUpdateEvent = firmwareupdate.Event
 
 func emitFirmwareUpdateEvent(event firmwareUpdateEvent) {
 	payload, err := json.Marshal(event)
 	if err != nil {
 		return
 	}
-	fmt.Printf("%s%s\n", firmwareUpdateEventPrefix, payload)
+	fmt.Printf("%s%s\n", firmwareupdate.EventPrefix, payload)
 }
 
 const launchAgentLabel = "com.codexbar-display.daemon.plist"

--- a/companion/cmd/codexbar-display/release_commands_test.go
+++ b/companion/cmd/codexbar-display/release_commands_test.go
@@ -657,6 +657,51 @@ func TestRunInstallUpdateDoesNotFallBackFromExplicitTarget(t *testing.T) {
 	}
 }
 
+func TestRunInstallUpdateAlreadyCurrentSkipsOTAUpload(t *testing.T) {
+	previousHTTPClient := releaseHTTPClient
+	previousUpload := uploadFirmwareOTAFn
+	t.Cleanup(func() {
+		releaseHTTPClient = previousHTTPClient
+		uploadFirmwareOTAFn = previousUpload
+	})
+	t.Setenv("HOME", t.TempDir())
+
+	uploads := 0
+	uploadFirmwareOTAFn = func(context.Context, string, string, string) error {
+		uploads++
+		return nil
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-current","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.1","features":["theme"],"maxFrameBytes":1024}`))
+		case "/manifest.json":
+			_, _ = w.Write([]byte(`{"schemaVersion":1,"release":"v1.0.1","artifacts":[{"firmwareEnv":"esp8266_smalltv_st7789","board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.1","asset":"firmware.bin","firmwareUrl":"https://example.invalid/firmware.bin","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]}`))
+		default:
+			t.Fatalf("already-current update must not request %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	releaseHTTPClient = server.Client()
+
+	output, err := captureStdout(t, func() error {
+		return runInstallUpdate([]string{
+			"--target", server.URL,
+			"--manifest-url", server.URL + "/manifest.json",
+			"--skip-launchagent-pause",
+		})
+	})
+	if err != nil {
+		t.Fatalf("already-current update: %v", err)
+	}
+	if uploads != 0 {
+		t.Fatalf("already-current firmware must not upload, got %d calls", uploads)
+	}
+	if !strings.Contains(output, `"outcome":"already_current"`) {
+		t.Fatalf("expected typed already-current outcome, got:\n%s", output)
+	}
+}
+
 func TestRunInstallUpdateRediscoverAfterFirmwareRebootIPChange(t *testing.T) {
 	previousHTTPClient := releaseHTTPClient
 	previousUpload := uploadFirmwareOTAFn

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/codexbar"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/daemon"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/errcode"
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/firmwareupdate"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/runtimeconfig"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/runtimepaths"
@@ -1001,6 +1002,10 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	device, startRecovery := s.withConfiguredConnectionState(cfg, device, reachable)
 	if startRecovery {
+		// Status remains free of synchronous discovery fan-out, but after the
+		// reconnect grace period it may schedule exactly one bounded background
+		// recovery for the pinned device. That recovery owns its own timeout and
+		// is cancelled as soon as a later status probe sees the device again.
 		s.startConfiguredDeviceRecovery(cfg)
 	}
 	writeJSON(w, http.StatusOK, statusResponse{
@@ -3589,7 +3594,7 @@ func (s *Server) verifyFirmwareUpdateResult(ctx context.Context, jobID string, i
 			break
 		}
 		if time.Now().After(healthDeadline) {
-			return firmwareAttentionOutcome(snapshot, "health"), "Firmware is current, but VibeTV health still needs attention.", nil
+			return firmwareAttentionOutcome("health"), "Firmware is current, but VibeTV health still needs attention.", nil
 		}
 		select {
 		case <-ctx.Done():
@@ -3605,11 +3610,11 @@ func (s *Server) verifyFirmwareUpdateResult(ctx context.Context, jobID string, i
 	baseline := health
 	streamStartedAt := time.Now().UTC()
 	if err := s.startDisplayStream(ctx, target); err != nil {
-		return firmwareAttentionOutcome(snapshot, "stream"), "Firmware is current, but the display stream could not restart.", nil
+		return firmwareAttentionOutcome("stream"), "Firmware is current, but the display stream could not restart.", nil
 	}
 	stream := s.waitForFreshDisplayStream(ctx, target, streamStartedAt)
 	if !displayStreamHealthyForTarget(&stream, target) {
-		return firmwareAttentionOutcome(snapshot, "stream"), "Firmware is current, but the display stream still needs attention.", nil
+		return firmwareAttentionOutcome("stream"), "Firmware is current, but the display stream still needs attention.", nil
 	}
 	s.updateFirmwareVerification(jobID, func(result *firmwareUpdateResult) {
 		result.StreamVerified = true
@@ -3617,7 +3622,7 @@ func (s *Server) verifyFirmwareUpdateResult(ctx context.Context, jobID string, i
 
 	s.setFirmwareUpdateStage(jobID, "verifying_render")
 	if _, err := s.waitForVerifiedDisplayRender(ctx, target, token, baseline, stream); err != nil {
-		return firmwareAttentionOutcome(snapshot, "render"), "Firmware is current, but the picture could not be verified.", nil
+		return firmwareAttentionOutcome("render"), "Firmware is current, but the picture could not be verified.", nil
 	}
 	s.updateFirmwareVerification(jobID, func(result *firmwareUpdateResult) {
 		result.RenderVerified = true
@@ -3628,7 +3633,7 @@ func (s *Server) verifyFirmwareUpdateResult(ctx context.Context, jobID string, i
 	return "updated", "", nil
 }
 
-func firmwareAttentionOutcome(job firmwareUpdateJob, kind string) string {
+func firmwareAttentionOutcome(kind string) string {
 	prefix := "firmware_current_"
 	switch kind {
 	case "health":
@@ -3734,9 +3739,9 @@ func (w *firmwareUpdateProgressWriter) noteLine(line string) {
 	if line == "" || w.server == nil {
 		return
 	}
-	if strings.HasPrefix(line, firmwareUpdateEventPrefix) {
+	if strings.HasPrefix(line, firmwareupdate.EventPrefix) {
 		var event firmwareUpdateEvent
-		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, firmwareUpdateEventPrefix)), &event); err == nil {
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, firmwareupdate.EventPrefix)), &event); err == nil {
 			w.server.applyFirmwareUpdateEvent(w.jobID, event)
 		}
 		return
@@ -3754,19 +3759,7 @@ func (w *firmwareUpdateProgressWriter) noteLine(line string) {
 	})
 }
 
-const firmwareUpdateEventPrefix = "CODEX_FIRMWARE_UPDATE_EVENT "
-
-type firmwareUpdateEvent struct {
-	Stage             string `json:"stage"`
-	Phase             string `json:"phase,omitempty"`
-	Outcome           string `json:"outcome,omitempty"`
-	Firmware          string `json:"firmware,omitempty"`
-	Target            string `json:"target,omitempty"`
-	DeviceID          string `json:"deviceId,omitempty"`
-	ArtifactValidated bool   `json:"artifactValidated,omitempty"`
-	UploadAccepted    bool   `json:"uploadAccepted,omitempty"`
-	HelloVerified     bool   `json:"helloVerified,omitempty"`
-}
+type firmwareUpdateEvent = firmwareupdate.Event
 
 func (s *Server) applyFirmwareUpdateEvent(jobID string, event firmwareUpdateEvent) {
 	s.updateFirmwareUpdateJob(jobID, func(job *firmwareUpdateJob) {
@@ -4247,6 +4240,9 @@ func runMacAppUpdateCommand(ctx context.Context, home string, addr string, req m
 	script := `set -euo pipefail
 installer_url="$1"
 shift
+# The public installer defaults to exit 0 for older Companions that curl the
+# same script. This version opts into the action-required status explicitly.
+export VIBETV_MAC_APP_ACTION_REQUIRED_EXIT_CODE=20
 curl -fsSL "$installer_url" | bash -s -- "$@"
 `
 	cmdArgs := append([]string{"-c", script, "vibetv-mac-app-update", macAppInstallerURL}, args...)
@@ -4729,14 +4725,30 @@ func (s *Server) getHelloProbe(ctx context.Context, target, token string, timeou
 	flight := &helloProbeFlight{done: make(chan struct{})}
 	s.helloProbeFlights[key] = flight
 	s.probeMu.Unlock()
+	go s.runHelloProbeFlight(key, target, token, timeout, flight)
+	select {
+	case <-flight.done:
+		return flight.hello, flight.err
+	case <-ctx.Done():
+		return protocol.DeviceHello{}, ctx.Err()
+	}
+}
 
-	flight.hello, flight.err = s.getHelloProbeDirect(ctx, target, token, timeout)
+func (s *Server) runHelloProbeFlight(
+	key string,
+	target string,
+	token string,
+	timeout time.Duration,
+	flight *helloProbeFlight,
+) {
+	hello, err := s.getHelloProbeDirect(context.Background(), target, token, timeout)
 	s.probeMu.Lock()
-	s.helloProbeCache[key] = helloProbeSnapshot{at: s.currentTime(), hello: flight.hello, err: flight.err}
+	flight.hello = hello
+	flight.err = err
+	s.helloProbeCache[key] = helloProbeSnapshot{at: s.currentTime(), hello: hello, err: err}
 	delete(s.helloProbeFlights, key)
 	close(flight.done)
 	s.probeMu.Unlock()
-	return flight.hello, flight.err
 }
 
 func (s *Server) getHelloProbeDirect(ctx context.Context, target, token string, timeout time.Duration) (protocol.DeviceHello, error) {
@@ -4822,14 +4834,30 @@ func (s *Server) getHealthProbe(ctx context.Context, target, token string, timeo
 	flight := &healthProbeFlight{done: make(chan struct{})}
 	s.healthProbeFlights[key] = flight
 	s.probeMu.Unlock()
+	go s.runHealthProbeFlight(key, target, token, timeout, flight)
+	select {
+	case <-flight.done:
+		return flight.health, flight.err
+	case <-ctx.Done():
+		return deviceHealth{}, ctx.Err()
+	}
+}
 
-	flight.health, flight.err = s.getHealthProbeDirect(ctx, target, token, timeout)
+func (s *Server) runHealthProbeFlight(
+	key string,
+	target string,
+	token string,
+	timeout time.Duration,
+	flight *healthProbeFlight,
+) {
+	health, err := s.getHealthProbeDirect(context.Background(), target, token, timeout)
 	s.probeMu.Lock()
-	s.healthProbeCache[key] = healthProbeSnapshot{at: s.currentTime(), health: flight.health, err: flight.err}
+	flight.health = health
+	flight.err = err
+	s.healthProbeCache[key] = healthProbeSnapshot{at: s.currentTime(), health: health, err: err}
 	delete(s.healthProbeFlights, key)
 	close(flight.done)
 	s.probeMu.Unlock()
-	return flight.health, flight.err
 }
 
 func (s *Server) getHealthProbeDirect(ctx context.Context, target, token string, timeout time.Duration) (deviceHealth, error) {

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -47,8 +47,14 @@ const (
 	previewOriginHostPrefix   = "codex-vibetv-control-center-"
 	previewOriginHostSuffix   = "-paul-anduschus-projects.vercel.app"
 	nativeControlCenterUA     = "VibeTVControlCenter/"
+	deviceConnectionReady     = "ready"
+	deviceConnectionRetrying  = "reconnecting"
+	deviceConnectionSetup     = "setup_required"
 	deviceTimeout             = 15 * time.Second
 	discoveryProbeTime        = 1500 * time.Millisecond
+	deviceProbeCacheTime      = 750 * time.Millisecond
+	deviceReconnectGraceTime  = 45 * time.Second
+	deviceReconnectRepairTime = 60 * time.Second
 	repairDiscoveryAttempts   = 3
 	repairDiscoveryRetryGap   = 1200 * time.Millisecond
 	subnetProbeLimit          = 32
@@ -72,12 +78,16 @@ const (
 	macAppReleaseAPIURL       = "https://api.github.com/repos/DreamyTalesPAN/CodexBar-Display/releases/latest"
 	macAppReleaseCheckGap     = 6 * time.Hour
 	macAppReleaseTimeout      = 5 * time.Second
+	macAppVersionEnv          = "VIBETV_MAC_APP_VERSION"
+	macAppBuildEnv            = "VIBETV_MAC_APP_BUILD"
 	firmwareManifestEnvVar    = "CODEXBAR_DISPLAY_FIRMWARE_MANIFEST_URL"
 	firmwareReleaseTimeout    = 5 * time.Second
 )
 
 var deviceHealthProbeTime = 2 * time.Second
+var firmwareHealthVerifyTime = 30 * time.Second
 var subnetProbeTime = 450 * time.Millisecond
+var errMacAppActionRequired = errors.New("mac app installation requires customer action")
 
 var printDisplayStreamService = func(ctx context.Context, service string) ([]byte, error) {
 	return exec.CommandContext(ctx, "launchctl", "print", service).CombinedOutput()
@@ -141,6 +151,18 @@ type Server struct {
 	repairMu               sync.Mutex
 	repairFlightsMu        sync.Mutex
 	repairFlights          map[string]*deviceRepairFlight
+	probeMu                sync.Mutex
+	helloProbeCache        map[string]helloProbeSnapshot
+	helloProbeFlights      map[string]*helloProbeFlight
+	healthProbeCache       map[string]healthProbeSnapshot
+	healthProbeFlights     map[string]*healthProbeFlight
+	probeCacheTime         time.Duration
+	connectionMu           sync.Mutex
+	connectionStates       map[string]*configuredDeviceConnection
+	reconnectGraceTime     time.Duration
+	reconnectRepairTime    time.Duration
+	now                    func() time.Time
+	autoRecover            func(context.Context, runtimeconfig.Config) (deviceInfo, error)
 	deviceMaintenanceMu    sync.Mutex
 	pairMu                 sync.Mutex
 	verificationMu         sync.Mutex
@@ -211,6 +233,39 @@ type deviceRepairFlight struct {
 	err    error
 }
 
+type helloProbeSnapshot struct {
+	at    time.Time
+	hello protocol.DeviceHello
+	err   error
+}
+
+type helloProbeFlight struct {
+	done  chan struct{}
+	hello protocol.DeviceHello
+	err   error
+}
+
+type healthProbeSnapshot struct {
+	at     time.Time
+	health deviceHealth
+	err    error
+}
+
+type healthProbeFlight struct {
+	done   chan struct{}
+	health deviceHealth
+	err    error
+}
+
+type configuredDeviceConnection struct {
+	outageStartedAt time.Time
+	lastSeenAt      time.Time
+	lastDevice      deviceInfo
+	recoveryStarted bool
+	recoveryFailed  bool
+	recoveryCancel  context.CancelFunc
+}
+
 func (e *repairStageError) Error() string {
 	if e == nil || e.err == nil {
 		return ""
@@ -226,19 +281,21 @@ func (e *repairStageError) Unwrap() error {
 }
 
 type deviceInfo struct {
-	Target       string                    `json:"target,omitempty"`
-	DeviceID     string                    `json:"deviceId,omitempty"`
-	NetworkMode  string                    `json:"networkMode,omitempty"`
-	Connected    bool                      `json:"connected"`
-	Paired       bool                      `json:"paired,omitempty"`
-	Ready        bool                      `json:"ready"`
-	Board        string                    `json:"board,omitempty"`
-	Firmware     string                    `json:"firmware,omitempty"`
-	ActiveTheme  string                    `json:"activeTheme,omitempty"`
-	Capabilities *protocol.CapabilityBlock `json:"capabilities,omitempty"`
-	Stream       *displayStreamInfo        `json:"stream,omitempty"`
-	Display      *deviceDisplayInfo        `json:"display,omitempty"`
-	Health       *deviceHealthInfo         `json:"health,omitempty"`
+	Target          string                    `json:"target,omitempty"`
+	DeviceID        string                    `json:"deviceId,omitempty"`
+	NetworkMode     string                    `json:"networkMode,omitempty"`
+	Connected       bool                      `json:"connected"`
+	Paired          bool                      `json:"paired,omitempty"`
+	Ready           bool                      `json:"ready"`
+	ConnectionState string                    `json:"connectionState,omitempty"`
+	LastSeenAt      string                    `json:"lastSeenAt,omitempty"`
+	Board           string                    `json:"board,omitempty"`
+	Firmware        string                    `json:"firmware,omitempty"`
+	ActiveTheme     string                    `json:"activeTheme,omitempty"`
+	Capabilities    *protocol.CapabilityBlock `json:"capabilities,omitempty"`
+	Stream          *displayStreamInfo        `json:"stream,omitempty"`
+	Display         *deviceDisplayInfo        `json:"display,omitempty"`
+	Health          *deviceHealthInfo         `json:"health,omitempty"`
 }
 
 type displayStreamInfo struct {
@@ -264,7 +321,11 @@ type deviceDisplayInfo struct {
 
 type deviceHealthInfo struct {
 	OK          bool   `json:"ok"`
+	BootID      string `json:"bootId,omitempty"`
+	UptimeMs    uint64 `json:"uptimeMs,omitempty"`
+	ResetCount  uint32 `json:"resetCount,omitempty"`
 	ResetReason string `json:"resetReason,omitempty"`
+	LastResetAt string `json:"lastResetAt,omitempty"`
 	RenderKind  string `json:"renderKind,omitempty"`
 	Error       string `json:"error,omitempty"`
 }
@@ -351,19 +412,29 @@ type firmwareReleaseArtifact struct {
 }
 
 type firmwareUpdateResult struct {
-	Firmware string `json:"firmware,omitempty"`
-	Target   string `json:"target,omitempty"`
+	Firmware          string `json:"firmware,omitempty"`
+	Target            string `json:"target,omitempty"`
+	DeviceID          string `json:"deviceId,omitempty"`
+	ArtifactValidated bool   `json:"artifactValidated"`
+	UploadAccepted    bool   `json:"uploadAccepted"`
+	HelloVerified     bool   `json:"helloVerified"`
+	HealthVerified    bool   `json:"healthVerified"`
+	StreamVerified    bool   `json:"streamVerified"`
+	RenderVerified    bool   `json:"renderVerified"`
 }
 
 type firmwareUpdateJob struct {
 	ID         string                `json:"id"`
 	Phase      string                `json:"phase"`
+	Stage      string                `json:"stage"`
+	Outcome    string                `json:"outcome,omitempty"`
 	Message    string                `json:"message"`
 	Progress   int                   `json:"progress"`
 	StartedAt  time.Time             `json:"startedAt"`
 	FinishedAt *time.Time            `json:"finishedAt,omitempty"`
 	Logs       []string              `json:"logs,omitempty"`
 	Result     *firmwareUpdateResult `json:"result,omitempty"`
+	Warnings   []string              `json:"warnings,omitempty"`
 	Error      *apiError             `json:"error,omitempty"`
 	target     string
 	firmware   string
@@ -432,8 +503,27 @@ type companion struct {
 	Status           string               `json:"status"`
 	Version          string               `json:"version"`
 	InstallationMode string               `json:"installationMode"`
+	App              companionAppInfo     `json:"app"`
+	Runtime          companionRuntimeInfo `json:"runtime"`
 	Update           companionReleaseInfo `json:"update"`
 	Features         companionFeatures    `json:"features"`
+}
+
+type companionAppInfo struct {
+	Version                 string `json:"version,omitempty"`
+	Build                   string `json:"build,omitempty"`
+	Path                    string `json:"path,omitempty"`
+	InstallationMode        string `json:"installationMode"`
+	InstalledInApplications bool   `json:"installedInApplications"`
+}
+
+type companionRuntimeInfo struct {
+	Version       string `json:"version"`
+	Commit        string `json:"commit,omitempty"`
+	BuiltAt       string `json:"builtAt,omitempty"`
+	Executable    string `json:"executable,omitempty"`
+	PID           int    `json:"pid"`
+	ListenerOwner string `json:"listenerOwner,omitempty"`
 }
 
 type companionFeatures struct {
@@ -648,6 +738,16 @@ func New(opts Options) (*Server, error) {
 		pairAttempts:          defaultPairAttempts,
 		pairAttemptTimeout:    defaultPairAttemptTimeout,
 		pairRetryGap:          defaultPairRetryGap,
+		repairFlights:         make(map[string]*deviceRepairFlight),
+		helloProbeCache:       make(map[string]helloProbeSnapshot),
+		helloProbeFlights:     make(map[string]*helloProbeFlight),
+		healthProbeCache:      make(map[string]healthProbeSnapshot),
+		healthProbeFlights:    make(map[string]*healthProbeFlight),
+		probeCacheTime:        deviceProbeCacheTime,
+		connectionStates:      make(map[string]*configuredDeviceConnection),
+		reconnectGraceTime:    deviceReconnectGraceTime,
+		reconnectRepairTime:   deviceReconnectRepairTime,
+		now:                   time.Now,
 		displayVerifications:  make(map[string]displayVerification),
 		allowMacAppSelfUpdate: false,
 		installationMode:      macAppInstallationMode(),
@@ -877,13 +977,17 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	cfg, _ := s.config()
 	stream := s.streamStatus(r.Context(), cfg.DeviceTarget)
 	device := deviceInfo{
-		Target:    publicTarget(cfg.DeviceTarget),
-		Connected: strings.TrimSpace(cfg.DeviceToken) != "" && stream.Healthy,
-		Paired:    strings.TrimSpace(cfg.DeviceToken) != "" && stream.Healthy,
-		Stream:    streamPointer(stream),
+		Target:          publicTarget(cfg.DeviceTarget),
+		DeviceID:        strings.TrimSpace(cfg.DeviceID),
+		Connected:       false,
+		Paired:          strings.TrimSpace(cfg.DeviceToken) != "",
+		ConnectionState: deviceConnectionSetup,
+		Stream:          streamPointer(stream),
 	}
+	reachable := false
 	if strings.TrimSpace(cfg.DeviceTarget) != "" {
 		if hello, probeToken, err := s.getHelloProbeWithTokenFallback(r.Context(), cfg.DeviceTarget, cfg.DeviceToken, discoveryProbeTime); err == nil {
+			reachable = true
 			device = withDisplayStreamInfo(deviceFromHello(cfg.DeviceTarget, cfg.DeviceToken, hello), stream)
 			device.Paired = strings.TrimSpace(cfg.DeviceToken) != "" &&
 				probeToken == cfg.DeviceToken &&
@@ -895,11 +999,159 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	device, startRecovery := s.withConfiguredConnectionState(cfg, device, reachable)
+	if startRecovery {
+		s.startConfiguredDeviceRecovery(cfg)
+	}
 	writeJSON(w, http.StatusOK, statusResponse{
 		OK:        true,
 		Companion: s.companionInfo(r.Context()),
 		Device:    device,
 	})
+}
+
+func (s *Server) withConfiguredConnectionState(
+	cfg runtimeconfig.Config,
+	device deviceInfo,
+	reachable bool,
+) (deviceInfo, bool) {
+	target := publicTarget(cfg.DeviceTarget)
+	token := strings.TrimSpace(cfg.DeviceToken)
+	if target == "" || token == "" {
+		device.ConnectionState = deviceConnectionSetup
+		return device, false
+	}
+
+	now := s.currentTime()
+	key := configuredDeviceKey(cfg)
+	s.connectionMu.Lock()
+	defer s.connectionMu.Unlock()
+	if s.connectionStates == nil {
+		s.connectionStates = make(map[string]*configuredDeviceConnection)
+	}
+	state := s.connectionStates[key]
+	if state == nil {
+		state = &configuredDeviceConnection{}
+		s.connectionStates[key] = state
+	}
+
+	if reachable {
+		state.lastSeenAt = now
+		state.lastDevice = device
+	}
+	if device.Ready {
+		if state.recoveryCancel != nil {
+			state.recoveryCancel()
+			state.recoveryCancel = nil
+		}
+		state.outageStartedAt = time.Time{}
+		state.recoveryStarted = false
+		state.recoveryFailed = false
+		device.ConnectionState = deviceConnectionReady
+		device.LastSeenAt = now.UTC().Format(time.RFC3339Nano)
+		state.lastDevice = device
+		return device, false
+	}
+
+	if !reachable && state.lastDevice.Target != "" {
+		last := state.lastDevice
+		last.Target = target
+		if strings.TrimSpace(cfg.DeviceID) != "" {
+			last.DeviceID = strings.TrimSpace(cfg.DeviceID)
+		}
+		last.Connected = false
+		last.Paired = true
+		last.Ready = false
+		last.Stream = device.Stream
+		if device.Health != nil {
+			last.Health = device.Health
+		}
+		device = last
+	}
+	if state.outageStartedAt.IsZero() {
+		state.outageStartedAt = now
+	}
+	if !state.lastSeenAt.IsZero() {
+		device.LastSeenAt = state.lastSeenAt.UTC().Format(time.RFC3339Nano)
+	}
+	device.ConnectionState = deviceConnectionRetrying
+	if state.recoveryFailed {
+		device.ConnectionState = deviceConnectionSetup
+		return device, false
+	}
+	grace := s.reconnectGraceTime
+	if grace <= 0 {
+		grace = deviceReconnectGraceTime
+	}
+	if !state.recoveryStarted && now.Sub(state.outageStartedAt) >= grace {
+		state.recoveryStarted = true
+		return device, true
+	}
+	return device, false
+}
+
+func configuredDeviceKey(cfg runtimeconfig.Config) string {
+	if id := strings.ToLower(strings.TrimSpace(cfg.DeviceID)); id != "" {
+		return "id:" + id
+	}
+	return "target:" + strings.ToLower(publicTarget(cfg.DeviceTarget))
+}
+
+func (s *Server) currentTime() time.Time {
+	if s.now != nil {
+		return s.now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (s *Server) startConfiguredDeviceRecovery(cfg runtimeconfig.Config) {
+	key := configuredDeviceKey(cfg)
+	timeout := s.reconnectRepairTime
+	if timeout <= 0 {
+		timeout = deviceReconnectRepairTime
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	s.connectionMu.Lock()
+	state := s.connectionStates[key]
+	if state == nil || !state.recoveryStarted {
+		s.connectionMu.Unlock()
+		cancel()
+		return
+	}
+	state.recoveryCancel = cancel
+	s.connectionMu.Unlock()
+	go func() {
+		defer cancel()
+		var (
+			device deviceInfo
+			err    error
+		)
+		if s.autoRecover != nil {
+			device, err = s.autoRecover(ctx, cfg)
+		} else {
+			device, err = s.repairDevice(ctx, "", cfg.DeviceID, false)
+		}
+
+		s.connectionMu.Lock()
+		defer s.connectionMu.Unlock()
+		state := s.connectionStates[key]
+		if state == nil || !state.recoveryStarted {
+			return
+		}
+		state.recoveryStarted = false
+		state.recoveryCancel = nil
+		if err != nil || !device.Ready {
+			state.recoveryFailed = true
+			return
+		}
+		now := s.currentTime()
+		device.ConnectionState = deviceConnectionReady
+		device.LastSeenAt = now.Format(time.RFC3339Nano)
+		state.lastSeenAt = now
+		state.lastDevice = device
+		state.outageStartedAt = time.Time{}
+		state.recoveryFailed = false
+	}()
 }
 
 func (s *Server) handleRuntimeHealth(w http.ResponseWriter, r *http.Request) {
@@ -909,13 +1161,21 @@ func (s *Server) handleRuntimeHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, struct {
 		OK        bool `json:"ok"`
 		Companion struct {
-			Version string `json:"version"`
+			Version string               `json:"version"`
+			App     companionAppInfo     `json:"app"`
+			Runtime companionRuntimeInfo `json:"runtime"`
 		} `json:"companion"`
 	}{
 		OK: true,
 		Companion: struct {
-			Version string `json:"version"`
-		}{Version: buildinfo.NormalizedVersion()},
+			Version string               `json:"version"`
+			App     companionAppInfo     `json:"app"`
+			Runtime companionRuntimeInfo `json:"runtime"`
+		}{
+			Version: buildinfo.NormalizedVersion(),
+			App:     currentCompanionAppInfo(s.installationMode),
+			Runtime: currentCompanionRuntimeInfo(),
+		},
 	})
 }
 
@@ -1207,6 +1467,8 @@ func (s *Server) companionInfo(ctx context.Context) companion {
 		Status:           "ready",
 		Version:          buildinfo.NormalizedVersion(),
 		InstallationMode: s.installationMode,
+		App:              currentCompanionAppInfo(s.installationMode),
+		Runtime:          currentCompanionRuntimeInfo(),
 		Update:           s.macAppReleaseInfo(ctx),
 		Features: companionFeatures{
 			ThemeInstallEnabled:     themeInstallEnabled(),
@@ -1216,7 +1478,11 @@ func (s *Server) companionInfo(ctx context.Context) companion {
 }
 
 func (s *Server) macAppReleaseInfo(ctx context.Context) companionReleaseInfo {
-	installedVersion := normalizeMacAppReleaseVersion(buildinfo.NormalizedVersion())
+	app := currentCompanionAppInfo(s.installationMode)
+	installedVersion := normalizeMacAppReleaseVersion(app.Version)
+	if installedVersion == "" {
+		installedVersion = normalizeMacAppReleaseVersion(buildinfo.NormalizedVersion())
+	}
 	now := time.Now().UTC()
 
 	s.macAppReleaseMu.Lock()
@@ -1942,6 +2208,7 @@ func (s *Server) handleSetupReset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.clearDisplayVerification("")
+	s.clearConfiguredDeviceState()
 	writeJSON(w, http.StatusOK, statusResponse{
 		OK:        true,
 		Companion: s.companionInfo(r.Context()),
@@ -1962,6 +2229,11 @@ func (s *Server) handleDevice(w http.ResponseWriter, r *http.Request) {
 		device = s.withVerifiedDeviceHealth(device, health, cfg.DeviceTarget, cfg.DeviceToken, false)
 	} else {
 		device = withDeviceHealthProbeError(device, err)
+	}
+	if device.Ready {
+		device.ConnectionState = deviceConnectionReady
+	} else {
+		device.ConnectionState = deviceConnectionRetrying
 	}
 	writeJSON(w, http.StatusOK, struct {
 		OK     bool       `json:"ok"`
@@ -2291,6 +2563,8 @@ func (s *Server) repairDeviceOnce(
 	if !device.Ready {
 		return deviceInfo{}, &repairStageError{stage: "display-render", err: errors.New("device is reachable but not ready")}
 	}
+	device.ConnectionState = deviceConnectionReady
+	device.LastSeenAt = s.currentTime().Format(time.RFC3339Nano)
 	return device, nil
 }
 
@@ -3179,6 +3453,7 @@ func (s *Server) createFirmwareUpdateJob(cfg runtimeconfig.Config) firmwareUpdat
 	job := &firmwareUpdateJob{
 		ID:        id,
 		Phase:     "installing",
+		Stage:     "validating_artifact",
 		Message:   "Preparing VibeTV update.",
 		Progress:  5,
 		StartedAt: time.Now().UTC(),
@@ -3195,19 +3470,58 @@ func (s *Server) startFirmwareUpdateJob(_ context.Context, jobID string, cfg run
 		defer s.deviceMaintenanceMu.Unlock()
 
 		s.firmwareUpdateActive.Store(true)
+		streamPaused := false
 		if s.pauseDisplayStream != nil {
 			s.pauseDisplayStream(true)
+			streamPaused = true
+		}
+		resumeStream := func() {
+			if !streamPaused {
+				return
+			}
+			streamPaused = false
+			s.pauseDisplayStream(false)
 		}
 		defer func() {
 			s.firmwareUpdateActive.Store(false)
-			if s.pauseDisplayStream != nil {
-				s.pauseDisplayStream(false)
-			}
+			resumeStream()
 		}()
 		ctx, cancel := context.WithTimeout(context.Background(), firmwareUpdateJobTime)
 		defer cancel()
 		writer := &firmwareUpdateProgressWriter{server: s, jobID: jobID}
 		err := s.updateFirmware(ctx, s.home, cfg, req, writer)
+		s.firmwareUpdateActive.Store(false)
+		resumeStream()
+
+		snapshot, _ := s.firmwareUpdateJobSnapshot(jobID)
+		shouldVerify := err == nil || (snapshot.Result != nil && snapshot.Result.UploadAccepted)
+		if shouldVerify {
+			outcome, attentionMessage, verifyErr := s.verifyFirmwareUpdateResult(ctx, jobID, cfg)
+			if verifyErr == nil {
+				finishedAt := time.Now().UTC()
+				s.updateFirmwareUpdateJob(jobID, func(job *firmwareUpdateJob) {
+					job.Progress = 100
+					job.FinishedAt = &finishedAt
+					job.Outcome = outcome
+					if attentionMessage != "" {
+						job.Phase = "attention"
+						job.Message = attentionMessage
+						job.Warnings = append(job.Warnings, attentionMessage)
+						appendFirmwareUpdateJobLog(job, attentionMessage)
+						return
+					}
+					job.Phase = "complete"
+					job.Message = "Update complete."
+					appendFirmwareUpdateJobLog(job, "Update complete.")
+				})
+				return
+			}
+			if err == nil {
+				err = verifyErr
+			} else {
+				err = fmt.Errorf("%v; final verification: %w", err, verifyErr)
+			}
+		}
 		finishedAt := time.Now().UTC()
 		if err != nil {
 			if detail := sanitizeErrorDetail(err); detail != "" {
@@ -3224,18 +3538,129 @@ func (s *Server) startFirmwareUpdateJob(_ context.Context, jobID string, cfg run
 			})
 			return
 		}
-		s.updateFirmwareUpdateJob(jobID, func(job *firmwareUpdateJob) {
-			job.Phase = "complete"
-			job.Message = "Update complete."
-			job.Progress = 100
-			job.FinishedAt = &finishedAt
-			job.Result = &firmwareUpdateResult{
-				Firmware: strings.TrimSpace(job.firmware),
-				Target:   strings.TrimSpace(job.target),
-			}
-			appendFirmwareUpdateJobLog(job, "Update complete.")
-		})
 	}()
+}
+
+func (s *Server) verifyFirmwareUpdateResult(ctx context.Context, jobID string, initialCfg runtimeconfig.Config) (string, string, error) {
+	snapshot, ok := s.firmwareUpdateJobSnapshot(jobID)
+	if !ok || snapshot.Result == nil {
+		return "", "", errors.New("firmware update produced no verification result")
+	}
+	expectedFirmware := strings.TrimSpace(snapshot.Result.Firmware)
+	expectedDeviceID := strings.TrimSpace(snapshot.Result.DeviceID)
+	target := strings.TrimSpace(snapshot.Result.Target)
+	if expectedFirmware == "" || expectedDeviceID == "" || target == "" {
+		return "", "", errors.New("firmware update result is missing firmware, device id, or target")
+	}
+	cfg := initialCfg
+	if current, err := s.loadConfig(s.home); err == nil {
+		cfg = current
+	}
+	token := strings.TrimSpace(cfg.DeviceToken)
+	s.setFirmwareUpdateStage(jobID, "verifying_firmware")
+	hello, err := s.getHello(ctx, target, token)
+	if err != nil {
+		return "", "", fmt.Errorf("verify installed firmware: %w", err)
+	}
+	if !strings.EqualFold(expectedDeviceID, strings.TrimSpace(hello.DeviceID)) {
+		return "", "", fmt.Errorf("VibeTV identity mismatch after update: expected=%q got=%q", expectedDeviceID, strings.TrimSpace(hello.DeviceID))
+	}
+	if strings.TrimSpace(hello.Firmware) != expectedFirmware {
+		return "", "", fmt.Errorf("VibeTV firmware mismatch after update: expected=%q got=%q", expectedFirmware, strings.TrimSpace(hello.Firmware))
+	}
+	s.updateFirmwareVerification(jobID, func(result *firmwareUpdateResult) {
+		result.HelloVerified = true
+		result.Target = target
+		result.Firmware = strings.TrimSpace(hello.Firmware)
+	})
+	if strings.TrimSpace(cfg.DeviceTarget) != target {
+		cfg.DeviceTarget = target
+		if err := s.saveConfig(s.home, cfg); err != nil {
+			return "", "", fmt.Errorf("save rediscovered VibeTV target: %w", err)
+		}
+	}
+
+	s.setFirmwareUpdateStage(jobID, "verifying_health")
+	healthDeadline := time.Now().Add(firmwareHealthVerifyTime)
+	var health deviceHealth
+	for {
+		health, err = s.getHealth(ctx, target, token)
+		if err == nil && health.OK {
+			break
+		}
+		if time.Now().After(healthDeadline) {
+			return firmwareAttentionOutcome(snapshot, "health"), "Firmware is current, but VibeTV health still needs attention.", nil
+		}
+		select {
+		case <-ctx.Done():
+			return "", "", ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+	s.updateFirmwareVerification(jobID, func(result *firmwareUpdateResult) {
+		result.HealthVerified = true
+	})
+
+	s.setFirmwareUpdateStage(jobID, "restarting_stream")
+	baseline := health
+	streamStartedAt := time.Now().UTC()
+	if err := s.startDisplayStream(ctx, target); err != nil {
+		return firmwareAttentionOutcome(snapshot, "stream"), "Firmware is current, but the display stream could not restart.", nil
+	}
+	stream := s.waitForFreshDisplayStream(ctx, target, streamStartedAt)
+	if !displayStreamHealthyForTarget(&stream, target) {
+		return firmwareAttentionOutcome(snapshot, "stream"), "Firmware is current, but the display stream still needs attention.", nil
+	}
+	s.updateFirmwareVerification(jobID, func(result *firmwareUpdateResult) {
+		result.StreamVerified = true
+	})
+
+	s.setFirmwareUpdateStage(jobID, "verifying_render")
+	if _, err := s.waitForVerifiedDisplayRender(ctx, target, token, baseline, stream); err != nil {
+		return firmwareAttentionOutcome(snapshot, "render"), "Firmware is current, but the picture could not be verified.", nil
+	}
+	s.updateFirmwareVerification(jobID, func(result *firmwareUpdateResult) {
+		result.RenderVerified = true
+	})
+	if snapshot.Outcome == "already_current" {
+		return "already_current", "", nil
+	}
+	return "updated", "", nil
+}
+
+func firmwareAttentionOutcome(job firmwareUpdateJob, kind string) string {
+	prefix := "firmware_current_"
+	switch kind {
+	case "health":
+		return prefix + "health_attention"
+	case "stream":
+		return prefix + "stream_attention"
+	default:
+		return prefix + "render_attention"
+	}
+}
+
+func (s *Server) setFirmwareUpdateStage(jobID, stage string) {
+	s.updateFirmwareUpdateJob(jobID, func(job *firmwareUpdateJob) {
+		job.Stage = stage
+		message, progress := firmwareUpdateStageProgress(stage)
+		if message != "" {
+			job.Message = message
+			appendFirmwareUpdateJobLog(job, message)
+		}
+		if progress > job.Progress {
+			job.Progress = progress
+		}
+	})
+}
+
+func (s *Server) updateFirmwareVerification(jobID string, update func(*firmwareUpdateResult)) {
+	s.updateFirmwareUpdateJob(jobID, func(job *firmwareUpdateJob) {
+		if job.Result == nil {
+			job.Result = &firmwareUpdateResult{}
+		}
+		update(job.Result)
+	})
 }
 
 func (s *Server) updateFirmwareUpdateJob(jobID string, update func(*firmwareUpdateJob)) {
@@ -3267,6 +3692,7 @@ func cloneFirmwareUpdateJob(job *firmwareUpdateJob) firmwareUpdateJob {
 	}
 	clone := *job
 	clone.Logs = append([]string(nil), job.Logs...)
+	clone.Warnings = append([]string(nil), job.Warnings...)
 	if job.Result != nil {
 		result := *job.Result
 		clone.Result = &result
@@ -3308,6 +3734,13 @@ func (w *firmwareUpdateProgressWriter) noteLine(line string) {
 	if line == "" || w.server == nil {
 		return
 	}
+	if strings.HasPrefix(line, firmwareUpdateEventPrefix) {
+		var event firmwareUpdateEvent
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, firmwareUpdateEventPrefix)), &event); err == nil {
+			w.server.applyFirmwareUpdateEvent(w.jobID, event)
+		}
+		return
+	}
 	w.server.updateFirmwareUpdateJob(w.jobID, func(job *firmwareUpdateJob) {
 		message, progress, ok := customerFirmwareUpdateProgress(line, job)
 		if !ok {
@@ -3319,6 +3752,82 @@ func (w *firmwareUpdateProgressWriter) noteLine(line string) {
 		}
 		appendFirmwareUpdateJobLog(job, message)
 	})
+}
+
+const firmwareUpdateEventPrefix = "CODEX_FIRMWARE_UPDATE_EVENT "
+
+type firmwareUpdateEvent struct {
+	Stage             string `json:"stage"`
+	Phase             string `json:"phase,omitempty"`
+	Outcome           string `json:"outcome,omitempty"`
+	Firmware          string `json:"firmware,omitempty"`
+	Target            string `json:"target,omitempty"`
+	DeviceID          string `json:"deviceId,omitempty"`
+	ArtifactValidated bool   `json:"artifactValidated,omitempty"`
+	UploadAccepted    bool   `json:"uploadAccepted,omitempty"`
+	HelloVerified     bool   `json:"helloVerified,omitempty"`
+}
+
+func (s *Server) applyFirmwareUpdateEvent(jobID string, event firmwareUpdateEvent) {
+	s.updateFirmwareUpdateJob(jobID, func(job *firmwareUpdateJob) {
+		if stage := strings.TrimSpace(event.Stage); stage != "" {
+			job.Stage = stage
+		}
+		if phase := strings.TrimSpace(event.Phase); phase != "" {
+			job.Phase = phase
+		}
+		if outcome := strings.TrimSpace(event.Outcome); outcome != "" {
+			job.Outcome = outcome
+		}
+		if job.Result == nil {
+			job.Result = &firmwareUpdateResult{}
+		}
+		if value := strings.TrimSpace(event.Firmware); value != "" {
+			job.firmware = value
+			job.Result.Firmware = value
+		}
+		if value := strings.TrimSpace(event.Target); value != "" {
+			job.target = value
+			job.Result.Target = value
+		}
+		if value := strings.TrimSpace(event.DeviceID); value != "" {
+			job.Result.DeviceID = value
+		}
+		job.Result.ArtifactValidated = job.Result.ArtifactValidated || event.ArtifactValidated
+		job.Result.UploadAccepted = job.Result.UploadAccepted || event.UploadAccepted
+		job.Result.HelloVerified = job.Result.HelloVerified || event.HelloVerified
+		message, progress := firmwareUpdateStageProgress(job.Stage)
+		if message != "" {
+			job.Message = message
+			appendFirmwareUpdateJobLog(job, message)
+		}
+		if progress > job.Progress {
+			job.Progress = progress
+		}
+	})
+}
+
+func firmwareUpdateStageProgress(stage string) (string, int) {
+	switch strings.TrimSpace(stage) {
+	case "validating_artifact":
+		return "Validating update.", 20
+	case "uploading":
+		return "Updating VibeTV.", 55
+	case "rebooting":
+		return "Restarting VibeTV.", 70
+	case "rediscovering":
+		return "Finding VibeTV again.", 76
+	case "verifying_firmware":
+		return "Checking installed firmware.", 82
+	case "verifying_health":
+		return "Checking VibeTV health.", 87
+	case "restarting_stream":
+		return "Restarting display stream.", 92
+	case "verifying_render":
+		return "Checking the picture.", 97
+	default:
+		return "", 0
+	}
 }
 
 func customerFirmwareUpdateProgress(line string, job *firmwareUpdateJob) (string, int, bool) {
@@ -3418,6 +3927,17 @@ func (s *Server) startMacAppUpdateJob(_ context.Context, jobID string, req macAp
 		err := s.updateMacApp(ctx, s.home, s.addr, req, writer)
 		finishedAt := time.Now().UTC()
 		if err != nil {
+			if errors.Is(err, errMacAppActionRequired) {
+				s.updateMacAppUpdateJob(jobID, func(job *macAppUpdateJob) {
+					job.Phase = "action_required"
+					job.Message = "Finish installing the Mac App in Applications."
+					job.Progress = 95
+					job.FinishedAt = &finishedAt
+					job.Result = &macAppUpdateResult{Version: strings.TrimSpace(job.version)}
+					appendMacAppUpdateJobLog(job, "Mac App installation needs customer action.")
+				})
+				return
+			}
 			apiErr := macAppUpdateErrorPayload(err)
 			s.updateMacAppUpdateJob(jobID, func(job *macAppUpdateJob) {
 				job.Phase = "error"
@@ -3650,6 +4170,11 @@ func firmwareUpdateDiagnosticDetail(job firmwareUpdateJob) string {
 			return "Last VibeTV update failed: " + strings.TrimSpace(job.Error.Message)
 		}
 		return "Last VibeTV update failed."
+	case "attention":
+		if strings.TrimSpace(job.Message) != "" {
+			return strings.TrimSpace(job.Message)
+		}
+		return "Firmware is current, but VibeTV still needs attention."
 	default:
 		return "VibeTV update is still running."
 	}
@@ -3663,6 +4188,9 @@ func firmwareUpdateDiagnosticErrorCode(job firmwareUpdateJob) string {
 }
 
 func firmwareUpdateDiagnosticNextAction(job firmwareUpdateJob) string {
+	if job.Phase == "attention" {
+		return "Use connection or picture repair. Do not install the same firmware again."
+	}
 	if job.Phase != "error" || job.Error == nil {
 		return ""
 	}
@@ -3729,6 +4257,10 @@ curl -fsSL "$installer_url" | bash -s -- "$@"
 		cmd.Env = append(os.Environ(), "HOME="+home)
 	}
 	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 20 {
+			return errMacAppActionRequired
+		}
 		return fmt.Errorf("mac app update command failed: %w", err)
 	}
 	return nil
@@ -3844,7 +4376,7 @@ func (s *Server) requireDevice(w http.ResponseWriter, r *http.Request) (runtimec
 		writeDeviceNotFound(w)
 		return runtimeconfig.Config{}, protocol.DeviceHello{}, false
 	}
-	hello, err := s.getHello(r.Context(), cfg.DeviceTarget, cfg.DeviceToken)
+	hello, err := s.getHelloProbe(r.Context(), cfg.DeviceTarget, cfg.DeviceToken, discoveryProbeTime)
 	if err != nil {
 		// A read-only status poll must never fan out into a subnet scan. The
 		// Control Center polls this endpoint frequently; when VibeTV is offline,
@@ -3855,6 +4387,21 @@ func (s *Server) requireDevice(w http.ResponseWriter, r *http.Request) (runtimec
 		return runtimeconfig.Config{}, protocol.DeviceHello{}, false
 	}
 	return cfg, hello, true
+}
+
+func (s *Server) clearConfiguredDeviceState() {
+	s.connectionMu.Lock()
+	for _, state := range s.connectionStates {
+		if state != nil && state.recoveryCancel != nil {
+			state.recoveryCancel()
+		}
+	}
+	clear(s.connectionStates)
+	s.connectionMu.Unlock()
+	s.probeMu.Lock()
+	clear(s.helloProbeCache)
+	clear(s.healthProbeCache)
+	s.probeMu.Unlock()
 }
 
 func (s *Server) discover(ctx context.Context, cfg runtimeconfig.Config, explicitTarget string) (string, protocol.DeviceHello, error) {
@@ -4160,6 +4707,39 @@ func (s *Server) getHello(ctx context.Context, target, token string) (protocol.D
 }
 
 func (s *Server) getHelloProbe(ctx context.Context, target, token string, timeout time.Duration) (protocol.DeviceHello, error) {
+	if timeout <= 0 || s.probeCacheTime <= 0 {
+		return s.getHelloProbeDirect(ctx, target, token, timeout)
+	}
+	key := deviceProbeKey(target, token)
+	now := s.currentTime()
+	s.probeMu.Lock()
+	if cached, ok := s.helloProbeCache[key]; ok && now.Sub(cached.at) < s.probeCacheTime {
+		s.probeMu.Unlock()
+		return cached.hello, cached.err
+	}
+	if flight := s.helloProbeFlights[key]; flight != nil {
+		s.probeMu.Unlock()
+		select {
+		case <-flight.done:
+			return flight.hello, flight.err
+		case <-ctx.Done():
+			return protocol.DeviceHello{}, ctx.Err()
+		}
+	}
+	flight := &helloProbeFlight{done: make(chan struct{})}
+	s.helloProbeFlights[key] = flight
+	s.probeMu.Unlock()
+
+	flight.hello, flight.err = s.getHelloProbeDirect(ctx, target, token, timeout)
+	s.probeMu.Lock()
+	s.helloProbeCache[key] = helloProbeSnapshot{at: s.currentTime(), hello: flight.hello, err: flight.err}
+	delete(s.helloProbeFlights, key)
+	close(flight.done)
+	s.probeMu.Unlock()
+	return flight.hello, flight.err
+}
+
+func (s *Server) getHelloProbeDirect(ctx context.Context, target, token string, timeout time.Duration) (protocol.DeviceHello, error) {
 	if timeout <= 0 {
 		return s.getHello(ctx, target, token)
 	}
@@ -4188,6 +4768,9 @@ type deviceHealth struct {
 	// It is intentionally not populated from device JSON.
 	correlatedFrameProof bool
 	System               struct {
+		BootID      string `json:"bootId"`
+		UptimeMs    uint64 `json:"uptimeMs"`
+		ResetCount  uint32 `json:"resetCount"`
 		ResetReason string `json:"resetReason"`
 	} `json:"system"`
 	Display struct {
@@ -4217,12 +4800,49 @@ func (s *Server) getHealth(ctx context.Context, target, token string) (deviceHea
 }
 
 func (s *Server) getHealthProbe(ctx context.Context, target, token string, timeout time.Duration) (deviceHealth, error) {
+	if timeout <= 0 || s.probeCacheTime <= 0 {
+		return s.getHealthProbeDirect(ctx, target, token, timeout)
+	}
+	key := deviceProbeKey(target, token)
+	now := s.currentTime()
+	s.probeMu.Lock()
+	if cached, ok := s.healthProbeCache[key]; ok && now.Sub(cached.at) < s.probeCacheTime {
+		s.probeMu.Unlock()
+		return cached.health, cached.err
+	}
+	if flight := s.healthProbeFlights[key]; flight != nil {
+		s.probeMu.Unlock()
+		select {
+		case <-flight.done:
+			return flight.health, flight.err
+		case <-ctx.Done():
+			return deviceHealth{}, ctx.Err()
+		}
+	}
+	flight := &healthProbeFlight{done: make(chan struct{})}
+	s.healthProbeFlights[key] = flight
+	s.probeMu.Unlock()
+
+	flight.health, flight.err = s.getHealthProbeDirect(ctx, target, token, timeout)
+	s.probeMu.Lock()
+	s.healthProbeCache[key] = healthProbeSnapshot{at: s.currentTime(), health: flight.health, err: flight.err}
+	delete(s.healthProbeFlights, key)
+	close(flight.done)
+	s.probeMu.Unlock()
+	return flight.health, flight.err
+}
+
+func (s *Server) getHealthProbeDirect(ctx context.Context, target, token string, timeout time.Duration) (deviceHealth, error) {
 	if timeout <= 0 {
 		return s.getHealth(ctx, target, token)
 	}
 	probeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	return s.getHealth(probeCtx, target, token)
+}
+
+func deviceProbeKey(target, token string) string {
+	return normalizeTarget(target) + "\x00" + strings.TrimSpace(token)
 }
 
 func (s *Server) captureDisplayRenderBaseline(ctx context.Context, target, token string) (deviceHealth, error) {
@@ -4782,6 +5402,58 @@ func macAppInstallationMode() string {
 	}
 }
 
+func currentCompanionAppInfo(installationMode string) companionAppInfo {
+	version := strings.TrimSpace(os.Getenv(macAppVersionEnv))
+	build := strings.TrimSpace(os.Getenv(macAppBuildEnv))
+	appPath := companionAppBundlePath()
+	installed := strings.HasPrefix(filepath.Clean(appPath), filepath.Clean("/Applications")+string(os.PathSeparator))
+	return companionAppInfo{
+		Version:                 version,
+		Build:                   build,
+		Path:                    appPath,
+		InstallationMode:        strings.TrimSpace(installationMode),
+		InstalledInApplications: installed,
+	}
+}
+
+func currentCompanionRuntimeInfo() companionRuntimeInfo {
+	executable, _ := os.Executable()
+	if resolved, err := filepath.EvalSymlinks(executable); err == nil {
+		executable = resolved
+	}
+	return companionRuntimeInfo{
+		Version:       buildinfo.NormalizedVersion(),
+		Commit:        strings.TrimSpace(buildinfo.Commit),
+		BuiltAt:       strings.TrimSpace(buildinfo.Date),
+		Executable:    strings.TrimSpace(executable),
+		PID:           os.Getpid(),
+		ListenerOwner: displayStreamLaunchAgentLabel(),
+	}
+}
+
+func companionAppBundlePath() string {
+	executable, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(executable); resolveErr == nil {
+		executable = resolved
+	}
+	helpersDir := filepath.Dir(executable)
+	if filepath.Base(helpersDir) != "Helpers" {
+		return ""
+	}
+	contentsDir := filepath.Dir(helpersDir)
+	if filepath.Base(contentsDir) != "Contents" {
+		return ""
+	}
+	appDir := filepath.Dir(contentsDir)
+	if !strings.HasSuffix(strings.ToLower(appDir), ".app") {
+		return ""
+	}
+	return filepath.Clean(appDir)
+}
+
 func minInt(a, b int) int {
 	if a < b {
 		return a
@@ -4832,9 +5504,17 @@ func withDisplayStreamInfo(device deviceInfo, stream displayStreamInfo) deviceIn
 }
 
 func withDeviceHealth(device deviceInfo, health deviceHealth) deviceInfo {
+	lastResetAt := ""
+	if health.System.UptimeMs > 0 {
+		lastResetAt = time.Now().UTC().Add(-time.Duration(health.System.UptimeMs) * time.Millisecond).Format(time.RFC3339Nano)
+	}
 	device.Health = &deviceHealthInfo{
 		OK:          health.OK,
+		BootID:      strings.TrimSpace(health.System.BootID),
+		UptimeMs:    health.System.UptimeMs,
+		ResetCount:  health.System.ResetCount,
 		ResetReason: strings.TrimSpace(health.System.ResetReason),
+		LastResetAt: lastResetAt,
 		RenderKind:  strings.TrimSpace(health.Render.LastKind),
 	}
 	device.ActiveTheme = strings.TrimSpace(health.Display.ActiveTheme)

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -463,6 +463,34 @@ func TestStatusReportsCachedMacAppUpdateState(t *testing.T) {
 	}
 }
 
+func TestStatusSeparatesMacAppAndRuntimeVersions(t *testing.T) {
+	t.Setenv(macAppVersionEnv, "1.0.98")
+	t.Setenv(macAppBuildEnv, "198")
+	server := newTestServer(t, runtimeconfig.Config{})
+	server.fetchMacAppRelease = func(context.Context) (githubRelease, error) {
+		return githubRelease{TagName: "v1.0.99"}, nil
+	}
+
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got statusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Companion.App.Version != "1.0.98" || got.Companion.App.Build != "198" {
+		t.Fatalf("unexpected native app metadata: %+v", got.Companion.App)
+	}
+	if got.Companion.Runtime.Version != got.Companion.Version {
+		t.Fatalf("legacy version alias must remain the runtime version: companion=%q runtime=%q", got.Companion.Version, got.Companion.Runtime.Version)
+	}
+	if got.Companion.Update.InstalledVersion != "1.0.98" || !got.Companion.Update.UpdateAvailable {
+		t.Fatalf("Mac App update check must compare the app version: %+v", got.Companion.Update)
+	}
+}
+
 func TestStatusReportsMacAppUpdateCheckFailure(t *testing.T) {
 	server := newTestServer(t, runtimeconfig.Config{})
 	server.fetchMacAppRelease = func(context.Context) (githubRelease, error) {
@@ -1764,6 +1792,240 @@ func TestDeviceGetDoesNotScanSubnetWhenSavedTargetIsStale(t *testing.T) {
 	}
 }
 
+func TestStatusKeepsConfiguredDeviceReconnectingDuringTransientProbeFailure(t *testing.T) {
+	var available atomic.Bool
+	var boot atomic.Int32
+	available.Store(true)
+	boot.Store(1)
+	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !available.Load() {
+			http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		switch r.URL.Path {
+		case "/hello":
+			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.44","deviceId":"vibetv-canary","networkMode":"station","capabilities":{"transport":{"active":"wifi"}}}`))
+		case "/health":
+			_, _ = fmt.Fprintf(w, `{"ok":true,"system":{"bootId":"boot-%d","uptimeMs":1200,"resetCount":%d,"resetReason":"Software/System restart"},"render":{"fullCount":3,"partialCount":1,"lastKind":"usage"}}`, boot.Load(), boot.Load()+3)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer device.Close()
+
+	server := newTestServer(t, runtimeconfig.Config{
+		DeviceTarget: device.URL,
+		DeviceToken:  "pair-token",
+		DeviceID:     "vibetv-canary",
+	})
+	subnetCalls := atomic.Int32{}
+	server.subnetTargets = func() []string {
+		subnetCalls.Add(1)
+		return nil
+	}
+
+	readStatus := func() statusResponse {
+		rec := httptest.NewRecorder()
+		server.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var got statusResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode status: %v", err)
+		}
+		return got
+	}
+
+	ready := readStatus()
+	if !ready.Device.Ready || ready.Device.ConnectionState != deviceConnectionReady {
+		t.Fatalf("expected initial ready device, got %+v", ready.Device)
+	}
+	available.Store(false)
+	reconnecting := readStatus()
+	if reconnecting.Device.ConnectionState != deviceConnectionRetrying || reconnecting.Device.Ready {
+		t.Fatalf("transient timeout restarted setup instead of reconnecting: %+v", reconnecting.Device)
+	}
+	if !reconnecting.Device.Paired || reconnecting.Device.DeviceID != "vibetv-canary" || reconnecting.Device.Firmware != "1.0.44" {
+		t.Fatalf("saved identity and last verified details were not preserved: %+v", reconnecting.Device)
+	}
+	if reconnecting.Device.LastSeenAt == "" {
+		t.Fatalf("expected last-seen timestamp, got %+v", reconnecting.Device)
+	}
+	if subnetCalls.Load() != 0 {
+		t.Fatalf("grace-period status poll started %d subnet scans", subnetCalls.Load())
+	}
+	boot.Store(2)
+	available.Store(true)
+	recovered := readStatus()
+	if !recovered.Device.Ready || recovered.Device.ConnectionState != deviceConnectionReady || recovered.Device.Health == nil || recovered.Device.Health.BootID != "boot-2" {
+		t.Fatalf("device reboot did not recover automatically inside grace period: %+v", recovered.Device)
+	}
+	if subnetCalls.Load() != 0 {
+		t.Fatalf("short reboot recovery unexpectedly scanned the subnet %d times", subnetCalls.Load())
+	}
+}
+
+func TestStatusStartsOneBoundedRecoveryAfterGraceAndThenRequiresSetup(t *testing.T) {
+	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "offline", http.StatusServiceUnavailable)
+	}))
+	defer device.Close()
+
+	server := newTestServer(t, runtimeconfig.Config{
+		DeviceTarget: device.URL,
+		DeviceToken:  "pair-token",
+		DeviceID:     "vibetv-canary",
+	})
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	server.now = func() time.Time { return now }
+	server.reconnectGraceTime = 30 * time.Second
+	recoveryStarted := make(chan struct{})
+	releaseRecovery := make(chan struct{})
+	var recoveryCalls atomic.Int32
+	server.autoRecover = func(context.Context, runtimeconfig.Config) (deviceInfo, error) {
+		if recoveryCalls.Add(1) == 1 {
+			close(recoveryStarted)
+		}
+		<-releaseRecovery
+		return deviceInfo{}, errors.New("saved identity not found")
+	}
+
+	readStatus := func() statusResponse {
+		rec := httptest.NewRecorder()
+		server.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+		var got statusResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode status: %v body=%s", err, rec.Body.String())
+		}
+		return got
+	}
+
+	if got := readStatus(); got.Device.ConnectionState != deviceConnectionRetrying {
+		t.Fatalf("first miss must enter reconnecting grace period: %+v", got.Device)
+	}
+	now = now.Add(31 * time.Second)
+	for range 5 {
+		if got := readStatus(); got.Device.ConnectionState != deviceConnectionRetrying {
+			t.Fatalf("active recovery must stay reconnecting: %+v", got.Device)
+		}
+	}
+	select {
+	case <-recoveryStarted:
+	case <-time.After(time.Second):
+		t.Fatal("recovery did not start after grace period")
+	}
+	if recoveryCalls.Load() != 1 {
+		t.Fatalf("overlapping status polls started %d recovery scans", recoveryCalls.Load())
+	}
+	close(releaseRecovery)
+	deadline := time.Now().Add(time.Second)
+	for {
+		got := readStatus()
+		if got.Device.ConnectionState == deviceConnectionSetup {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("failed bounded recovery never required setup: %+v", got.Device)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestStatusAutoRecoveryFindsSavedDeviceIDAtChangedIP(t *testing.T) {
+	stale := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "old address", http.StatusServiceUnavailable)
+	}))
+	defer stale.Close()
+	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.44","deviceId":"vibetv-canary","networkMode":"station","capabilities":{"transport":{"active":"wifi"}}}`))
+		case "/health":
+			_, _ = w.Write([]byte(`{"ok":true,"render":{"fullCount":3,"partialCount":1,"lastKind":"usage"}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer device.Close()
+
+	server := newTestServer(t, runtimeconfig.Config{
+		DeviceTarget: stale.URL,
+		DeviceToken:  "pair-token",
+		DeviceID:     "vibetv-canary",
+	})
+	server.subnetTargets = func() []string { return []string{device.URL} }
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	server.now = func() time.Time { return now }
+	server.reconnectGraceTime = time.Second
+
+	readStatus := func() statusResponse {
+		rec := httptest.NewRecorder()
+		server.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+		var got statusResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode status: %v body=%s", err, rec.Body.String())
+		}
+		return got
+	}
+
+	_ = readStatus()
+	now = now.Add(2 * time.Second)
+	_ = readStatus()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		got := readStatus()
+		if got.Device.Target == device.URL && got.Device.Ready && got.Device.ConnectionState == deviceConnectionReady {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("saved device ID was not recovered at changed IP: %+v", got.Device)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestDeviceProbesAreSingleFlightAndCached(t *testing.T) {
+	var helloCalls atomic.Int32
+	var healthCalls atomic.Int32
+	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			helloCalls.Add(1)
+			time.Sleep(20 * time.Millisecond)
+			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"board":"esp8266-smalltv-st7789"}`))
+		case "/health":
+			healthCalls.Add(1)
+			time.Sleep(20 * time.Millisecond)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}
+	}))
+	defer device.Close()
+
+	server := newTestServer(t, runtimeconfig.Config{})
+	server.probeCacheTime = time.Second
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if _, err := server.getHelloProbe(context.Background(), device.URL, "pair-token", time.Second); err != nil {
+				t.Errorf("hello probe: %v", err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if _, err := server.getHealthProbe(context.Background(), device.URL, "pair-token", time.Second); err != nil {
+				t.Errorf("health probe: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if helloCalls.Load() != 1 || healthCalls.Load() != 1 {
+		t.Fatalf("probes were not coalesced: hello=%d health=%d", helloCalls.Load(), healthCalls.Load())
+	}
+}
+
 func TestDeviceReachableButDisplayStreamNotReadyStaysConnected(t *testing.T) {
 	device := newHelloDeviceServer(t)
 	defer device.Close()
@@ -2216,7 +2478,7 @@ func TestDeviceHealthReportsResetReason(t *testing.T) {
 			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.35","capabilities":{"transport":{"active":"wifi"}}}`))
 		case "/health":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"ok":true,"system":{"resetReason":"Exception"},"settings":{"display":{"brightnessPercent":40}}}`))
+			_, _ = w.Write([]byte(`{"ok":true,"system":{"bootId":"00abc123-7-deadbeef","uptimeMs":2500,"resetCount":7,"resetReason":"Exception"},"settings":{"display":{"brightnessPercent":40}}}`))
 		default:
 			t.Fatalf("unexpected device path %s", r.URL.Path)
 		}
@@ -2239,6 +2501,9 @@ func TestDeviceHealthReportsResetReason(t *testing.T) {
 	}
 	if got.Device.Health == nil || !got.Device.Health.OK || got.Device.Health.ResetReason != "Exception" {
 		t.Fatalf("expected reset reason in health metadata, got %+v", got.Device.Health)
+	}
+	if got.Device.Health.BootID != "00abc123-7-deadbeef" || got.Device.Health.UptimeMs != 2500 || got.Device.Health.ResetCount != 7 || got.Device.Health.LastResetAt == "" {
+		t.Fatalf("expected boot identity, uptime, counter, and reset timestamp, got %+v", got.Device.Health)
 	}
 }
 
@@ -4167,10 +4432,28 @@ func TestThemeInstallAsyncReportsCustomerProgress(t *testing.T) {
 }
 
 func TestFirmwareUpdateAsyncReportsCustomerProgress(t *testing.T) {
-	device := newThemeInstallReadyDeviceServer(t)
+	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-174","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.32","capabilities":{"transport":{"active":"wifi"}}}`))
+		case "/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			t.Fatalf("unexpected device path %s", r.URL.Path)
+		}
+	}))
 	defer device.Close()
 
-	server := newTestServer(t, runtimeconfig.Config{DeviceTarget: device.URL, DeviceToken: "pair-token"})
+	server := newTestServer(t, runtimeconfig.Config{DeviceTarget: device.URL, DeviceToken: "pair-token", DeviceID: "device-174"})
+	server.refreshStream = func(context.Context, string) error { return nil }
+	server.waitStreamAfter = func(_ context.Context, target string, _ time.Time) displayStreamInfo {
+		return displayStreamInfo{Healthy: true, Running: true, Target: target, LastTarget: target}
+	}
+	server.waitRender = func(_ context.Context, _ string, _ string, _ deviceHealth) (deviceHealth, error) {
+		return deviceHealth{OK: true}, nil
+	}
 	server.updateFirmware = func(_ context.Context, _ string, cfg runtimeconfig.Config, req firmwareUpdateRequest, out io.Writer) error {
 		if cfg.DeviceTarget != device.URL || strings.TrimSpace(cfg.DeviceToken) != "pair-token" {
 			t.Fatalf("unexpected update config: %+v", cfg)
@@ -4179,6 +4462,7 @@ func TestFirmwareUpdateAsyncReportsCustomerProgress(t *testing.T) {
 			t.Fatalf("force should default to false")
 		}
 		for _, line := range []string{
+			`CODEX_FIRMWARE_UPDATE_EVENT {"stage":"validating_artifact","phase":"installing","target":"` + device.URL + `","deviceId":"device-174","helloVerified":true}`,
 			"Checking device...",
 			"Device: esp8266-smalltv-st7789 firmware 1.0.31",
 			"Checking firmware...",
@@ -4187,6 +4471,7 @@ func TestFirmwareUpdateAsyncReportsCustomerProgress(t *testing.T) {
 			"Pausing Mac App during firmware update...",
 			"Uploading firmware...",
 			"Restarting VibeTV...",
+			`CODEX_FIRMWARE_UPDATE_EVENT {"stage":"verifying_health","phase":"installing","firmware":"1.0.32","target":"` + device.URL + `","deviceId":"device-174","artifactValidated":true,"uploadAccepted":true,"helloVerified":true}`,
 			"Done: firmware 1.0.32 installed",
 		} {
 			_, _ = io.WriteString(out, line+"\n")
@@ -4233,7 +4518,7 @@ func TestFirmwareUpdateAsyncReportsCustomerProgress(t *testing.T) {
 		t.Fatalf("expected firmware result, got %+v", got.Job.Result)
 	}
 	joinedLogs := strings.Join(got.Job.Logs, "\n")
-	for _, want := range []string{"Checking VibeTV.", "Checking update.", "Update downloaded.", "Updating VibeTV.", "Restarting VibeTV.", "Update complete."} {
+	for _, want := range []string{"Update downloaded.", "Updating VibeTV.", "Restarting VibeTV.", "Checking VibeTV health.", "Restarting display stream.", "Checking the picture.", "Update complete."} {
 		if !strings.Contains(joinedLogs, want) {
 			t.Fatalf("expected customer update log %q in %q", want, joinedLogs)
 		}
@@ -4252,7 +4537,7 @@ func TestFirmwareUpdatePausesDisplayTrafficUntilJobFinishes(t *testing.T) {
 		switch r.URL.Path {
 		case "/hello":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.36","capabilities":{"transport":{"active":"wifi"}}}`))
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-pause","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.36","capabilities":{"transport":{"active":"wifi"}}}`))
 		case "/health":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"ok":true}`))
@@ -4262,14 +4547,22 @@ func TestFirmwareUpdatePausesDisplayTrafficUntilJobFinishes(t *testing.T) {
 	}))
 	defer device.Close()
 
-	server := newTestServer(t, runtimeconfig.Config{DeviceTarget: device.URL, DeviceToken: "pair-token"})
+	server := newTestServer(t, runtimeconfig.Config{DeviceTarget: device.URL, DeviceToken: "pair-token", DeviceID: "device-pause"})
+	server.refreshStream = func(context.Context, string) error { return nil }
+	server.waitStreamAfter = func(_ context.Context, target string, _ time.Time) displayStreamInfo {
+		return displayStreamInfo{Healthy: true, Running: true, Target: target, LastTarget: target}
+	}
+	server.waitRender = func(_ context.Context, _ string, _ string, _ deviceHealth) (deviceHealth, error) {
+		return deviceHealth{OK: true}, nil
+	}
 	pauseEvents := make(chan bool, 2)
 	server.pauseDisplayStream = func(paused bool) { pauseEvents <- paused }
 	startedUpdate := make(chan struct{})
 	finishUpdate := make(chan struct{})
-	server.updateFirmware = func(context.Context, string, runtimeconfig.Config, firmwareUpdateRequest, io.Writer) error {
+	server.updateFirmware = func(_ context.Context, _ string, _ runtimeconfig.Config, _ firmwareUpdateRequest, out io.Writer) error {
 		close(startedUpdate)
 		<-finishUpdate
+		_, _ = io.WriteString(out, `CODEX_FIRMWARE_UPDATE_EVENT {"stage":"verifying_health","phase":"installing","outcome":"already_current","firmware":"1.0.36","target":"`+device.URL+`","deviceId":"device-pause","artifactValidated":true,"helloVerified":true}`+"\n")
 		return nil
 	}
 
@@ -4324,6 +4617,88 @@ func TestFirmwareUpdatePausesDisplayTrafficUntilJobFinishes(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("firmware update did not resume display stream")
+	}
+}
+
+func TestFirmwareUpdateVerifiedFirmwareOverridesTemporaryCommandError(t *testing.T) {
+	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-recovered","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.40"}`))
+		case "/health":
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			t.Fatalf("unexpected device path %s", r.URL.Path)
+		}
+	}))
+	defer device.Close()
+	server := newTestServer(t, runtimeconfig.Config{DeviceTarget: device.URL, DeviceID: "device-recovered", DeviceToken: "pair-token"})
+	server.refreshStream = func(context.Context, string) error { return nil }
+	server.waitStreamAfter = func(_ context.Context, target string, _ time.Time) displayStreamInfo {
+		return displayStreamInfo{Healthy: true, Running: true, Target: target, LastTarget: target}
+	}
+	server.waitRender = func(_ context.Context, _ string, _ string, _ deviceHealth) (deviceHealth, error) {
+		return deviceHealth{OK: true}, nil
+	}
+	server.updateFirmware = func(_ context.Context, _ string, _ runtimeconfig.Config, _ firmwareUpdateRequest, out io.Writer) error {
+		_, _ = io.WriteString(out, `CODEX_FIRMWARE_UPDATE_EVENT {"stage":"rebooting","phase":"installing","firmware":"1.0.40","target":"`+device.URL+`","deviceId":"device-recovered","artifactValidated":true,"uploadAccepted":true,"helloVerified":true}`+"\n")
+		return errors.New("temporary timeout after accepted upload")
+	}
+
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/updates/install", strings.NewReader(`{}`)))
+	var started firmwareUpdateJobResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	var job firmwareUpdateJob
+	for attempt := 0; attempt < 100; attempt++ {
+		job, _ = server.firmwareUpdateJobSnapshot(started.Job.ID)
+		if job.Phase != "installing" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if job.Phase != "complete" || job.Outcome != "updated" || job.Result == nil || !job.Result.RenderVerified {
+		t.Fatalf("verified running state must override the temporary command error: %+v", job)
+	}
+}
+
+func TestFirmwareUpdateCurrentFirmwareWithStreamFailureNeedsAttention(t *testing.T) {
+	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-attention","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.40"}`))
+		case "/health":
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			t.Fatalf("unexpected device path %s", r.URL.Path)
+		}
+	}))
+	defer device.Close()
+	server := newTestServer(t, runtimeconfig.Config{DeviceTarget: device.URL, DeviceID: "device-attention", DeviceToken: "pair-token"})
+	server.refreshStream = func(context.Context, string) error { return errors.New("stream unavailable") }
+	server.updateFirmware = func(_ context.Context, _ string, _ runtimeconfig.Config, _ firmwareUpdateRequest, out io.Writer) error {
+		_, _ = io.WriteString(out, `CODEX_FIRMWARE_UPDATE_EVENT {"stage":"verifying_health","phase":"installing","firmware":"1.0.40","target":"`+device.URL+`","deviceId":"device-attention","artifactValidated":true,"uploadAccepted":true,"helloVerified":true}`+"\n")
+		return nil
+	}
+
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/updates/install", strings.NewReader(`{}`)))
+	var started firmwareUpdateJobResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	var job firmwareUpdateJob
+	for attempt := 0; attempt < 100; attempt++ {
+		job, _ = server.firmwareUpdateJobSnapshot(started.Job.ID)
+		if job.Phase != "installing" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if job.Phase != "attention" || job.Outcome != "firmware_current_stream_attention" || job.Result == nil || !job.Result.HealthVerified || job.Result.StreamVerified {
+		t.Fatalf("current firmware with a broken stream must need attention without another flash: %+v", job)
 	}
 }
 
@@ -4807,6 +5182,7 @@ func newTestServer(t *testing.T, cfg runtimeconfig.Config) *Server {
 	if err != nil {
 		t.Fatalf("new server: %v", err)
 	}
+	server.probeCacheTime = 0
 	current := cfg
 	server.loadConfig = func(string) (runtimeconfig.Config, error) {
 		return current, nil

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -2026,6 +2026,88 @@ func TestDeviceProbesAreSingleFlightAndCached(t *testing.T) {
 	}
 }
 
+func TestDeviceProbeFlightsOutliveTheFirstRequestCancellation(t *testing.T) {
+	t.Run("hello", func(t *testing.T) {
+		var calls atomic.Int32
+		started := make(chan struct{})
+		release := make(chan struct{})
+		device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			close(started)
+			<-release
+			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"board":"esp8266-smalltv-st7789"}`))
+		}))
+		defer device.Close()
+
+		server := newTestServer(t, runtimeconfig.Config{})
+		server.probeCacheTime = time.Second
+		firstContext, cancelFirst := context.WithCancel(context.Background())
+		firstResult := make(chan error, 1)
+		go func() {
+			_, err := server.getHelloProbe(firstContext, device.URL, "pair-token", time.Second)
+			firstResult <- err
+		}()
+		<-started
+		cancelFirst()
+		if err := <-firstResult; !errors.Is(err, context.Canceled) {
+			t.Fatalf("first request should observe its own cancellation, got %v", err)
+		}
+
+		secondResult := make(chan error, 1)
+		go func() {
+			_, err := server.getHelloProbe(context.Background(), device.URL, "pair-token", time.Second)
+			secondResult <- err
+		}()
+		close(release)
+		if err := <-secondResult; err != nil {
+			t.Fatalf("shared hello probe was poisoned by the first cancellation: %v", err)
+		}
+		if calls.Load() != 1 {
+			t.Fatalf("expected one detached hello probe, got %d", calls.Load())
+		}
+	})
+
+	t.Run("health", func(t *testing.T) {
+		var calls atomic.Int32
+		started := make(chan struct{})
+		release := make(chan struct{})
+		device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			close(started)
+			<-release
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		defer device.Close()
+
+		server := newTestServer(t, runtimeconfig.Config{})
+		server.probeCacheTime = time.Second
+		firstContext, cancelFirst := context.WithCancel(context.Background())
+		firstResult := make(chan error, 1)
+		go func() {
+			_, err := server.getHealthProbe(firstContext, device.URL, "pair-token", time.Second)
+			firstResult <- err
+		}()
+		<-started
+		cancelFirst()
+		if err := <-firstResult; !errors.Is(err, context.Canceled) {
+			t.Fatalf("first request should observe its own cancellation, got %v", err)
+		}
+
+		secondResult := make(chan error, 1)
+		go func() {
+			_, err := server.getHealthProbe(context.Background(), device.URL, "pair-token", time.Second)
+			secondResult <- err
+		}()
+		close(release)
+		if err := <-secondResult; err != nil {
+			t.Fatalf("shared health probe was poisoned by the first cancellation: %v", err)
+		}
+		if calls.Load() != 1 {
+			t.Fatalf("expected one detached health probe, got %d", calls.Load())
+		}
+	})
+}
+
 func TestDeviceReachableButDisplayStreamNotReadyStaysConnected(t *testing.T) {
 	device := newHelloDeviceServer(t)
 	defer device.Close()

--- a/companion/internal/firmwareupdate/event.go
+++ b/companion/internal/firmwareupdate/event.go
@@ -1,0 +1,15 @@
+package firmwareupdate
+
+const EventPrefix = "CODEX_FIRMWARE_UPDATE_EVENT "
+
+type Event struct {
+	Stage             string `json:"stage"`
+	Phase             string `json:"phase,omitempty"`
+	Outcome           string `json:"outcome,omitempty"`
+	Firmware          string `json:"firmware,omitempty"`
+	Target            string `json:"target,omitempty"`
+	DeviceID          string `json:"deviceId,omitempty"`
+	ArtifactValidated bool   `json:"artifactValidated,omitempty"`
+	UploadAccepted    bool   `json:"uploadAccepted,omitempty"`
+	HelloVerified     bool   `json:"helloVerified,omitempty"`
+}

--- a/companion/internal/transport/wifi_discovery.go
+++ b/companion/internal/transport/wifi_discovery.go
@@ -28,6 +28,7 @@ type WiFiDiscoveryOptions struct {
 	IncludeNetworkScan bool
 	Timeout            time.Duration
 	Client             *http.Client
+	ExpectedDeviceID   string
 }
 
 type WiFiDiscoveryResult struct {
@@ -57,6 +58,10 @@ func DiscoverWiFiDevice(ctx context.Context, opts WiFiDiscoveryOptions) (WiFiDis
 	for _, candidate := range candidates {
 		hello, err := probeWiFiHello(ctx, client, candidate)
 		if err == nil {
+			if !matchesExpectedDeviceID(hello, opts.ExpectedDeviceID) {
+				lastErr = fmt.Errorf("VibeTV device id mismatch: expected=%q got=%q", strings.TrimSpace(opts.ExpectedDeviceID), hello.DeviceID)
+				continue
+			}
 			return WiFiDiscoveryResult{Target: publicDiscoveryTarget(candidate), Hello: hello, Source: "candidate"}, nil
 		}
 		lastErr = err
@@ -88,7 +93,7 @@ func DiscoverWiFiDevice(ctx context.Context, opts WiFiDiscoveryOptions) (WiFiDis
 		filtered = append(filtered, target)
 	}
 
-	result, err := scanWiFiTargets(ctx, client, filtered)
+	result, err := scanWiFiTargets(ctx, client, filtered, opts.ExpectedDeviceID)
 	if err == nil {
 		return result, nil
 	}
@@ -98,7 +103,7 @@ func DiscoverWiFiDevice(ctx context.Context, opts WiFiDiscoveryOptions) (WiFiDis
 	return WiFiDiscoveryResult{}, err
 }
 
-func scanWiFiTargets(ctx context.Context, client *http.Client, targets []string) (WiFiDiscoveryResult, error) {
+func scanWiFiTargets(ctx context.Context, client *http.Client, targets []string, expectedDeviceID string) (WiFiDiscoveryResult, error) {
 	if len(targets) == 0 {
 		return WiFiDiscoveryResult{}, errors.New("no scan targets")
 	}
@@ -123,6 +128,9 @@ func scanWiFiTargets(ctx context.Context, client *http.Client, targets []string)
 				}
 				hello, err := probeWiFiHello(ctx, client, target)
 				if err != nil {
+					continue
+				}
+				if !matchesExpectedDeviceID(hello, expectedDeviceID) {
 					continue
 				}
 				select {
@@ -160,6 +168,14 @@ func scanWiFiTargets(ctx context.Context, client *http.Client, targets []string)
 	case <-ctx.Done():
 		return WiFiDiscoveryResult{}, ctx.Err()
 	}
+}
+
+func matchesExpectedDeviceID(hello protocol.DeviceHello, expected string) bool {
+	expected = strings.TrimSpace(expected)
+	if expected == "" {
+		return true
+	}
+	return strings.EqualFold(expected, strings.TrimSpace(hello.DeviceID))
 }
 
 func probeWiFiHello(ctx context.Context, client *http.Client, target string) (protocol.DeviceHello, error) {

--- a/companion/internal/transport/wifi_discovery_test.go
+++ b/companion/internal/transport/wifi_discovery_test.go
@@ -52,6 +52,32 @@ func TestDiscoverWiFiDeviceRejectsNonVibeHello(t *testing.T) {
 	}
 }
 
+func TestDiscoverWiFiDeviceRequiresExpectedDeviceID(t *testing.T) {
+	device := func(id string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"` + id + `","protocolVersion":2,"board":"esp8266-smalltv-st7789","capabilities":{"transport":{"active":"wifi"}}}`))
+		}))
+	}
+	wrong := device("wrong-device")
+	defer wrong.Close()
+	expected := device("expected-device")
+	defer expected.Close()
+
+	result, err := DiscoverWiFiDevice(context.Background(), WiFiDiscoveryOptions{
+		Candidates:       []string{wrong.URL, expected.URL},
+		Client:           expected.Client(),
+		Timeout:          time.Second,
+		ExpectedDeviceID: "EXPECTED-device",
+	})
+	if err != nil {
+		t.Fatalf("DiscoverWiFiDevice returned error: %v", err)
+	}
+	if result.Target != expected.URL || result.Hello.DeviceID != "expected-device" {
+		t.Fatalf("discovery accepted the wrong VibeTV identity: %+v", result)
+	}
+}
+
 func TestLocalIPv4DiscoveryTargetsFromAddrsScansHostSubnet(t *testing.T) {
 	_, ipNet, err := net.ParseCIDR("192.168.178.42/24")
 	if err != nil {

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -40,6 +40,7 @@ constexpr int kMaxFrameBytes = 2048;
 constexpr uint16_t kDnsPort = 53;
 constexpr uint32_t kWifiCredsMagic = 0x56544231UL;  // VTB1
 constexpr uint32_t kBootRecoveryMagic = 0x56544252UL;  // VTBR
+constexpr uint32_t kBootDiagnosticsMagic = 0x56544244UL;  // VTBD
 constexpr size_t kWifiSsidBytes = 33;
 constexpr size_t kWifiPasswordBytes = 65;
 constexpr size_t kWifiCredsBytes = 4 + kWifiSsidBytes + kWifiPasswordBytes;
@@ -47,7 +48,10 @@ constexpr size_t kBootRecoveryOffset = kWifiCredsBytes;
 constexpr size_t kBootRecoveryBytes = 6;
 constexpr size_t kBootRecoveryCounterOffset = kBootRecoveryOffset + 4;
 constexpr size_t kBootRecoveryUploadOffset = kBootRecoveryOffset + 5;
-constexpr size_t kEepromBytes = kWifiCredsBytes + kBootRecoveryBytes;
+constexpr size_t kBootDiagnosticsOffset = kBootRecoveryOffset + kBootRecoveryBytes;
+constexpr size_t kBootDiagnosticsBytes = 8;
+constexpr size_t kBootResetCounterOffset = kBootDiagnosticsOffset + 4;
+constexpr size_t kEepromBytes = kWifiCredsBytes + kBootRecoveryBytes + kBootDiagnosticsBytes;
 constexpr unsigned long kWifiConnectTimeoutMs = 20000UL;
 constexpr unsigned long kWifiReconnectRetryMs = 5000UL;
 constexpr unsigned long kWifiReconnectFallbackMs = 120000UL;
@@ -191,7 +195,9 @@ OtaUploadDiagnostics otaDiagnostics;
 RuntimeRenderDiagnostics renderDiagnostics;
 DeviceSettings deviceSettings;
 String deviceAuthToken;
+String bootID;
 String bootResetReasonJSON;
+uint32_t bootResetCounter = 0;
 
 void addCorsHeaders();
 
@@ -908,6 +914,23 @@ void clearBootRecoveryCounter() {
   Serial.println("boot_recovery_counter_cleared");
 }
 
+uint32_t incrementBootResetCounter() {
+  EEPROM.begin(kEepromBytes);
+  uint32_t magic = 0;
+  uint32_t counter = 0;
+  EEPROM.get(kBootDiagnosticsOffset, magic);
+  if (magic == kBootDiagnosticsMagic) {
+    EEPROM.get(kBootResetCounterOffset, counter);
+  }
+  if (counter < 0xFFFFFFFFUL) {
+    ++counter;
+  }
+  EEPROM.put(kBootDiagnosticsOffset, kBootDiagnosticsMagic);
+  EEPROM.put(kBootResetCounterOffset, counter);
+  EEPROM.commit();
+  return counter;
+}
+
 bool consumeBootRecoveryTrigger() {
   if (readBootRecoveryUploadActive()) {
     clearBootRecoveryCounter();
@@ -1336,7 +1359,7 @@ void handleHealth() {
   const codexbar_display::esp8266::RendererHealthSnapshot snapshot = renderer.HealthSnapshot();
 
   String out;
-  out.reserve(768);
+  out.reserve(896);
   out += "{\"ok\":true,\"firmware\":\"";
   out += jsonEscape(CODEXBAR_DISPLAY_FW_VERSION);
   out += "\",\"system\":{\"freeHeap\":";
@@ -1345,6 +1368,12 @@ void handleHealth() {
   out += String(ESP.getMaxFreeBlockSize());
   out += ",\"heapFragmentationPercent\":";
   out += String(ESP.getHeapFragmentation());
+  out += ",\"bootId\":\"";
+  out += jsonEscape(bootID);
+  out += "\",\"uptimeMs\":";
+  out += String(millis());
+  out += ",\"resetCount\":";
+  out += String(bootResetCounter);
   out += ",\"resetReason\":";
   out += bootResetReasonJSON;
   out += "},";
@@ -2567,6 +2596,12 @@ void setup() {
   bootResetReasonJSON = "\"";
   bootResetReasonJSON += jsonEscape(ESP.getResetReason());
   bootResetReasonJSON += "\"";
+  bootResetCounter = incrementBootResetCounter();
+  bootID = String(ESP.getChipId(), HEX);
+  bootID += "-";
+  bootID += String(bootResetCounter);
+  bootID += "-";
+  bootID += String(ESP.getCycleCount(), HEX);
   renderer.Setup(runtimeCtx);
   loadDeviceSettings();
   loadDeviceAuthToken();

--- a/macos/VibeTVControlCenter/SparklePublicKey.txt
+++ b/macos/VibeTVControlCenter/SparklePublicKey.txt
@@ -1,0 +1,1 @@
+2txeIAd+ofTbffzPR5hy5J4lvGX8LGclIdG82es1qPA=

--- a/macos/VibeTVControlCenter/URLSchemeTests.swift
+++ b/macos/VibeTVControlCenter/URLSchemeTests.swift
@@ -161,6 +161,40 @@ func runURLSchemeTests() {
         ) == "VibeTVControlCenter/99.0.16+163",
         "native WebView must identify itself without exposing the browser UI"
     )
+    let pendingCreatedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let pendingUpdate = PendingNativeUpdate(
+        version: "1.2.4",
+        build: "201",
+        createdAt: pendingCreatedAt
+    )
+    require(
+        pendingNativeUpdateMatchesBundle(
+            pendingUpdate,
+            shortVersion: "1.2.4",
+            buildVersion: "201"
+        ),
+        "a relaunched updated bundle must satisfy its pending marker"
+    )
+    require(
+        pendingNativeUpdateBlocksBundle(
+            pendingUpdate,
+            shortVersion: "1.2.3",
+            buildVersion: "200",
+            now: pendingCreatedAt.addingTimeInterval(60),
+            maximumAge: 1_800
+        ),
+        "a fresh pending marker must block an unverified old bundle"
+    )
+    require(
+        !pendingNativeUpdateBlocksBundle(
+            pendingUpdate,
+            shortVersion: "1.2.3",
+            buildVersion: "200",
+            now: pendingCreatedAt.addingTimeInterval(1_801),
+            maximumAge: 1_800
+        ),
+        "an abandoned pending marker must expire instead of permanently locking the old app"
+    )
     let localNetworkProbe = makeLocalNetworkPrivacyProbeRequest(timeout: 12)
     require(
         localNetworkProbe?.url?.absoluteString == "http://192.168.4.1/hello",

--- a/macos/VibeTVControlCenter/URLSchemeTests.swift
+++ b/macos/VibeTVControlCenter/URLSchemeTests.swift
@@ -14,8 +14,8 @@ func runURLSchemeTests() {
         "healthy native runtime must refresh the WebView"
     )
     require(
-        RuntimePreparationOutcome.legacyRuntimeRestored.shouldReloadControlCenter,
-        "successful rollback must refresh the WebView to the restored runtime"
+        !RuntimePreparationOutcome.legacyRuntimeRestored.shouldReloadControlCenter,
+        "a restored legacy runtime must keep the WebView closed until native installation succeeds"
     )
     require(
         !RuntimePreparationOutcome.keepCurrentPage.shouldReloadControlCenter,
@@ -53,6 +53,21 @@ func runURLSchemeTests() {
         !isOpenControlCenterURL(URL(string: "https://open-control-center")!),
         "non-VibeTV schemes must be rejected"
     )
+    require(
+        isCheckForUpdatesURL(URL(string: "vibetv://check-for-updates")!),
+        "the exact native Sparkle action must be accepted"
+    )
+    for rejectedUpdateURL in [
+        "vibetv://check-for-updates/extra",
+        "vibetv://check-for-updates?channel=beta",
+        "https://check-for-updates",
+        "vibetv://install-update",
+    ] {
+        require(
+            !isCheckForUpdatesURL(URL(string: rejectedUpdateURL)!),
+            "unexpected update action must be rejected: \(rejectedUpdateURL)"
+        )
+    }
     require(
         isApprovedDMGDownloadURL(
             URL(
@@ -238,6 +253,48 @@ func runURLSchemeTests() {
         ) == .versionMismatch(expected: "1.2.4", actual: "1.2.3"),
         "wrong Companion version must fail the health gate"
     )
+    let nativeStatus = Data(
+        #"{"ok":true,"companion":{"version":"1.2.3","app":{"version":"2.0.0","build":"200","path":"/Applications/VibeTV Control Center.app","installedInApplications":true},"runtime":{"version":"1.2.3","listenerOwner":"shop.vibetv.control-center.runtime"}}}"#.utf8
+    )
+    require(
+        evaluateRuntimeHealth(
+            data: nativeStatus,
+            httpStatus: 200,
+            expectedVersion: "1.2.3",
+            expectedAppVersion: "2.0.0",
+            expectedBuild: "200",
+            expectedAppPath: "/Applications/VibeTV Control Center.app",
+            expectedRuntimeOwner: "shop.vibetv.control-center.runtime"
+        ) == .healthy(version: "1.2.3"),
+        "native health must verify app, runtime, and listener independently"
+    )
+    require(
+        evaluateRuntimeHealth(
+            data: nativeStatus,
+            httpStatus: 200,
+            expectedVersion: "1.2.3",
+            expectedAppVersion: "2.0.0",
+            expectedBuild: "201",
+            expectedAppPath: "/Applications/VibeTV Control Center.app",
+            expectedRuntimeOwner: "shop.vibetv.control-center.runtime"
+        ) == .appBuildMismatch(expected: "201", actual: "200"),
+        "a stale app build must fail the native health gate"
+    )
+    require(
+        evaluateRuntimeHealth(
+            data: nativeStatus,
+            httpStatus: 200,
+            expectedVersion: "1.2.3",
+            expectedAppVersion: "2.0.0",
+            expectedBuild: "200",
+            expectedAppPath: "/Applications/VibeTV Control Center.app",
+            expectedRuntimeOwner: "unexpected.owner"
+        ) == .runtimeOwnerMismatch(
+            expected: "unexpected.owner",
+            actual: "shop.vibetv.control-center.runtime"
+        ),
+        "the wrong listener owner must fail the native health gate"
+    )
     require(
         evaluateRuntimeHealth(
             data: healthyStatus,
@@ -293,6 +350,15 @@ func runURLSchemeTests() {
             httpStatus: 200
         ) == .needsRepair,
         "a preserved target without a fresh frame must be repaired automatically"
+    )
+    require(
+        evaluateExistingDeviceStatus(
+            data: Data(
+                #"{"ok":true,"companion":{"version":"1.2.3"},"device":{"target":"http://192.168.178.72","paired":true,"ready":false,"connectionState":"reconnecting"}}"#.utf8
+            ),
+            httpStatus: 200
+        ) == .ready,
+        "a configured VibeTV in its reconnect grace period must not restart setup"
     )
     require(
         evaluateExistingDeviceStatus(

--- a/macos/VibeTVControlCenter/main.swift
+++ b/macos/VibeTVControlCenter/main.swift
@@ -20,6 +20,7 @@ private let runtimeLaunchAgentPlistName = "shop.vibetv.control-center.runtime.pl
 private let runtimeRegisteredVersionDefaultsKey =
     "shop.vibetv.control-center.runtime.registered-bundle-version"
 private let pendingNativeUpdateFileName = "pending-native-update.json"
+private let pendingNativeUpdateMaximumAge: TimeInterval = 30 * 60
 private let runtimeHealthTimeout: TimeInterval = 35
 private let runtimeHealthRequestTimeout: TimeInterval = 5
 private let runtimeDeviceRepairTimeout: TimeInterval = 90
@@ -797,6 +798,32 @@ func pendingNativeUpdateMatchesBundle(
         == (buildVersion ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
+func pendingNativeUpdateIsExpired(
+    _ pending: PendingNativeUpdate,
+    now: Date = Date(),
+    maximumAge: TimeInterval = pendingNativeUpdateMaximumAge
+) -> Bool {
+    maximumAge >= 0 && now.timeIntervalSince(pending.createdAt) > maximumAge
+}
+
+func pendingNativeUpdateBlocksBundle(
+    _ pending: PendingNativeUpdate,
+    shortVersion: String?,
+    buildVersion: String?,
+    now: Date = Date(),
+    maximumAge: TimeInterval = pendingNativeUpdateMaximumAge
+) -> Bool {
+    !pendingNativeUpdateMatchesBundle(
+        pending,
+        shortVersion: shortVersion,
+        buildVersion: buildVersion
+    ) && !pendingNativeUpdateIsExpired(
+        pending,
+        now: now,
+        maximumAge: maximumAge
+    )
+}
+
 enum RuntimePreparationOutcome: Equatable {
     case nativeRuntimeReady
     case legacyRuntimeRestored
@@ -837,13 +864,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
         configureMenu()
-#if canImport(Sparkle)
-        _ = updaterController
-#endif
         guard !installationRequired else {
             presentInstallationRequiredAlert()
             return
         }
+#if canImport(Sparkle)
+        _ = updaterController
+#endif
         presentInstallationStatus(
             title: "Finishing installation…",
             detail: "Checking the Mac App and its background runtime.",
@@ -919,6 +946,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
     }
 
     @objc private func retryRuntimePreparation() {
+        discardMismatchedPendingNativeUpdate()
         startRuntimePreparation()
     }
 
@@ -971,6 +999,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
     }
 
     @objc private func checkForUpdates() {
+        guard !installationRequired else {
+            presentInstallationRequiredAlert()
+            return
+        }
 #if canImport(Sparkle)
         updaterController.checkForUpdates(nil)
 #else
@@ -1159,20 +1191,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
             )
             return .keepCurrentPage
         }
-        if let pending = loadPendingNativeUpdate(),
-           !pendingNativeUpdateMatchesBundle(
-               pending,
-               shortVersion: Bundle.main.object(
-                   forInfoDictionaryKey: "CFBundleShortVersionString"
-               ) as? String,
-               buildVersion: Bundle.main.object(
-                   forInfoDictionaryKey: "CFBundleVersion"
-               ) as? String
-           ) {
-            NSLog(
-                "VibeTV Control Center pending update mismatch expected=\(pending.version)+\(pending.build)"
-            )
-            return .keepCurrentPage
+        if let pending = loadPendingNativeUpdate() {
+            let shortVersion = Bundle.main.object(
+                forInfoDictionaryKey: "CFBundleShortVersionString"
+            ) as? String
+            let buildVersion = Bundle.main.object(
+                forInfoDictionaryKey: "CFBundleVersion"
+            ) as? String
+            if pendingNativeUpdateBlocksBundle(
+                pending,
+                shortVersion: shortVersion,
+                buildVersion: buildVersion
+            ) {
+                NSLog(
+                    "VibeTV Control Center pending update mismatch expected=\(pending.version)+\(pending.build); Try again can discard the failed handoff"
+                )
+                return .keepCurrentPage
+            }
+            if !pendingNativeUpdateMatchesBundle(
+                pending,
+                shortVersion: shortVersion,
+                buildVersion: buildVersion
+            ) {
+                NSLog(
+                    "VibeTV Control Center discarded expired pending update expected=\(pending.version)+\(pending.build)"
+                )
+                clearPendingNativeUpdate()
+            }
         }
         guard bundledRuntimeResourcesAreValid() else {
             NSLog("VibeTV Control Center app-managed runtime resources are missing")
@@ -2101,6 +2146,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
         } catch {
             NSLog("VibeTV Control Center could not clear pending update verification: \(error)")
         }
+    }
+
+    private func discardMismatchedPendingNativeUpdate() {
+        guard let pending = loadPendingNativeUpdate(),
+              !pendingNativeUpdateMatchesBundle(
+                  pending,
+                  shortVersion: Bundle.main.object(
+                      forInfoDictionaryKey: "CFBundleShortVersionString"
+                  ) as? String,
+                  buildVersion: Bundle.main.object(
+                      forInfoDictionaryKey: "CFBundleVersion"
+                  ) as? String
+              ) else {
+            return
+        }
+        NSLog(
+            "VibeTV Control Center user discarded failed pending update expected=\(pending.version)+\(pending.build)"
+        )
+        clearPendingNativeUpdate()
     }
 
 #if canImport(Sparkle)

--- a/macos/VibeTVControlCenter/main.swift
+++ b/macos/VibeTVControlCenter/main.swift
@@ -2,6 +2,9 @@ import Cocoa
 import Foundation
 import ServiceManagement
 import WebKit
+#if canImport(Sparkle)
+import Sparkle
+#endif
 
 private let controlCenterURLString = "http://127.0.0.1:47832/control-center"
 private let runtimeHealthURLString = "http://127.0.0.1:47832/v1/runtime-health"
@@ -10,11 +13,13 @@ private let runtimeDeviceRepairURLString = "http://127.0.0.1:47832/v1/device/rep
 private let nativeControlCenterUserAgentPrefix = "VibeTVControlCenter/"
 private let controlCenterURLScheme = "vibetv"
 private let controlCenterURLHost = "open-control-center"
+private let checkForUpdatesURLHost = "check-for-updates"
 private let controlCenterBundleIdentifier = "shop.vibetv.control-center"
 private let runtimeLaunchAgentLabel = "shop.vibetv.control-center.runtime"
 private let runtimeLaunchAgentPlistName = "shop.vibetv.control-center.runtime.plist"
 private let runtimeRegisteredVersionDefaultsKey =
     "shop.vibetv.control-center.runtime.registered-bundle-version"
+private let pendingNativeUpdateFileName = "pending-native-update.json"
 private let runtimeHealthTimeout: TimeInterval = 35
 private let runtimeHealthRequestTimeout: TimeInterval = 5
 private let runtimeDeviceRepairTimeout: TimeInterval = 90
@@ -36,6 +41,21 @@ func isOpenControlCenterURL(_ url: URL) -> Bool {
     guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
           components.scheme?.lowercased() == controlCenterURLScheme,
           components.host?.lowercased() == controlCenterURLHost,
+          components.user == nil,
+          components.password == nil,
+          components.port == nil,
+          components.query == nil,
+          components.fragment == nil,
+          components.path.isEmpty || components.path == "/" else {
+        return false
+    }
+    return true
+}
+
+func isCheckForUpdatesURL(_ url: URL) -> Bool {
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+          components.scheme?.lowercased() == controlCenterURLScheme,
+          components.host?.lowercased() == checkForUpdatesURLHost,
           components.user == nil,
           components.password == nil,
           components.port == nil,
@@ -265,12 +285,29 @@ private func runRuntimeValidationUnregister() async -> Int32 {
 private struct RuntimeStatusPayload: Decodable {
     struct Companion: Decodable {
         let version: String
+        let app: App?
+        let runtime: Runtime?
+
+        struct App: Decodable {
+            let version: String?
+            let build: String?
+            let path: String?
+            let installedInApplications: Bool?
+        }
+
+        struct Runtime: Decodable {
+            let version: String?
+            let commit: String?
+            let pid: Int32?
+            let listenerOwner: String?
+        }
     }
 
     struct Device: Decodable {
         let target: String?
         let paired: Bool?
         let ready: Bool
+        let connectionState: String?
     }
 
     let ok: Bool
@@ -339,7 +376,10 @@ func evaluateExistingDeviceStatus(
     guard !target.isEmpty else {
         return .notConfigured
     }
-    return payload.device?.ready == true ? .ready : .needsRepair
+    if payload.device?.ready == true || payload.device?.connectionState == "reconnecting" {
+        return .ready
+    }
+    return .needsRepair
 }
 
 func evaluateExistingDeviceRepair(
@@ -396,6 +436,10 @@ enum RuntimeHealthEvaluation: Equatable, CustomStringConvertible {
     case reportedUnhealthy
     case expectedVersionMissing
     case versionMismatch(expected: String, actual: String)
+    case appMetadataMissing
+    case appBuildMismatch(expected: String, actual: String)
+    case appPathMismatch(expected: String, actual: String)
+    case runtimeOwnerMismatch(expected: String, actual: String)
     case ownershipFailed(RuntimeOwnershipEvaluation)
     case requestFailed(String)
 
@@ -413,6 +457,14 @@ enum RuntimeHealthEvaluation: Equatable, CustomStringConvertible {
             return "expected bundled Companion version is missing"
         case .versionMismatch(let expected, let actual):
             return "version mismatch expected=\(expected) actual=\(actual)"
+        case .appMetadataMissing:
+            return "native app metadata is missing"
+        case .appBuildMismatch(let expected, let actual):
+            return "app build mismatch expected=\(expected) actual=\(actual)"
+        case .appPathMismatch(let expected, let actual):
+            return "app path mismatch expected=\(expected) actual=\(actual)"
+        case .runtimeOwnerMismatch(let expected, let actual):
+            return "runtime owner mismatch expected=\(expected) actual=\(actual)"
         case .ownershipFailed(let ownership):
             return "listener ownership failed: \(ownership)"
         case .requestFailed(let detail):
@@ -503,7 +555,11 @@ func evaluateRuntimeOwnership(
 func evaluateRuntimeHealth(
     data: Data,
     httpStatus: Int,
-    expectedVersion: String
+    expectedVersion: String,
+    expectedAppVersion: String? = nil,
+    expectedBuild: String? = nil,
+    expectedAppPath: String? = nil,
+    expectedRuntimeOwner: String? = nil
 ) -> RuntimeHealthEvaluation {
     guard (200..<300).contains(httpStatus) else {
         return .httpStatus(httpStatus)
@@ -522,6 +578,53 @@ func evaluateRuntimeHealth(
     let actual = normalizedCompanionVersion(payload.companion.version)
     guard actual == expected else {
         return .versionMismatch(expected: expected, actual: actual)
+    }
+
+    let requiresNativeMetadata = expectedBuild != nil
+        || expectedAppPath != nil
+        || expectedRuntimeOwner != nil
+    if requiresNativeMetadata {
+        guard let app = payload.companion.app,
+              let runtime = payload.companion.runtime,
+              app.installedInApplications == true else {
+            return .appMetadataMissing
+        }
+        let expectedNativeAppVersion = normalizedCompanionVersion(
+            expectedAppVersion ?? expectedVersion
+        )
+        let appVersion = normalizedCompanionVersion(app.version ?? "")
+        guard appVersion == expectedNativeAppVersion else {
+            return .versionMismatch(expected: expectedNativeAppVersion, actual: appVersion)
+        }
+        if let expectedBuild {
+            let actualBuild = app.build?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard actualBuild == expectedBuild.trimmingCharacters(in: .whitespacesAndNewlines) else {
+                return .appBuildMismatch(expected: expectedBuild, actual: actualBuild)
+            }
+        }
+        if let expectedAppPath {
+            let expectedPath = URL(fileURLWithPath: expectedAppPath)
+                .standardizedFileURL.resolvingSymlinksInPath().path
+            let actualPath = URL(fileURLWithPath: app.path ?? "")
+                .standardizedFileURL.resolvingSymlinksInPath().path
+            guard actualPath == expectedPath else {
+                return .appPathMismatch(expected: expectedPath, actual: actualPath)
+            }
+        }
+        let runtimeVersion = normalizedCompanionVersion(runtime.version ?? "")
+        guard runtimeVersion == expected else {
+            return .versionMismatch(expected: expected, actual: runtimeVersion)
+        }
+        if let expectedRuntimeOwner {
+            let actualOwner = runtime.listenerOwner?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard actualOwner == expectedRuntimeOwner else {
+                return .runtimeOwnerMismatch(
+                    expected: expectedRuntimeOwner,
+                    actual: actualOwner
+                )
+            }
+        }
     }
     return .healthy(version: actual)
 }
@@ -548,7 +651,11 @@ func shouldRetryRuntimeRegistration(
          .invalidPayload,
          .reportedUnhealthy,
          .expectedVersionMissing,
-         .versionMismatch:
+         .versionMismatch,
+         .appMetadataMissing,
+         .appBuildMismatch,
+         .appPathMismatch,
+         .runtimeOwnerMismatch:
         return false
     }
 }
@@ -673,13 +780,30 @@ private struct ProcessOutput {
     let output: String
 }
 
+struct PendingNativeUpdate: Codable, Equatable {
+    let version: String
+    let build: String
+    let createdAt: Date
+}
+
+func pendingNativeUpdateMatchesBundle(
+    _ pending: PendingNativeUpdate,
+    shortVersion: String?,
+    buildVersion: String?
+) -> Bool {
+    normalizedCompanionVersion(pending.version)
+        == normalizedCompanionVersion(shortVersion ?? "")
+        && pending.build.trimmingCharacters(in: .whitespacesAndNewlines)
+        == (buildVersion ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
 enum RuntimePreparationOutcome: Equatable {
     case nativeRuntimeReady
     case legacyRuntimeRestored
     case keepCurrentPage
 
     var shouldReloadControlCenter: Bool {
-        self == .nativeRuntimeReady || self == .legacyRuntimeRestored
+        self == .nativeRuntimeReady
     }
 }
 
@@ -697,6 +821,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
     private var urlRouter = ControlCenterURLRouter()
     private var reloadAttempts = 0
     private var scheduledReload: Task<Void, Never>?
+    private var preparationTask: Task<Void, Never>?
+    private var installationReady = false
+#if canImport(Sparkle)
+    private lazy var updaterController = SPUStandardUpdaterController(
+        startingUpdater: true,
+        updaterDelegate: self,
+        userDriverDelegate: nil
+    )
+#endif
     private var installationRequired: Bool {
         requiresApplicationInstallation(Bundle.main.bundleURL)
     }
@@ -704,26 +837,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
         configureMenu()
+#if canImport(Sparkle)
+        _ = updaterController
+#endif
         guard !installationRequired else {
             presentInstallationRequiredAlert()
             return
         }
-        Task { [weak self] in
-            guard let self else {
-                return
-            }
-            await self.performLocalNetworkPrivacyPreflight()
-            let outcome = await self.prepareCompanion()
-            if outcome.shouldReloadControlCenter {
-                self.reloadControlCenter()
-            }
-        }
-        _ = urlRouter.markReady()
-        presentControlCenter()
+        presentInstallationStatus(
+            title: "Finishing installation…",
+            detail: "Checking the Mac App and its background runtime.",
+            failed: false
+        )
+        startRuntimePreparation()
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {
         guard !installationRequired else {
+            return
+        }
+        if urls.contains(where: isCheckForUpdatesURL) {
+            checkForUpdates()
             return
         }
         if urlRouter.receive(urls) {
@@ -738,8 +872,62 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
         guard !installationRequired else {
             return false
         }
-        presentControlCenter()
+        if installationReady {
+            presentControlCenter()
+        } else {
+            window?.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+        }
         return true
+    }
+
+    private func startRuntimePreparation() {
+        guard preparationTask == nil else {
+            return
+        }
+        presentInstallationStatus(
+            title: "Finishing installation…",
+            detail: "Checking the Mac App and its background runtime.",
+            failed: false
+        )
+        preparationTask = Task { [weak self] in
+            guard let self else {
+                return
+            }
+            await self.performLocalNetworkPrivacyPreflight()
+            let outcome = await self.prepareCompanion()
+            self.preparationTask = nil
+            switch outcome {
+            case .nativeRuntimeReady:
+                self.installationReady = true
+                _ = self.urlRouter.markReady()
+                self.presentControlCenter()
+            case .legacyRuntimeRestored:
+                self.presentInstallationStatus(
+                    title: "Installation needs attention",
+                    detail: "The previous VibeTV service was restored. Try again or open the support log.",
+                    failed: true
+                )
+            case .keepCurrentPage:
+                self.presentInstallationStatus(
+                    title: "Installation could not be verified",
+                    detail: "The Mac App, runtime, and local listener did not reach one verified state.",
+                    failed: true
+                )
+            }
+        }
+    }
+
+    @objc private func retryRuntimePreparation() {
+        startRuntimePreparation()
+    }
+
+    @objc private func openSupportLog() {
+        let logURL = applicationSupportURL()
+            .appendingPathComponent("logs", isDirectory: true)
+        if !NSWorkspace.shared.open(logURL) {
+            _ = NSWorkspace.shared.open(applicationSupportURL())
+        }
     }
 
     @objc private func reloadControlCenter() {
@@ -761,6 +949,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
                 keyEquivalent: "r"
             )
         )
+        appMenu.addItem(
+            NSMenuItem(
+                title: "Check for Updates…",
+                action: #selector(checkForUpdates),
+                keyEquivalent: ""
+            )
+        )
         appMenu.addItem(NSMenuItem.separator())
         appMenu.addItem(
             NSMenuItem(
@@ -775,11 +970,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
         NSApp.mainMenu = mainMenu
     }
 
+    @objc private func checkForUpdates() {
+#if canImport(Sparkle)
+        updaterController.checkForUpdates(nil)
+#else
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Native updater is unavailable"
+        alert.informativeText = "Install the latest signed VibeTV Control Center from app.vibetv.shop."
+        alert.runModal()
+#endif
+    }
+
     private func presentControlCenter() {
-        guard !installationRequired else {
+        guard !installationRequired, installationReady else {
             return
         }
-        if window == nil {
+        if webView == nil {
             createWindow()
         }
         window?.makeKeyAndOrderFront(nil)
@@ -822,6 +1029,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
         )
         webView.navigationDelegate = self
 
+        let window = window ?? makeMainWindow()
+        window.title = "VibeTV Control Center"
+        window.contentView = webView
+
+        self.window = window
+        self.webView = webView
+        loadControlCenter()
+    }
+
+    private func makeMainWindow() -> NSWindow {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1180, height: 820),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
@@ -830,12 +1047,94 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
         )
         window.title = "VibeTV Control Center"
         window.center()
-        window.contentView = webView
         window.isReleasedWhenClosed = false
+        return window
+    }
 
+    private func presentInstallationStatus(
+        title: String,
+        detail: String,
+        failed: Bool
+    ) {
+        let window = window ?? makeMainWindow()
+        let container = NSView()
+        container.wantsLayer = true
+        container.layer?.backgroundColor = NSColor(
+            calibratedRed: 0.976,
+            green: 0.976,
+            blue: 0.976,
+            alpha: 1
+        ).cgColor
+
+        let brand = NSTextField(labelWithString: "VIBETV")
+        brand.font = .systemFont(ofSize: 40, weight: .black)
+        brand.textColor = NSColor(calibratedWhite: 0.1, alpha: 1)
+        brand.alignment = .center
+
+        let titleLabel = NSTextField(labelWithString: title)
+        titleLabel.font = .systemFont(ofSize: 28, weight: .bold)
+        titleLabel.textColor = NSColor(calibratedWhite: 0.1, alpha: 1)
+        titleLabel.alignment = .center
+        titleLabel.maximumNumberOfLines = 2
+        titleLabel.lineBreakMode = .byWordWrapping
+        titleLabel.setAccessibilityRole(.staticText)
+
+        let detailLabel = NSTextField(wrappingLabelWithString: detail)
+        detailLabel.font = .systemFont(ofSize: 16, weight: .regular)
+        detailLabel.textColor = NSColor(calibratedWhite: 0.28, alpha: 1)
+        detailLabel.alignment = .center
+        detailLabel.maximumNumberOfLines = 3
+
+        let progress = NSProgressIndicator()
+        progress.style = .spinning
+        progress.controlSize = .large
+        if failed {
+            progress.isHidden = true
+        } else {
+            progress.startAnimation(nil)
+        }
+
+        let retry = NSButton(
+            title: "Try again",
+            target: self,
+            action: #selector(retryRuntimePreparation)
+        )
+        retry.bezelStyle = .rounded
+        retry.keyEquivalent = "\r"
+        retry.isHidden = !failed
+
+        let support = NSButton(
+            title: "Open support log",
+            target: self,
+            action: #selector(openSupportLog)
+        )
+        support.bezelStyle = .rounded
+        support.isHidden = !failed
+
+        let actions = NSStackView(views: [retry, support])
+        actions.orientation = .horizontal
+        actions.alignment = .centerY
+        actions.spacing = 12
+
+        let stack = NSStackView(views: [brand, progress, titleLabel, detailLabel, actions])
+        stack.orientation = .vertical
+        stack.alignment = .centerX
+        stack.spacing = 18
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            stack.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: 32),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -32),
+            titleLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 620),
+            detailLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 620),
+        ])
+
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
         self.window = window
-        self.webView = webView
-        loadControlCenter()
     }
 
     private func loadControlCenter(
@@ -857,6 +1156,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
         guard isInstalledApplicationsBundle(Bundle.main.bundleURL) else {
             NSLog(
                 "VibeTV Control Center runtime migration skipped: move the app to /Applications first"
+            )
+            return .keepCurrentPage
+        }
+        if let pending = loadPendingNativeUpdate(),
+           !pendingNativeUpdateMatchesBundle(
+               pending,
+               shortVersion: Bundle.main.object(
+                   forInfoDictionaryKey: "CFBundleShortVersionString"
+               ) as? String,
+               buildVersion: Bundle.main.object(
+                   forInfoDictionaryKey: "CFBundleVersion"
+               ) as? String
+           ) {
+            NSLog(
+                "VibeTV Control Center pending update mismatch expected=\(pending.version)+\(pending.build)"
             )
             return .keepCurrentPage
         }
@@ -951,6 +1265,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
             }
             return .keepCurrentPage
         }
+        clearPendingNativeUpdate()
 
         let devicePreparation = await prepareExistingDeviceConnectionWithRetries(
             requireFreshFullFrame: !legacyStates.isEmpty || !legacyApps.isEmpty
@@ -1238,7 +1553,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
                 lastEvaluation = evaluateRuntimeHealth(
                     data: data,
                     httpStatus: http.statusCode,
-                    expectedVersion: expectedVersion
+                    expectedVersion: expectedVersion,
+                    expectedAppVersion: Bundle.main.object(
+                        forInfoDictionaryKey: "CFBundleShortVersionString"
+                    ) as? String,
+                    expectedBuild: Bundle.main.object(
+                        forInfoDictionaryKey: "CFBundleVersion"
+                    ) as? String,
+                    expectedAppPath: Bundle.main.bundleURL.path,
+                    expectedRuntimeOwner: runtimeLaunchAgentLabel
                 )
                 if case .healthy = lastEvaluation {
                     let ownership = verifyRuntimeListenerOwnership()
@@ -1739,6 +2062,56 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
             .appendingPathComponent("Library/Application Support/codexbar-display", isDirectory: true)
     }
 
+    private func pendingNativeUpdateURL() -> URL {
+        applicationSupportURL().appendingPathComponent(pendingNativeUpdateFileName)
+    }
+
+    private func loadPendingNativeUpdate() -> PendingNativeUpdate? {
+        guard let data = try? Data(contentsOf: pendingNativeUpdateURL()) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(PendingNativeUpdate.self, from: data)
+    }
+
+    private func savePendingNativeUpdate(version: String, build: String) {
+        let pending = PendingNativeUpdate(
+            version: version,
+            build: build,
+            createdAt: Date()
+        )
+        do {
+            try FileManager.default.createDirectory(
+                at: applicationSupportURL(),
+                withIntermediateDirectories: true
+            )
+            let data = try JSONEncoder().encode(pending)
+            try data.write(to: pendingNativeUpdateURL(), options: .atomic)
+        } catch {
+            NSLog("VibeTV Control Center could not save pending update verification: \(error)")
+        }
+    }
+
+    private func clearPendingNativeUpdate() {
+        let url = pendingNativeUpdateURL()
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return
+        }
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            NSLog("VibeTV Control Center could not clear pending update verification: \(error)")
+        }
+    }
+
+#if canImport(Sparkle)
+    func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+        savePendingNativeUpdate(
+            version: item.displayVersionString,
+            build: item.versionString
+        )
+    }
+#endif
+
     private func timestampForBackup() -> String {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .gregorian)
@@ -1753,8 +2126,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
         decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
     ) {
         guard navigationAction.navigationType == .linkActivated,
-              let url = navigationAction.request.url,
-              isApprovedDMGDownloadURL(url) else {
+              let url = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+
+        if isCheckForUpdatesURL(url) {
+            decisionHandler(.cancel)
+            checkForUpdates()
+            return
+        }
+
+        guard isApprovedDMGDownloadURL(url) else {
             decisionHandler(.allow)
             return
         }
@@ -1827,6 +2210,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate {
         }
     }
 }
+
+#if canImport(Sparkle)
+extension AppDelegate: SPUUpdaterDelegate {}
+#endif
 
 #if VIBETV_CONTROL_CENTER_TESTING
 runURLSchemeTests()

--- a/macos/VibeTVControlCenter/shop.vibetv.control-center.runtime.plist
+++ b/macos/VibeTVControlCenter/shop.vibetv.control-center.runtime.plist
@@ -29,6 +29,10 @@
       <string>shop.vibetv.control-center.runtime</string>
       <key>VIBETV_DISABLE_MAC_APP_SELF_UPDATE</key>
       <string>1</string>
+      <key>VIBETV_MAC_APP_VERSION</key>
+      <string>__VIBETV_MAC_APP_VERSION__</string>
+      <key>VIBETV_MAC_APP_BUILD</key>
+      <string>__VIBETV_MAC_APP_BUILD__</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>

--- a/protocol/PROTOCOL.md
+++ b/protocol/PROTOCOL.md
@@ -84,7 +84,7 @@ Design constraints:
 When the ESP8266 is connected to WiFi, it serves:
 
 - `GET /hello`: returns the same Device Hello JSON shape as USB Serial. For WiFi, `capabilities.transport.active` is `wifi` and `supported` includes both `usb` and `wifi`.
-- `GET /health`: returns current WiFi/filesystem/display diagnostics plus `system.freeHeap`, `system.resetReason`, and ThemeSpec render status fields (`renderOk`, `renderError`, `renderFailures`), which help detect watchdog resets or render failures after heavy themes.
+- `GET /health`: returns current WiFi/filesystem/display diagnostics plus `system.freeHeap`, `system.bootId`, `system.uptimeMs`, `system.resetCount`, `system.resetReason`, and ThemeSpec render status fields (`renderOk`, `renderError`, `renderFailures`). A changed `bootId` proves a reboot; `uptimeMs` lets the Companion calculate the reset timestamp using the Mac clock.
 - `POST /frame`: accepts one newline-delimited JSON frame as the request body and feeds it into the same firmware parser used by USB Serial.
 - Frame payloads may include a local `update` object (`available`, `latestVersion`, `status`, `lastError`). This updates the cached display/diagnostic update state. On built-in themes, `available=true` renders a firmware-level notice that cycles through the provider, `Update available`, and `app.vibetv.shop`. ThemeSpec themes receive the same values through the existing `{label}` / `label` binding. The ESP8266 firmware must not fetch public HTTPS manifests directly.
 - `POST /reset-wifi`: clears saved WiFi credentials and restarts the device into setup mode.

--- a/scripts/build-macos-control-center-app.sh
+++ b/scripts/build-macos-control-center-app.sh
@@ -11,6 +11,10 @@ ICON_FILE_NAME="VibeTVControlCenter.icns"
 RUNTIME_AGENT_PLIST_NAME="shop.vibetv.control-center.runtime.plist"
 APP_ICON="${ROOT}/macos/VibeTVControlCenter/${ICON_FILE_NAME}"
 RUNTIME_AGENT_PLIST="${ROOT}/macos/VibeTVControlCenter/${RUNTIME_AGENT_PLIST_NAME}"
+SPARKLE_PUBLIC_KEY_FILE="${ROOT}/macos/VibeTVControlCenter/SparklePublicKey.txt"
+SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/appcast.xml}"
+SPARKLE_PUBLIC_ED_KEY="${SPARKLE_PUBLIC_ED_KEY:-}"
+SPARKLE_DIST_DIR=""
 VERSION="${VERSION:-0.0.0}"
 BUILD="${BUILD:-0}"
 APP_DIR="${ROOT}/dist/macos/${APP_NAME}.app"
@@ -22,7 +26,7 @@ UNIVERSAL=0
 usage() {
   cat <<EOF
 Usage:
-  build-macos-control-center-app.sh [--version x.y.z] [--build n] [--output path.app] [--control-center-static dir] [--companion-binary path] [--app-icon path.icns] [--universal] [--dry-run]
+  build-macos-control-center-app.sh [--version x.y.z] [--build n] [--output path.app] [--control-center-static dir] [--companion-binary path] [--app-icon path.icns] [--sparkle-feed-url url] [--sparkle-public-key key] [--universal] [--dry-run]
 
 Builds the prepared macOS .app bundle for ${APP_NAME}.
 
@@ -75,6 +79,16 @@ while [[ $# -gt 0 ]]; do
       APP_ICON="$2"
       shift 2
       ;;
+    --sparkle-feed-url)
+      need_value "$1" "${2:-}"
+      SPARKLE_FEED_URL="$2"
+      shift 2
+      ;;
+    --sparkle-public-key)
+      need_value "$1" "${2:-}"
+      SPARKLE_PUBLIC_ED_KEY="$2"
+      shift 2
+      ;;
     --dry-run)
       DRY_RUN=1
       shift
@@ -92,6 +106,13 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ -z "$SPARKLE_PUBLIC_ED_KEY" && -f "$SPARKLE_PUBLIC_KEY_FILE" ]]; then
+  SPARKLE_PUBLIC_ED_KEY="$(tr -d '[:space:]' < "$SPARKLE_PUBLIC_KEY_FILE")"
+fi
+[[ "$SPARKLE_FEED_URL" == https://* ]] || die "Sparkle feed URL must use HTTPS"
+[[ "$SPARKLE_PUBLIC_ED_KEY" =~ ^[A-Za-z0-9+/]{43}=$ ]] \
+  || die "Sparkle public key must be one base64-encoded Ed25519 key"
 
 xml_escape() {
   local value="$1"
@@ -159,6 +180,12 @@ write_info_plist() {
     <string>VibeTV Control Center uses the local network to connect to your VibeTV display.</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
+    <key>SUEnableAutomaticChecks</key>
+    <false/>
+    <key>SUFeedURL</key>
+    <string>$(xml_escape "$SPARKLE_FEED_URL")</string>
+    <key>SUPublicEDKey</key>
+    <string>$(xml_escape "$SPARKLE_PUBLIC_ED_KEY")</string>
   </dict>
 </plist>
 PLIST
@@ -211,6 +238,36 @@ EOF
   die "real app builds need --companion-binary path/to/${COMPANION_NAME}"
 }
 
+copy_runtime_agent_plist() {
+  local target="$1"
+  [[ -f "$RUNTIME_AGENT_PLIST" ]] || die "runtime LaunchAgent plist not found: ${RUNTIME_AGENT_PLIST}"
+  sed \
+    -e "s/__VIBETV_MAC_APP_VERSION__/$(xml_escape "${VERSION#v}")/g" \
+    -e "s/__VIBETV_MAC_APP_BUILD__/$(xml_escape "$BUILD")/g" \
+    "$RUNTIME_AGENT_PLIST" > "$target"
+}
+
+prepare_sparkle() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    return 0
+  fi
+  SPARKLE_DIST_DIR="$("${ROOT}/scripts/fetch-sparkle.sh")"
+  [[ -d "${SPARKLE_DIST_DIR}/Sparkle.framework" ]] \
+    || die "Sparkle framework not found after verified download"
+}
+
+copy_sparkle_framework() {
+  local target_dir="$1"
+  mkdir -p "$target_dir"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    mkdir -p "${target_dir}/Sparkle.framework"
+    printf 'Sparkle 2.9.2 dry-run placeholder\n' > "${target_dir}/Sparkle.framework/README.txt"
+    return 0
+  fi
+  command -v ditto >/dev/null 2>&1 || die "ditto is required to preserve Sparkle framework symlinks"
+  ditto "${SPARKLE_DIST_DIR}/Sparkle.framework" "${target_dir}/Sparkle.framework"
+}
+
 copy_app_icon() {
   local target_dir="$1"
   [[ -f "$APP_ICON" ]] || die "app icon not found: ${APP_ICON}"
@@ -244,15 +301,23 @@ EOF
       -target x86_64-apple-macos13 \
       "${ROOT}/macos/VibeTVControlCenter/main.swift" \
       -o "$x86_binary" \
+      -F "$SPARKLE_DIST_DIR" \
       -framework Cocoa \
       -framework ServiceManagement \
+      -framework Sparkle \
+      -Xlinker -rpath \
+      -Xlinker @executable_path/../Frameworks \
       -framework WebKit
     swiftc \
       -target arm64-apple-macos13 \
       "${ROOT}/macos/VibeTVControlCenter/main.swift" \
       -o "$arm64_binary" \
+      -F "$SPARKLE_DIST_DIR" \
       -framework Cocoa \
       -framework ServiceManagement \
+      -framework Sparkle \
+      -Xlinker -rpath \
+      -Xlinker @executable_path/../Frameworks \
       -framework WebKit
     lipo -create -output "$target" "$x86_binary" "$arm64_binary"
     rm -rf "$build_dir"
@@ -263,8 +328,12 @@ EOF
   swiftc \
     "${ROOT}/macos/VibeTVControlCenter/main.swift" \
     -o "$target" \
+    -F "$SPARKLE_DIST_DIR" \
     -framework Cocoa \
     -framework ServiceManagement \
+    -framework Sparkle \
+    -Xlinker -rpath \
+    -Xlinker @executable_path/../Frameworks \
     -framework WebKit
   chmod 755 "$target"
 }
@@ -275,19 +344,21 @@ main() {
   local contents="${APP_DIR}/Contents"
   local macos_dir="${contents}/MacOS"
   local helpers_dir="${contents}/Helpers"
+  local frameworks_dir="${contents}/Frameworks"
   local resources_dir="${contents}/Resources"
   local launch_agents_dir="${contents}/Library/LaunchAgents"
 
   rm -rf "$APP_DIR"
-  mkdir -p "$macos_dir" "$helpers_dir" "$resources_dir" "$launch_agents_dir"
+  mkdir -p "$macos_dir" "$helpers_dir" "$frameworks_dir" "$resources_dir" "$launch_agents_dir"
 
+  prepare_sparkle
   write_info_plist "${contents}/Info.plist"
   build_executable "${macos_dir}/${EXECUTABLE_NAME}"
+  copy_sparkle_framework "$frameworks_dir"
   copy_app_icon "$resources_dir"
   copy_control_center_static "${resources_dir}/control-center"
   copy_companion_binary "$helpers_dir"
-  [[ -f "$RUNTIME_AGENT_PLIST" ]] || die "runtime LaunchAgent plist not found: ${RUNTIME_AGENT_PLIST}"
-  cp "$RUNTIME_AGENT_PLIST" "${launch_agents_dir}/${RUNTIME_AGENT_PLIST_NAME}"
+  copy_runtime_agent_plist "${launch_agents_dir}/${RUNTIME_AGENT_PLIST_NAME}"
   cp "${ROOT}/macos/VibeTVControlCenter/VibeTVControlCenter.entitlements" "${resources_dir}/VibeTVControlCenter.entitlements"
 
   if command -v xattr >/dev/null 2>&1; then

--- a/scripts/fetch-sparkle.sh
+++ b/scripts/fetch-sparkle.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="2.9.2"
+SHA256="1cb340cbbef04c6c0d162078610c25e2221031d794a3449d89f2f56f4df77c95"
+CACHE_ROOT="${SPARKLE_CACHE_ROOT:-${ROOT}/tmp/sparkle}"
+DIST_DIR="${CACHE_ROOT}/${VERSION}"
+ARCHIVE="${CACHE_ROOT}/Sparkle-${VERSION}.tar.xz"
+URL="https://github.com/sparkle-project/Sparkle/releases/download/${VERSION}/Sparkle-${VERSION}.tar.xz"
+
+if [[ -f "${DIST_DIR}/Sparkle.framework/Versions/B/Sparkle" \
+      && -x "${DIST_DIR}/bin/generate_appcast" ]]; then
+  printf '%s\n' "$DIST_DIR"
+  exit 0
+fi
+
+mkdir -p "$CACHE_ROOT"
+if [[ ! -f "$ARCHIVE" ]] \
+    || [[ "$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')" != "$SHA256" ]]; then
+  partial="${ARCHIVE}.part"
+  rm -f "$partial"
+  curl -fL --retry 3 --connect-timeout 15 -o "$partial" "$URL"
+  actual="$(shasum -a 256 "$partial" | awk '{print $1}')"
+  [[ "$actual" == "$SHA256" ]] || {
+    rm -f "$partial"
+    printf 'error: Sparkle %s checksum mismatch\n' "$VERSION" >&2
+    exit 1
+  }
+  mv -f "$partial" "$ARCHIVE"
+fi
+
+rm -rf "$DIST_DIR"
+mkdir -p "$DIST_DIR"
+tar -xJf "$ARCHIVE" -C "$DIST_DIR"
+[[ -f "${DIST_DIR}/Sparkle.framework/Versions/B/Sparkle" ]] \
+  || { printf 'error: Sparkle framework missing after extraction\n' >&2; exit 1; }
+[[ -x "${DIST_DIR}/bin/generate_appcast" ]] \
+  || { printf 'error: Sparkle appcast tool missing after extraction\n' >&2; exit 1; }
+printf '%s\n' "$DIST_DIR"

--- a/scripts/install-control-center-companion-release.sh
+++ b/scripts/install-control-center-companion-release.sh
@@ -1339,7 +1339,12 @@ main() {
     say ""
     say "Done. The new VibeTV Mac App is ready to install."
     say "Drag VibeTV Control Center to Applications, then open it."
-    exit 20
+    # This script is also curl-loaded by older Companions. Keep their default
+    # exit status successful; only a new Companion opts into exit 20.
+    if [[ "${VIBETV_MAC_APP_ACTION_REQUIRED_EXIT_CODE:-0}" == "20" ]]; then
+      exit 20
+    fi
+    exit 0
   fi
 
   if [[ "$MODE" == "uninstall" ]]; then

--- a/scripts/install-control-center-companion-release.sh
+++ b/scripts/install-control-center-companion-release.sh
@@ -10,6 +10,7 @@ BIN_DIR="${APP_SUPPORT_DIR}/bin"
 BIN_PATH="${BIN_DIR}/${INSTALL_NAME}"
 USER_APPLICATIONS_DIR="${HOME}/Applications"
 APP_BUNDLE_DIR="${USER_APPLICATIONS_DIR}/VibeTV Control Center.app"
+SYSTEM_APP_BUNDLE_DIR="${VIBETV_SYSTEM_APP_BUNDLE_DIR:-/Applications/VibeTV Control Center.app}"
 LEGACY_APP_BUNDLE_DIR="${APP_SUPPORT_DIR}/VibeTV Control Center.app"
 APP_BUNDLE_CONTENTS_DIR="${APP_BUNDLE_DIR}/Contents"
 APP_BUNDLE_BIN_DIR="${APP_BUNDLE_CONTENTS_DIR}/MacOS"
@@ -565,9 +566,26 @@ restart_service() {
 }
 
 download_new_mac_app() {
-  local partial_path
+  local partial_path installed_version signature_details
   require_cmd_for curl "download the new VibeTV Mac App" "use a standard macOS Terminal with curl available, then try again."
   require_cmd_for open "open the new VibeTV Mac App DMG" "open the downloaded DMG from your Downloads folder."
+
+  if [[ -x "${SYSTEM_APP_BUNDLE_DIR}/Contents/MacOS/VibeTVControlCenter" \
+        && -f "${SYSTEM_APP_BUNDLE_DIR}/Contents/Info.plist" ]] \
+      && command -v plutil >/dev/null 2>&1 \
+      && [[ "$(plutil -extract CFBundleIdentifier raw -o - "${SYSTEM_APP_BUNDLE_DIR}/Contents/Info.plist" 2>/dev/null || true)" == "shop.vibetv.control-center" ]]; then
+    installed_version="$(plutil -extract CFBundleShortVersionString raw -o - "${SYSTEM_APP_BUNDLE_DIR}/Contents/Info.plist" 2>/dev/null || true)"
+    signature_details="$(codesign --display --verbose=2 "$SYSTEM_APP_BUNDLE_DIR" 2>&1 || true)"
+    if codesign --verify --deep --strict "$SYSTEM_APP_BUNDLE_DIR" >/dev/null 2>&1 \
+        && [[ "$signature_details" == *"Authority=Developer ID Application:"* ]] \
+        && { [[ -z "$RELEASE_VERSION" ]] || [[ "$installed_version" == "$RELEASE_VERSION" ]]; }; then
+      log "vibetv: verified native Mac App already installed version=${installed_version}"
+      open "$SYSTEM_APP_BUNDLE_DIR" >/dev/null 2>&1 \
+        || die "the verified VibeTV Control Center app could not be opened from Applications."
+      say "CODEX_MAC_APP_ACTION_REQUIRED kind=handoff version=${installed_version}"
+      return 0
+    fi
+  fi
 
   mkdir -p "$DMG_DOWNLOAD_DIR"
   partial_path="${DMG_PATH}.part"
@@ -582,6 +600,7 @@ download_new_mac_app() {
   open "$DMG_PATH" >/dev/null 2>&1 \
     || die "the DMG was downloaded to ${DMG_PATH}, but could not be opened automatically."
   log "vibetv: opened new Mac App DMG"
+  say "CODEX_MAC_APP_ACTION_REQUIRED kind=manual_install path=${DMG_PATH}"
 }
 
 verify_launchagent_loaded() {
@@ -1320,7 +1339,7 @@ main() {
     say ""
     say "Done. The new VibeTV Mac App is ready to install."
     say "Drag VibeTV Control Center to Applications, then open it."
-    exit 0
+    exit 20
   fi
 
   if [[ "$MODE" == "uninstall" ]]; then

--- a/scripts/sign-notarize-macos-control-center.sh
+++ b/scripts/sign-notarize-macos-control-center.sh
@@ -310,7 +310,33 @@ run_notary_submission_preflight() {
 sign_app_bundle() {
   local identity="$1"
   local companion_binary="${APP_DIR}/Contents/Helpers/codexbar-display"
+  local sparkle_framework="${APP_DIR}/Contents/Frameworks/Sparkle.framework"
   local authority signature_details signed_team_id
+
+  if [[ -d "$sparkle_framework" ]]; then
+    local sparkle_version_dir="${sparkle_framework}/Versions/B"
+    local nested
+    for nested in \
+      "${sparkle_version_dir}/XPCServices/Downloader.xpc" \
+      "${sparkle_version_dir}/XPCServices/Installer.xpc" \
+      "${sparkle_version_dir}/Updater.app" \
+      "${sparkle_version_dir}/Autoupdate"; do
+      [[ -e "$nested" ]] || die "Sparkle nested code is missing: ${nested}"
+      codesign \
+        --force \
+        --options runtime \
+        --timestamp \
+        --sign "$identity" \
+        "$nested"
+    done
+    codesign \
+      --force \
+      --options runtime \
+      --timestamp \
+      --sign "$identity" \
+      "$sparkle_framework"
+    codesign --verify --deep --strict --verbose=2 "$sparkle_framework"
+  fi
 
   if [[ -x "$companion_binary" ]]; then
     codesign \

--- a/scripts/test-control-center-companion-legacy-installer.sh
+++ b/scripts/test-control-center-companion-legacy-installer.sh
@@ -474,7 +474,7 @@ run_install_can_skip_device_setup_for_mac_app_update() {
 }
 
 run_install_downloads_dmg_when_started_inside_display_daemon() {
-	local root output setup_log dmg_url dmg_path old_binary old_binary_before installer_status
+	local root output protocol_output setup_log dmg_url dmg_path old_binary old_binary_before installer_status
   root="${TMP_WORK_DIR}/dmg-download"
   write_fake_commands "${root}/fake-bin"
   prepare_home "${root}/home"
@@ -491,8 +491,16 @@ run_install_downloads_dmg_when_started_inside_display_daemon() {
 	output="$(VIBETV_INSTALLER_DISPLAY_DAEMON_PID="$$" VIBETV_MAC_APP_DMG_URL="$dmg_url" run_installer "$root" --version 9.9.9 --skip-device-setup)"
 	installer_status=$?
 	set -e
+	[[ "$installer_status" == "0" ]] \
+		|| die "legacy Companion handoff must stay compatible with exit 0, got ${installer_status}"
+
+	set +e
+	protocol_output="$(VIBETV_INSTALLER_DISPLAY_DAEMON_PID="$$" VIBETV_MAC_APP_DMG_URL="$dmg_url" VIBETV_MAC_APP_ACTION_REQUIRED_EXIT_CODE=20 run_installer "$root" --version 9.9.9 --skip-device-setup)"
+	installer_status=$?
+	set -e
 	[[ "$installer_status" == "20" ]] \
-		|| die "DMG handoff must report action_required with exit 20, got ${installer_status}"
+		|| die "new Companion handoff must report action_required with exit 20, got ${installer_status}"
+	assert_contains "$protocol_output" "CODEX_MAC_APP_ACTION_REQUIRED kind=manual_install"
 
   setup_log="$(support_log "$root")"
 
@@ -519,7 +527,7 @@ run_install_downloads_dmg_when_started_inside_display_daemon() {
 }
 
 run_install_hands_off_to_existing_app_without_second_dmg() {
-  local root output app_path installer_status
+  local root output protocol_output app_path installer_status
   root="${TMP_WORK_DIR}/existing-system-app"
   write_fake_commands "${root}/fake-bin"
   prepare_home "${root}/home"
@@ -559,8 +567,16 @@ PLIST
   output="$(VIBETV_INSTALLER_DISPLAY_DAEMON_PID="$$" VIBETV_SYSTEM_APP_BUNDLE_DIR="$app_path" run_installer "$root" --version 9.9.9 --skip-device-setup)"
   installer_status=$?
   set -e
+  [[ "$installer_status" == "0" ]] \
+    || die "legacy existing-app handoff must stay compatible with exit 0, got ${installer_status}"
+
+  set +e
+  protocol_output="$(VIBETV_INSTALLER_DISPLAY_DAEMON_PID="$$" VIBETV_SYSTEM_APP_BUNDLE_DIR="$app_path" VIBETV_MAC_APP_ACTION_REQUIRED_EXIT_CODE=20 run_installer "$root" --version 9.9.9 --skip-device-setup)"
+  installer_status=$?
+  set -e
   [[ "$installer_status" == "20" ]] \
-    || die "existing native app handoff must report action_required with exit 20, got ${installer_status}"
+    || die "new Companion existing-app handoff must report action_required with exit 20, got ${installer_status}"
+  assert_contains "$protocol_output" "CODEX_MAC_APP_ACTION_REQUIRED kind=handoff version=9.9.9"
   assert_contains "$output" "CODEX_MAC_APP_ACTION_REQUIRED kind=handoff version=9.9.9"
   assert_contains "$(cat "${root}/open.log")" "$app_path"
   [[ ! -s "${root}/curl.log" ]] || die "existing native app handoff must not download a second DMG"

--- a/scripts/test-control-center-companion-legacy-installer.sh
+++ b/scripts/test-control-center-companion-legacy-installer.sh
@@ -527,6 +527,21 @@ run_install_hands_off_to_existing_app_without_second_dmg() {
   : > "${root}/curl.log"
   : > "${root}/api.log"
   : > "${root}/open.log"
+  cat > "${root}/fake-bin/plutil" <<'EOF'
+#!/usr/bin/env bash
+case "${2:-}" in
+  CFBundleIdentifier)
+    printf 'shop.vibetv.control-center\n'
+    ;;
+  CFBundleShortVersionString)
+    printf '9.9.9\n'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "${root}/fake-bin/plutil"
   app_path="${root}/Applications/VibeTV Control Center.app"
   mkdir -p "${app_path}/Contents/MacOS"
   printf '#!/usr/bin/env bash\nexit 0\n' > "${app_path}/Contents/MacOS/VibeTVControlCenter"

--- a/scripts/test-control-center-companion-legacy-installer.sh
+++ b/scripts/test-control-center-companion-legacy-installer.sh
@@ -213,6 +213,9 @@ EOF
 
   cat > "${fake_bin}/codesign" <<'EOF'
 #!/usr/bin/env bash
+if [[ " $* " == *" --display "* ]]; then
+  printf 'Authority=Developer ID Application: VibeTV Test (TESTTEAM)\n' >&2
+fi
 exit 0
 EOF
 
@@ -282,6 +285,7 @@ run_installer() {
       FAKE_STATUS_DEVICE_DISCONNECTED="${FAKE_STATUS_DEVICE_DISCONNECTED:-}" \
       VIBETV_INSTALLER_DISPLAY_DAEMON_PID="${VIBETV_INSTALLER_DISPLAY_DAEMON_PID:-}" \
       VIBETV_MAC_APP_DMG_URL="${VIBETV_MAC_APP_DMG_URL:-}" \
+      VIBETV_SYSTEM_APP_BUNDLE_DIR="${VIBETV_SYSTEM_APP_BUNDLE_DIR:-}" \
       VIBETV_COMPANION_REPAIR_ATTEMPTS="${VIBETV_COMPANION_REPAIR_ATTEMPTS:-3}" \
       VIBETV_COMPANION_REPAIR_RETRY_DELAY="${VIBETV_COMPANION_REPAIR_RETRY_DELAY:-0}" \
       VIBETV_COMPANION_STABLE_RETRY_DELAY="${VIBETV_COMPANION_STABLE_RETRY_DELAY:-0}" \
@@ -470,7 +474,7 @@ run_install_can_skip_device_setup_for_mac_app_update() {
 }
 
 run_install_downloads_dmg_when_started_inside_display_daemon() {
-  local root output setup_log dmg_url dmg_path old_binary old_binary_before
+	local root output setup_log dmg_url dmg_path old_binary old_binary_before installer_status
   root="${TMP_WORK_DIR}/dmg-download"
   write_fake_commands "${root}/fake-bin"
   prepare_home "${root}/home"
@@ -483,15 +487,18 @@ run_install_downloads_dmg_when_started_inside_display_daemon() {
   old_binary="${root}/home/Library/Application Support/codexbar-display/bin/codexbar-display"
   old_binary_before="$(cat "$old_binary")"
 
-  output="$(VIBETV_INSTALLER_DISPLAY_DAEMON_PID="$$" VIBETV_MAC_APP_DMG_URL="$dmg_url" run_installer "$root" --version 9.9.9 --skip-device-setup)" || {
-    printf '%s\n' "$output" >&2
-    die "expected DMG download to pass"
-  }
+	set +e
+	output="$(VIBETV_INSTALLER_DISPLAY_DAEMON_PID="$$" VIBETV_MAC_APP_DMG_URL="$dmg_url" run_installer "$root" --version 9.9.9 --skip-device-setup)"
+	installer_status=$?
+	set -e
+	[[ "$installer_status" == "20" ]] \
+		|| die "DMG handoff must report action_required with exit 20, got ${installer_status}"
 
   setup_log="$(support_log "$root")"
 
   assert_contains "$output" "Downloading the new VibeTV Mac App"
-  assert_contains "$output" "[1/1] Downloading Mac App"
+	assert_contains "$output" "[1/1] Downloading Mac App"
+	assert_contains "$output" "CODEX_MAC_APP_ACTION_REQUIRED kind=manual_install"
   assert_contains "$output" "Done. The new VibeTV Mac App is ready to install."
   assert_contains "$output" "Drag VibeTV Control Center to Applications, then open it."
   assert_not_contains "$output" "Installing your local Control Center"
@@ -509,6 +516,39 @@ run_install_downloads_dmg_when_started_inside_display_daemon() {
   assert_not_contains "$(cat "${root}/curl.log")" "/releases/latest"
   assert_not_contains "$(cat "${root}/curl.log")" "checksums-"
   assert_not_contains "$(cat "${root}/api.log")" "install-update"
+}
+
+run_install_hands_off_to_existing_app_without_second_dmg() {
+  local root output app_path installer_status
+  root="${TMP_WORK_DIR}/existing-system-app"
+  write_fake_commands "${root}/fake-bin"
+  prepare_home "${root}/home"
+  : > "${root}/launchctl.log"
+  : > "${root}/curl.log"
+  : > "${root}/api.log"
+  : > "${root}/open.log"
+  app_path="${root}/Applications/VibeTV Control Center.app"
+  mkdir -p "${app_path}/Contents/MacOS"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "${app_path}/Contents/MacOS/VibeTVControlCenter"
+  chmod +x "${app_path}/Contents/MacOS/VibeTVControlCenter"
+  cat > "${app_path}/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleIdentifier</key><string>shop.vibetv.control-center</string>
+  <key>CFBundleShortVersionString</key><string>9.9.9</string>
+</dict></plist>
+PLIST
+
+  set +e
+  output="$(VIBETV_INSTALLER_DISPLAY_DAEMON_PID="$$" VIBETV_SYSTEM_APP_BUNDLE_DIR="$app_path" run_installer "$root" --version 9.9.9 --skip-device-setup)"
+  installer_status=$?
+  set -e
+  [[ "$installer_status" == "20" ]] \
+    || die "existing native app handoff must report action_required with exit 20, got ${installer_status}"
+  assert_contains "$output" "CODEX_MAC_APP_ACTION_REQUIRED kind=handoff version=9.9.9"
+  assert_contains "$(cat "${root}/open.log")" "$app_path"
+  [[ ! -s "${root}/curl.log" ]] || die "existing native app handoff must not download a second DMG"
 }
 
 run_install_disables_global_legacy_launchagent() {
@@ -699,6 +739,7 @@ run_install_restarts_when_old_api_version_answers() {
 run_install_writes_integrated_daemon_launchagent
 run_install_can_skip_device_setup_for_mac_app_update
 run_install_downloads_dmg_when_started_inside_display_daemon
+run_install_hands_off_to_existing_app_without_second_dmg
 run_install_disables_global_legacy_launchagent
 run_install_retries_transient_repair_failure
 run_install_waits_for_slow_repair_recovery

--- a/scripts/test-macos-control-center-app-bundle.sh
+++ b/scripts/test-macos-control-center-app-bundle.sh
@@ -596,6 +596,9 @@ required_source = [
     "requiresApplicationInstallation(Bundle.main.bundleURL)",
     "presentInstallationRequiredAlert()",
     "RuntimePreparationOutcome",
+    "pendingNativeUpdateBlocksBundle(",
+    "pendingNativeUpdateIsExpired(",
+    "discardMismatchedPendingNativeUpdate()",
     "presentInstallationStatus(",
     'title: "Finishing installation…"',
     'title: "Installation needs attention"',
@@ -613,11 +616,12 @@ launch_end = source.find("func application(_ application:", launch_start)
 launch_method = source[launch_start:launch_end]
 install_guard = launch_method.find("guard !installationRequired else")
 install_alert = launch_method.find("presentInstallationRequiredAlert()", install_guard)
+sparkle_start = launch_method.find("_ = updaterController", install_guard)
 runtime_start = launch_method.find("Task {", install_guard)
 runtime_start = launch_method.find("startRuntimePreparation()", install_guard)
-if not (0 <= install_guard < install_alert < runtime_start):
+if not (0 <= install_guard < install_alert < sparkle_start < runtime_start):
     raise SystemExit(
-        "native app must stop at the install dialog before starting the runtime or WebView"
+        "native app must stop at the install dialog before starting Sparkle, the runtime, or WebView"
     )
 
 prepare_start = source.find("private func startRuntimePreparation()")

--- a/scripts/test-macos-control-center-app-bundle.sh
+++ b/scripts/test-macos-control-center-app-bundle.sh
@@ -436,6 +436,7 @@ main() {
     || die "Mach-O helpers must not be stored in the Resources directory"
   assert_file "${app}/Contents/Resources/VibeTVControlCenter.icns"
   assert_file "${app}/Contents/Library/LaunchAgents/shop.vibetv.control-center.runtime.plist"
+  assert_file "${app}/Contents/Frameworks/Sparkle.framework/README.txt"
 
   python3 - \
     "${app}/Contents/Info.plist" \
@@ -456,6 +457,9 @@ expected = {
     "CFBundleShortVersionString": "1.2.3",
     "CFBundleVersion": "146",
     "CFBundlePackageType": "APPL",
+    "SUEnableAutomaticChecks": False,
+    "SUFeedURL": "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/appcast.xml",
+    "SUPublicEDKey": "2txeIAd+ofTbffzPR5hy5J4lvGX8LGclIdG82es1qPA=",
 }
 
 for key, value in expected.items():
@@ -519,6 +523,10 @@ if environment.get("VIBETV_DISABLE_MAC_APP_SELF_UPDATE") != "1":
     raise SystemExit(
         "DMG runtime must disable the legacy Terminal Mac App updater"
     )
+if environment.get("VIBETV_MAC_APP_VERSION") != "1.2.3":
+    raise SystemExit("DMG runtime must report its containing Mac App version")
+if environment.get("VIBETV_MAC_APP_BUILD") != "146":
+    raise SystemExit("DMG runtime must report its containing Mac App build")
 
 with open(sys.argv[3], encoding="utf-8") as f:
     source = f.read()
@@ -538,6 +546,11 @@ if stop_legacy > register_runtime:
 
 required_source = [
     "import ServiceManagement",
+    "import Sparkle",
+    "SPUStandardUpdaterController(",
+    "SPUUpdaterDelegate",
+    'isCheckForUpdatesURL(url)',
+    'pendingNativeUpdateFileName = "pending-native-update.json"',
     "SMAppService.agent(plistName: runtimeLaunchAgentPlistName)",
     "try runtimeService.register()",
     "runtimeService.unregister(completionHandler:",
@@ -583,6 +596,9 @@ required_source = [
     "requiresApplicationInstallation(Bundle.main.bundleURL)",
     "presentInstallationRequiredAlert()",
     "RuntimePreparationOutcome",
+    "presentInstallationStatus(",
+    'title: "Finishing installation…"',
+    'title: "Installation needs attention"',
     "activeNavigation = webView?.load(",
     ".reloadIgnoringLocalCacheData",
     'alert.addButton(withTitle: "Open Applications")',
@@ -598,24 +614,23 @@ launch_method = source[launch_start:launch_end]
 install_guard = launch_method.find("guard !installationRequired else")
 install_alert = launch_method.find("presentInstallationRequiredAlert()", install_guard)
 runtime_start = launch_method.find("Task {", install_guard)
-control_center_start = launch_method.find("presentControlCenter()", install_guard)
-if not (
-    0 <= install_guard < install_alert < runtime_start
-    and install_guard < control_center_start
-):
+runtime_start = launch_method.find("startRuntimePreparation()", install_guard)
+if not (0 <= install_guard < install_alert < runtime_start):
     raise SystemExit(
         "native app must stop at the install dialog before starting the runtime or WebView"
     )
 
-prepare_runtime = launch_method.find("let outcome = await self.prepareCompanion()")
-reload_after_prepare = launch_method.find(
-    "if outcome.shouldReloadControlCenter",
-    prepare_runtime,
-)
-reload_call = launch_method.find("self.reloadControlCenter()", reload_after_prepare)
-if not (0 <= prepare_runtime < reload_after_prepare < reload_call):
+prepare_start = source.find("private func startRuntimePreparation()")
+prepare_end = source.find("@objc private func retryRuntimePreparation()", prepare_start)
+preparation_method = source[prepare_start:prepare_end]
+status_start = preparation_method.find("presentInstallationStatus(")
+prepare_runtime = preparation_method.find("let outcome = await self.prepareCompanion()")
+native_case = preparation_method.find("case .nativeRuntimeReady:", prepare_runtime)
+webview_after_verify = preparation_method.find("self.presentControlCenter()", native_case)
+legacy_case = preparation_method.find("case .legacyRuntimeRestored:", native_case)
+if not (0 <= status_start < prepare_runtime < native_case < webview_after_verify < legacy_case):
     raise SystemExit(
-        "native app must refresh the WebView after a confirmed runtime migration or rollback"
+        "native app must keep the WebView closed until app, runtime, and listener verification succeeds"
     )
 
 if "shouldRetryControlCenterNavigation(error)" not in source:
@@ -648,10 +663,11 @@ if (
     )
 
 present_start = source.find("private func presentControlCenter()")
-present_end = source.find("private func createWindow()", present_start)
-if "guard !installationRequired else" not in source[present_start:present_end]:
+present_end = source.find("private func presentInstallationRequiredAlert()", present_start)
+present_source = source[present_start:present_end]
+if "guard !installationRequired, installationReady else" not in present_source:
     raise SystemExit(
-        "native app must prevent every non-Applications launch from creating a WebView"
+        "native app must prevent every unverified launch from creating a WebView"
     )
 
 registration = source.find("guard await ensureBundledRuntimeServiceRegistered()")
@@ -844,6 +860,33 @@ PY
     "signing dry-run must show stapler"
   assert_contains "$sign_output" "spctl --assess" \
     "signing dry-run must show Gatekeeper assessment"
+
+  python3 - "${ROOT}/scripts/sign-notarize-macos-control-center.sh" <<'PY'
+import sys
+
+source = open(sys.argv[1], encoding="utf-8").read()
+positions = [
+    source.index('"${sparkle_version_dir}/XPCServices/Downloader.xpc"'),
+    source.index('"${sparkle_version_dir}/XPCServices/Installer.xpc"'),
+    source.index('"${sparkle_version_dir}/Updater.app"'),
+    source.index('"${sparkle_version_dir}/Autoupdate"'),
+    source.index('"$sparkle_framework"', source.index('"${sparkle_version_dir}/Autoupdate"')),
+    source.index('"$companion_binary"', source.index('"$sparkle_framework"')),
+]
+if positions != sorted(positions):
+    raise SystemExit("Sparkle nested helpers, framework, and companion must be signed inside-out")
+PY
+
+  grep -qF 'VERSION="2.9.2"' "${ROOT}/scripts/fetch-sparkle.sh" \
+    || die "Sparkle distribution version must stay pinned"
+  grep -qF 'SHA256="1cb340cbbef04c6c0d162078610c25e2221031d794a3449d89f2f56f4df77c95"' "${ROOT}/scripts/fetch-sparkle.sh" \
+    || die "Sparkle distribution checksum must stay pinned"
+  grep -qF 'generate_appcast' "${ROOT}/.github/workflows/release.yml" \
+    || die "release workflow must generate a Sparkle appcast"
+  grep -qF 'sparkle:edSignature=' "${ROOT}/.github/workflows/release.yml" \
+    || die "release workflow must verify the appcast signature"
+  grep -qF 'SPARKLE_ED25519_PRIVATE_KEY' "${ROOT}/.github/workflows/release.yml" \
+    || die "release workflow must source the Sparkle private key from Actions secrets"
 
   grep -qF "com.codexbar-display.daemon" "${ROOT}/macos/VibeTVControlCenter/main.swift" \
     || die "native app shell must detect the old LaunchAgent"


### PR DESCRIPTION
Closes #171
Closes #174

## Summary
- recover transient device reconnects without unnecessary setup or writes
- verify macOS app, embedded runtime, and listener ownership before reporting update success
- integrate pinned Sparkle 2.9.2 packaging and signed appcast generation
- make firmware updates transactional with typed stages, exact-device rediscovery, health, stream, and render verification
- separate app, runtime, listener, and attention states in the Control Center UI

## Verification
- go test ./... in companion
- go vet ./... and staticcheck
- Control Center lint, local build, full customer flows, UI copy checks
- macOS app bundle, legacy installer, release workflow, migration, and customer readiness scripts
- native firmware tests: 45/45
- ESP8266 preview firmware build
- real device OTA on device 14799300: 1.0.36-rc.1 -> 1.0.45-rc.174.1
- second install: already_current, uploadAccepted=false
- 5-minute read-only soak: 21/21 successful samples

## Release boundary
- no merge, tag, prerelease, or production release performed
- signed CI preview remains gated on the GitHub secret SPARKLE_ED25519_PRIVATE_KEY