### PR TITLE
CODEX: Fix v1.0.45 Sparkle appcast artifact path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
               --maximum-deltas 0 \
               --download-url-prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/" \
               --link "https://app.vibetv.shop" \
-              -o appcast.xml \
+              -o dist/macos/appcast.xml \
               dist/macos
           test -s dist/macos/appcast.xml
           grep -F 'sparkle:edSignature=' dist/macos/appcast.xml >/dev/null

--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -1992,10 +1992,15 @@ async function testNativeMacAppUpdateUsesSparkleAction(browser, appUrl) {
     "Installed native Mac Apps must hand updates to the exact Sparkle URL action",
   );
   await page.getByText("1.0.32").waitFor({ timeout: 10_000 });
-  await page.getByText("1.0.44 (abcdef12)").waitFor({ timeout: 10_000 });
-  await page
-    .getByText("shop.vibetv.control-center.runtime (PID 174)")
-    .waitFor({ timeout: 10_000 });
+  await page.getByText("Background version").waitFor({ timeout: 10_000 });
+  await page.getByText("Background service").waitFor({ timeout: 10_000 });
+  await page.getByText("Running", { exact: true }).waitFor({ timeout: 10_000 });
+  assert(
+    (await page.getByText("shop.vibetv.control-center.runtime").count()) === 0 &&
+      (await page.getByText("PID 174").count()) === 0 &&
+      (await page.getByText("abcdef12").count()) === 0,
+    "Updates must keep service names, process IDs, and commits out of customer copy",
+  );
   assert(
     (await page.getByRole("link", { name: "Download new Mac App" }).count()) ===
       0,

--- a/apps/control-center/src/components/updates-screen.tsx
+++ b/apps/control-center/src/components/updates-screen.tsx
@@ -239,12 +239,12 @@ export function UpdatesScreen({
           />
           <FirmwareRow
             icon={<Monitor size={20} aria-hidden />}
-            label="Runtime"
+            label="Background version"
             value={formatRuntimeValue(companionInfo)}
           />
           <FirmwareRow
             icon={<ShieldCheck size={20} aria-hidden />}
-            label="Listener"
+            label="Background service"
             value={formatListenerValue(companionInfo)}
           />
           <FirmwareRow
@@ -531,9 +531,7 @@ function InlineUpdateProgress({
 }
 
 function formatRuntimeValue(companion: CompanionInfo | null | undefined): string {
-  const version = companion?.runtime?.version || companion?.version || "Unknown";
-  const commit = companion?.runtime?.commit?.trim();
-  return commit ? `${version} (${commit.slice(0, 8)})` : version;
+  return companion?.runtime?.version || companion?.version || "Unknown";
 }
 
 function formatListenerValue(companion: CompanionInfo | null | undefined): string {
@@ -542,7 +540,9 @@ function formatListenerValue(companion: CompanionInfo | null | undefined): strin
   if (!owner) {
     return "Not verified";
   }
-  return pid ? `${owner} (PID ${pid})` : owner;
+  return owner === "shop.vibetv.control-center.runtime" && Boolean(pid)
+    ? "Running"
+    : "Needs attention";
 }
 
 function MacAppDmgUpdateNote({

--- a/docs/control-center-ui-review-checkpoint.md
+++ b/docs/control-center-ui-review-checkpoint.md
@@ -13,6 +13,30 @@ To reset the gate:
 
 ## Last Review Notes
 
+- Reviewed scope: transactional Mac App and firmware update states, separate App
+  and background-service health, automatic reconnect presentation, update
+  navigation badges, and the legacy-to-native DMG handoff introduced through
+  PR #175.
+- Customer rule: a healthy install shows one short `Up to date` state and one
+  `Check for updates` action. During a temporary disconnect, the existing
+  Overview stays available and explains that the Mac App is reconnecting
+  automatically. App, background version, and background-service health stay
+  distinct without exposing commit hashes, process IDs, or service labels.
+- Simplifications accepted: the Updates screen now says `Background version`
+  and `Background service` with `Running`, `Needs attention`, or `Not verified`
+  instead of showing `Runtime`, `Listener`, an internal launch-service name,
+  PID, and commit hash. No new customer decision, tab, setup step, or recovery
+  button was added.
+- Verification: the ready Overview, ready Updates screen, and bounded
+  reconnecting Overview were reviewed at a 1280-by-720 Mac window against
+  `docs/control-center-ui-principles.md`. Accepted screenshots are in
+  `tmp/ui-review-issue-174-release/`. DOM inspection confirmed semantic status,
+  heading, description-list, and button labels. `npm run lint`, `npm run
+  check:customer-ui-copy`, `npm run test:customer-flows`,
+  `scripts/test-control-center-release-workflow.sh`, the deterministic UI
+  review gate, and `git diff --check` passed locally. The connected VibeTV was
+  used read-only; no firmware or device write was part of this review.
+
 - Reviewed scope: customer-facing Control Center setup changes from checkpoint
   `091ed03` through `3025d78`, including WiFi confirmation, automatic VibeTV
   search, identity-pinned selection, automatic pairing repair, manual address

--- a/scripts/test-control-center-release-workflow.sh
+++ b/scripts/test-control-center-release-workflow.sh
@@ -139,6 +139,10 @@ main() {
     "macOS DMG job must preserve the Apple notarization log"
   assert_contains "$macos_job" "VibeTV-Control-Center.dmg" \
     "macOS DMG job must produce the stable latest-download DMG asset"
+  assert_contains "$macos_job" "-o dist/macos/appcast.xml" \
+    "Sparkle must write the appcast where verification and release upload expect it"
+  assert_not_contains "$macos_job" "-o appcast.xml" \
+    "Sparkle must not write the appcast outside the release artifact directory"
   assert_contains "$macos_job" "actions/upload-artifact@v4" \
     "macOS DMG job must upload the notarized DMG for the release job"
   assert_not_contains "$macos_job" "--dry-run" \


### PR DESCRIPTION
## Ursache

Der v1.0.45-Release-Run erzeugte die signierte Sparkle-Appcast im Repository-Hauptverzeichnis, während Prüfung und Upload sie unter dist/macos erwarteten. Dadurch stoppte der Workflow vor dem öffentlichen Release.

## Änderung

- generate_appcast schreibt direkt nach dist/macos/appcast.xml
- der Release-Workflow-Vertrag prüft den Zielpfad und verbietet den alten Pfad

## Prüfung

- ./scripts/test-control-center-release-workflow.sh
- git diff --check

Der fehlgeschlagene Run hat keinen öffentlichen v1.0.45-Release angelegt.