### PR TITLE
CODEX: Add protocol-faithful Virtual VibeTV simulator (#177 part 1/2)

### DIFF
--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -542,24 +542,44 @@ func runInstallUpdate(args []string) (retErr error) {
 				uploadErr = fmt.Errorf("%w; repair pairing failed: %v", uploadErr, pairErr)
 			}
 		}
-		if uploadErr != nil {
+	}
+
+	verifiedBase := ""
+	if uploadErr != nil {
+		if firmwareOTAAuthError(uploadErr) {
 			return &commandError{
 				Op:   "ota-upload",
 				Code: errcode.UpgradeFlashFirmware,
 				Err:  uploadErr,
+				Hint: "pair VibeTV again, then retry",
+			}
+		}
+		// A VibeTV can finish writing the OTA image and reboot before its HTTP
+		// acknowledgement reaches the Mac. Retrying that ambiguous upload can
+		// flash the same image twice. Verify the candidate version first; only an
+		// explicit authentication rejection is safe to retry above.
+		fmt.Println("Firmware upload response was interrupted. Checking VibeTV before retrying...")
+		verifiedBase, err = waitForHTTPFirmwareVersionWithDiscovery(ctx, home, base, targetVersion, hello.DeviceID, 90*time.Second)
+		if err != nil {
+			return &commandError{
+				Op:   "ota-upload",
+				Code: errcode.UpgradeFlashFirmware,
+				Err:  fmt.Errorf("%w; candidate verification also failed: %v", uploadErr, err),
 				Hint: "keep VibeTV powered and on the same WiFi, then retry",
 			}
 		}
 	}
 	fmt.Println("Restarting VibeTV...")
 
-	verifiedBase, err := waitForHTTPFirmwareVersionWithDiscovery(ctx, home, base, targetVersion, 90*time.Second)
-	if err != nil {
-		return &commandError{
-			Op:   "post-update-verify",
-			Code: errcode.UpgradeFlashFirmware,
-			Err:  err,
-			Hint: "wait one minute, then open http://<device-ip>/health",
+	if verifiedBase == "" {
+		verifiedBase, err = waitForHTTPFirmwareVersionWithDiscovery(ctx, home, base, targetVersion, hello.DeviceID, 90*time.Second)
+		if err != nil {
+			return &commandError{
+				Op:   "post-update-verify",
+				Code: errcode.UpgradeFlashFirmware,
+				Err:  err,
+				Hint: "wait one minute, then open http://<device-ip>/health",
+			}
 		}
 	}
 	if verifiedBase != base {
@@ -610,20 +630,20 @@ func shouldStoreFirmwareUpdateTarget(current, next string) bool {
 	return true
 }
 
-func waitForHTTPFirmwareVersionWithDiscovery(ctx context.Context, home, base, version string, timeout time.Duration) (string, error) {
+func waitForHTTPFirmwareVersionWithDiscovery(ctx context.Context, home, base, version, deviceID string, timeout time.Duration) (string, error) {
 	firstTimeout := timeout
 	if firmwareUpdateRediscoveryAfter > 0 && firmwareUpdateRediscoveryAfter < timeout {
 		firstTimeout = firmwareUpdateRediscoveryAfter
 	}
-	err := waitForHTTPFirmwareVersion(ctx, base, version, firstTimeout)
+	err := waitForHTTPFirmwareVersion(ctx, base, version, deviceID, firstTimeout)
 	if err == nil {
 		return base, nil
 	}
 
-	discovered, discoverErr := discoverInstallUpdateTarget(ctx, home, base)
+	discovered, discoverErr := discoverInstallUpdateTarget(ctx, home, base, deviceID)
 	if discoverErr != nil {
 		if firstTimeout < timeout {
-			if retryErr := waitForHTTPFirmwareVersion(ctx, base, version, timeout-firstTimeout); retryErr == nil {
+			if retryErr := waitForHTTPFirmwareVersion(ctx, base, version, deviceID, timeout-firstTimeout); retryErr == nil {
 				return base, nil
 			}
 		}
@@ -633,13 +653,13 @@ func waitForHTTPFirmwareVersionWithDiscovery(ctx context.Context, home, base, ve
 		return "", err
 	}
 	fmt.Printf("Using rediscovered VibeTV address: %s\n", discovered)
-	if verifyErr := waitForHTTPFirmwareVersion(ctx, discovered, version, 30*time.Second); verifyErr != nil {
+	if verifyErr := waitForHTTPFirmwareVersion(ctx, discovered, version, deviceID, 30*time.Second); verifyErr != nil {
 		return "", fmt.Errorf("%w; rediscovered target %s also failed: %v", err, discovered, verifyErr)
 	}
 	return discovered, nil
 }
 
-func discoverInstallUpdateTarget(ctx context.Context, home, base string) (string, error) {
+func discoverInstallUpdateTarget(ctx context.Context, home, base, deviceID string) (string, error) {
 	candidates := []string{base, setup.DefaultWiFiTarget()}
 	if cfg, err := runtimeconfig.Load(home); err == nil {
 		candidates = append(candidates, cfg.DeviceTarget)
@@ -651,6 +671,11 @@ func discoverInstallUpdateTarget(ctx context.Context, home, base string) (string
 	})
 	if err != nil {
 		return "", err
+	}
+	expectedDeviceID := strings.TrimSpace(deviceID)
+	discoveredDeviceID := strings.TrimSpace(result.Hello.DeviceID)
+	if expectedDeviceID != "" && discoveredDeviceID != "" && discoveredDeviceID != expectedDeviceID {
+		return "", fmt.Errorf("rediscovered deviceId %q does not match original deviceId %q", discoveredDeviceID, expectedDeviceID)
 	}
 	target, err := normalizeHTTPBaseURL(result.Target)
 	if err != nil {
@@ -1214,7 +1239,10 @@ func uploadFirmwareOTA(ctx context.Context, base, imagePath, token string) error
 	} else if !rawFirmwareUploadUnavailable(err) {
 		return err
 	}
+	return uploadFirmwareOTAMultipart(ctx, base, imagePath, token)
+}
 
+func uploadFirmwareOTAMultipart(ctx context.Context, base, imagePath, token string) error {
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 	part, err := writer.CreateFormFile("firmware", filepath.Base(imagePath))
@@ -1326,7 +1354,7 @@ func rawFirmwareUploadUnavailable(err error) bool {
 		strings.Contains(msg, "404")
 }
 
-func waitForHTTPFirmwareVersion(ctx context.Context, base, version string, timeout time.Duration) error {
+func waitForHTTPFirmwareVersion(ctx context.Context, base, version, deviceID string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for time.Now().Before(deadline) {
@@ -1335,7 +1363,12 @@ func waitForHTTPFirmwareVersion(ctx context.Context, base, version string, timeo
 		}
 		hello, err := fetchDeviceHelloHTTP(ctx, base)
 		if err == nil && normalizeReleaseVersion(hello.Firmware) == normalizeReleaseVersion(version) {
-			return nil
+			expectedDeviceID := strings.TrimSpace(deviceID)
+			observedDeviceID := strings.TrimSpace(hello.DeviceID)
+			if expectedDeviceID == "" || observedDeviceID == expectedDeviceID {
+				return nil
+			}
+			err = fmt.Errorf("device reported deviceId %q, want %q", observedDeviceID, expectedDeviceID)
 		}
 		if err != nil {
 			lastErr = err

--- a/companion/cmd/codexbar-display/release_commands_test.go
+++ b/companion/cmd/codexbar-display/release_commands_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/runtimeconfig"
 	transportlayer "github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/transport"
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/virtualvibetv"
 )
 
 func TestReleaseStateRoundTrip(t *testing.T) {
@@ -613,6 +614,239 @@ func TestRunInstallUpdateDownloadsVerifiesAndUploadsOTA(t *testing.T) {
 		if strings.Contains(output, noisy) {
 			t.Fatalf("expected quiet update output not to contain %q, got:\n%s", noisy, output)
 		}
+	}
+}
+
+func TestRunInstallUpdateAgainstVirtualVibeTVPreventsSecondFlash(t *testing.T) {
+	previousHTTPClient := releaseHTTPClient
+	previousPoll := firmwareHTTPVerifyPollInterval
+	previousUpload := uploadFirmwareOTAFn
+	t.Cleanup(func() {
+		releaseHTTPClient = previousHTTPClient
+		firmwareHTTPVerifyPollInterval = previousPoll
+		uploadFirmwareOTAFn = previousUpload
+	})
+	t.Setenv("HOME", t.TempDir())
+	firmwareHTTPVerifyPollInterval = time.Millisecond
+
+	imageBody := []byte("virtual candidate firmware")
+	imageSum := sha256.Sum256(imageBody)
+	cfg := virtualvibetv.DefaultConfig()
+	cfg.ExpectedFirmwareSHA256 = hex.EncodeToString(imageSum[:])
+	cfg.RebootUnavailableRequests = 2
+	device := virtualvibetv.New(cfg)
+	deviceServer := httptest.NewServer(device)
+	defer deviceServer.Close()
+
+	artifactServerURL := ""
+	artifactServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			_, _ = io.WriteString(w, `{"schemaVersion":1,"release":"v1.0.1","artifacts":[{"firmwareEnv":"esp8266_smalltv_st7789","board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.1","asset":"firmware.bin","firmwareUrl":"`+artifactServerURL+`/firmware.bin","sha256":"`+hex.EncodeToString(imageSum[:])+`"}]}`)
+		case "/firmware.bin":
+			_, _ = w.Write(imageBody)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer artifactServer.Close()
+	artifactServerURL = artifactServer.URL
+	releaseHTTPClient = &http.Client{Timeout: 5 * time.Second}
+	uploadFirmwareOTAFn = uploadFirmwareOTAMultipart
+
+	args := []string{"--target", deviceServer.URL, "--manifest-url", artifactServer.URL + "/manifest.json", "--skip-launchagent-pause"}
+	if _, err := captureStdout(t, func() error { return runInstallUpdate(args) }); err != nil {
+		t.Fatalf("first virtual update: %v", err)
+	}
+	secondOutput, err := captureStdout(t, func() error { return runInstallUpdate(args) })
+	if err != nil {
+		t.Fatalf("second virtual update check: %v", err)
+	}
+	if !strings.Contains(secondOutput, "Firmware: already current (1.0.1)") {
+		t.Fatalf("expected already-current result, got:\n%s", secondOutput)
+	}
+	snapshot := device.Snapshot()
+	if snapshot.UpdateUploads != 1 || snapshot.Firmware != "1.0.1" || len(snapshot.Violations) != 0 {
+		t.Fatalf("unexpected virtual update snapshot: %+v", snapshot)
+	}
+}
+
+func TestRunInstallUpdateVerifiesAcceptedOTAAfterTransportErrorWithoutRetry(t *testing.T) {
+	previousHTTPClient := releaseHTTPClient
+	previousPoll := firmwareHTTPVerifyPollInterval
+	previousUpload := uploadFirmwareOTAFn
+	t.Cleanup(func() {
+		releaseHTTPClient = previousHTTPClient
+		firmwareHTTPVerifyPollInterval = previousPoll
+		uploadFirmwareOTAFn = previousUpload
+	})
+	t.Setenv("HOME", t.TempDir())
+	firmwareHTTPVerifyPollInterval = time.Millisecond
+
+	imageBody := []byte("accepted before response dropped")
+	imageSum := sha256.Sum256(imageBody)
+	cfg := virtualvibetv.DefaultConfig()
+	cfg.ExpectedFirmwareSHA256 = hex.EncodeToString(imageSum[:])
+	cfg.DropUpdateResponseAfterAccept = true
+	cfg.RebootUnavailableRequests = 1
+	device := virtualvibetv.New(cfg)
+	deviceServer := httptest.NewServer(device)
+	defer deviceServer.Close()
+
+	artifactServerURL := ""
+	artifactServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			_, _ = io.WriteString(w, `{"schemaVersion":1,"release":"v1.0.1","artifacts":[{"firmwareEnv":"esp8266_smalltv_st7789","board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.1","asset":"firmware.bin","firmwareUrl":"`+artifactServerURL+`/firmware.bin","sha256":"`+hex.EncodeToString(imageSum[:])+`"}]}`)
+		case "/firmware.bin":
+			_, _ = w.Write(imageBody)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer artifactServer.Close()
+	artifactServerURL = artifactServer.URL
+	releaseHTTPClient = &http.Client{Timeout: 5 * time.Second}
+	uploadFirmwareOTAFn = uploadFirmwareOTAMultipart
+
+	output, err := captureStdout(t, func() error {
+		return runInstallUpdate([]string{"--target", deviceServer.URL, "--manifest-url", artifactServer.URL + "/manifest.json", "--skip-launchagent-pause"})
+	})
+	if err != nil {
+		t.Fatalf("accepted virtual update: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "Checking VibeTV before retrying") || !strings.Contains(output, "Done: firmware 1.0.1 installed") {
+		t.Fatalf("missing accepted-upload verification output:\n%s", output)
+	}
+	snapshot := device.Snapshot()
+	if snapshot.UpdateUploads != 1 || len(snapshot.Violations) != 0 {
+		t.Fatalf("accepted upload was repeated: %+v", snapshot)
+	}
+}
+
+func TestRunInstallUpdateRediscoveryFollowsSameDeviceIDAtNewAddress(t *testing.T) {
+	previousHTTPClient := releaseHTTPClient
+	previousPoll := firmwareHTTPVerifyPollInterval
+	previousRediscoveryAfter := firmwareUpdateRediscoveryAfter
+	previousUpload := uploadFirmwareOTAFn
+	previousDiscover := discoverWiFiDeviceFn
+	t.Cleanup(func() {
+		releaseHTTPClient = previousHTTPClient
+		firmwareHTTPVerifyPollInterval = previousPoll
+		firmwareUpdateRediscoveryAfter = previousRediscoveryAfter
+		uploadFirmwareOTAFn = previousUpload
+		discoverWiFiDeviceFn = previousDiscover
+	})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	firmwareHTTPVerifyPollInterval = time.Millisecond
+	firmwareUpdateRediscoveryAfter = 2 * time.Millisecond
+
+	imageBody := []byte("candidate moving to another address")
+	imageSum := sha256.Sum256(imageBody)
+	cfg := virtualvibetv.DefaultConfig()
+	cfg.ExpectedFirmwareSHA256 = hex.EncodeToString(imageSum[:])
+	cfg.RebootUnavailableRequests = 0
+	device := virtualvibetv.New(cfg)
+	newAddress := httptest.NewServer(device)
+	defer newAddress.Close()
+	oldAddress := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/hello" && device.Snapshot().UpdateUploads > 0 {
+			http.Error(w, "old address unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		device.ServeHTTP(w, r)
+	}))
+	defer oldAddress.Close()
+
+	artifactServerURL := ""
+	artifactServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			_, _ = io.WriteString(w, `{"schemaVersion":1,"release":"v1.0.1","artifacts":[{"firmwareEnv":"esp8266_smalltv_st7789","board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.1","asset":"firmware.bin","firmwareUrl":"`+artifactServerURL+`/firmware.bin","sha256":"`+hex.EncodeToString(imageSum[:])+`"}]}`)
+		case "/firmware.bin":
+			_, _ = w.Write(imageBody)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer artifactServer.Close()
+	artifactServerURL = artifactServer.URL
+
+	releaseHTTPClient = &http.Client{Timeout: 5 * time.Second}
+	uploadFirmwareOTAFn = uploadFirmwareOTAMultipart
+	discoverWiFiDeviceFn = func(context.Context, transportlayer.WiFiDiscoveryOptions) (transportlayer.WiFiDiscoveryResult, error) {
+		return transportlayer.WiFiDiscoveryResult{
+			Target: newAddress.URL,
+			Hello:  protocol.DeviceHello{DeviceID: cfg.DeviceID, Firmware: cfg.CandidateFirmware},
+			Source: "virtual-ip-change",
+		}, nil
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runInstallUpdate([]string{
+			"--target", oldAddress.URL,
+			"--manifest-url", artifactServer.URL + "/manifest.json",
+			"--skip-launchagent-pause",
+		})
+	})
+	if err != nil {
+		t.Fatalf("rediscovered virtual update: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "Using rediscovered VibeTV address: "+newAddress.URL) {
+		t.Fatalf("missing address-change evidence:\n%s", output)
+	}
+	saved, err := runtimeconfig.Load(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved.DeviceTarget != newAddress.URL {
+		t.Fatalf("rediscovered target was not saved: %+v", saved)
+	}
+	if snapshot := device.Snapshot(); snapshot.UpdateUploads != 1 || len(snapshot.Violations) != 0 {
+		t.Fatalf("unexpected rediscovered device state: %+v", snapshot)
+	}
+}
+
+func TestFirmwareRediscoveryRejectsDifferentDeviceID(t *testing.T) {
+	previousPoll := firmwareHTTPVerifyPollInterval
+	previousRediscoveryAfter := firmwareUpdateRediscoveryAfter
+	previousDiscover := discoverWiFiDeviceFn
+	t.Cleanup(func() {
+		firmwareHTTPVerifyPollInterval = previousPoll
+		firmwareUpdateRediscoveryAfter = previousRediscoveryAfter
+		discoverWiFiDeviceFn = previousDiscover
+	})
+	firmwareHTTPVerifyPollInterval = time.Millisecond
+	firmwareUpdateRediscoveryAfter = 2 * time.Millisecond
+
+	oldAddress := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "old address unavailable", http.StatusServiceUnavailable)
+	}))
+	defer oldAddress.Close()
+	wrongDevice := virtualvibetv.DefaultConfig()
+	wrongDevice.DeviceID = "different-device"
+	wrongDevice.Firmware = wrongDevice.CandidateFirmware
+	wrongServer := httptest.NewServer(virtualvibetv.New(wrongDevice))
+	defer wrongServer.Close()
+	discoverWiFiDeviceFn = func(context.Context, transportlayer.WiFiDiscoveryOptions) (transportlayer.WiFiDiscoveryResult, error) {
+		return transportlayer.WiFiDiscoveryResult{
+			Target: wrongServer.URL,
+			Hello:  protocol.DeviceHello{DeviceID: wrongDevice.DeviceID, Firmware: wrongDevice.Firmware},
+			Source: "virtual-wrong-device",
+		}, nil
+	}
+
+	_, err := waitForHTTPFirmwareVersionWithDiscovery(
+		context.Background(),
+		t.TempDir(),
+		oldAddress.URL,
+		wrongDevice.Firmware,
+		"expected-device",
+		10*time.Millisecond,
+	)
+	if err == nil || !strings.Contains(err.Error(), "does not match original deviceId") {
+		t.Fatalf("wrong rediscovered device was not rejected: %v", err)
 	}
 }
 

--- a/companion/cmd/virtual-vibetv/main.go
+++ b/companion/cmd/virtual-vibetv/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/virtualvibetv"
+)
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:47834", "listen address")
+	deviceID := flag.String("device-id", "virtual-vibetv-001", "stable virtual device ID")
+	firmware := flag.String("firmware", "1.0.0", "installed firmware version")
+	candidate := flag.String("candidate-firmware", "1.0.1", "version applied after a valid OTA upload")
+	token := flag.String("token", "virtual-pair-token", "pairing token required by write endpoints")
+	expectedSHA := flag.String("expected-firmware-sha256", "", "optional SHA-256 required for OTA uploads")
+	scenario := flag.String("scenario", "normal", "normal|different-device|never-returns|health-unhealthy|render-fails|stream-restart-fails|accepted-transport-error")
+	rebootRequests := flag.Int("reboot-unavailable-requests", 2, "number of requests returning 503 after OTA")
+	flag.Parse()
+
+	cfg := virtualvibetv.DefaultConfig()
+	cfg.DeviceID = strings.TrimSpace(*deviceID)
+	cfg.Firmware = strings.TrimSpace(*firmware)
+	cfg.CandidateFirmware = strings.TrimSpace(*candidate)
+	cfg.PairingToken = strings.TrimSpace(*token)
+	cfg.ExpectedFirmwareSHA256 = strings.TrimSpace(*expectedSHA)
+	cfg.RebootUnavailableRequests = *rebootRequests
+	switch strings.TrimSpace(*scenario) {
+	case "normal":
+	case "different-device":
+		cfg.DeviceIDAfterUpdate = cfg.DeviceID + "-different"
+	case "never-returns":
+		cfg.NeverReturnsAfterUpdate = true
+	case "health-unhealthy":
+		cfg.HealthUnhealthy = true
+	case "render-fails":
+		cfg.RenderVerificationFails = true
+	case "stream-restart-fails":
+		cfg.StreamRestartFails = true
+	case "accepted-transport-error":
+		cfg.DropUpdateResponseAfterAccept = true
+	default:
+		fmt.Fprintf(os.Stderr, "unknown scenario %q\n", *scenario)
+		os.Exit(2)
+	}
+
+	device := virtualvibetv.New(cfg)
+	server := &http.Server{Addr: *addr, Handler: device, ReadHeaderTimeout: 5 * time.Second}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	fmt.Printf("Virtual VibeTV listening on http://%s deviceId=%s firmware=%s candidate=%s scenario=%s\n", *addr, cfg.DeviceID, cfg.Firmware, cfg.CandidateFirmware, *scenario)
+	err := server.ListenAndServe()
+	snapshot := device.Snapshot()
+	_ = json.NewEncoder(os.Stdout).Encode(snapshot)
+	if err != nil && err != http.ErrServerClosed {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/companion/internal/virtualvibetv/server.go
+++ b/companion/internal/virtualvibetv/server.go
@@ -1,0 +1,496 @@
+package virtualvibetv
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
+)
+
+const maxUploadBytes = 8 << 20
+
+// Config describes one deterministic Virtual VibeTV scenario.
+type Config struct {
+	DeviceID                      string
+	DeviceIDAfterUpdate           string
+	Board                         string
+	Firmware                      string
+	CandidateFirmware             string
+	PairingToken                  string
+	ExpectedFirmwareSHA256        string
+	RebootUnavailableRequests     int
+	NeverReturnsAfterUpdate       bool
+	HealthUnhealthy               bool
+	RenderVerificationFails       bool
+	StreamRestartFails            bool
+	DropUpdateResponseAfterAccept bool
+	RejectUnnecessarySecondFlash  bool
+}
+
+func DefaultConfig() Config {
+	return Config{
+		DeviceID:                     "virtual-vibetv-001",
+		Board:                        "esp8266-smalltv-st7789",
+		Firmware:                     "1.0.0",
+		CandidateFirmware:            "1.0.1",
+		PairingToken:                 "virtual-pair-token",
+		RebootUnavailableRequests:    2,
+		RejectUnnecessarySecondFlash: true,
+	}
+}
+
+type Event struct {
+	Sequence int    `json:"sequence"`
+	At       string `json:"at"`
+	Method   string `json:"method"`
+	Path     string `json:"path"`
+	Status   int    `json:"status"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+type Asset struct {
+	Path      string `json:"path"`
+	SizeBytes int64  `json:"sizeBytes"`
+	SHA256    string `json:"sha256"`
+}
+
+type Snapshot struct {
+	DeviceID          string          `json:"deviceId"`
+	Firmware          string          `json:"firmware"`
+	ActiveTheme       string          `json:"activeTheme"`
+	ActiveThemePath   string          `json:"activeThemePath,omitempty"`
+	ActiveThemeSHA256 string          `json:"activeThemeSha256,omitempty"`
+	UpdateUploads     int             `json:"updateUploads"`
+	FramesAccepted    int             `json:"framesAccepted"`
+	LastFrame         json.RawMessage `json:"lastFrame,omitempty"`
+	Assets            []Asset         `json:"assets,omitempty"`
+	Violations        []string        `json:"violations,omitempty"`
+	Events            []Event         `json:"events"`
+}
+
+type Server struct {
+	mu sync.Mutex
+
+	cfg Config
+
+	firmware            string
+	activeTheme         string
+	activeThemePath     string
+	activeThemeSHA256   string
+	assets              map[string][]byte
+	lastFrame           json.RawMessage
+	framesAccepted      int
+	updateUploads       int
+	offlineRequestsLeft int
+	droppedUpdateReply  bool
+	violations          []string
+	events              []Event
+}
+
+func New(cfg Config) *Server {
+	defaults := DefaultConfig()
+	if strings.TrimSpace(cfg.DeviceID) == "" {
+		cfg.DeviceID = defaults.DeviceID
+	}
+	if strings.TrimSpace(cfg.Board) == "" {
+		cfg.Board = defaults.Board
+	}
+	if strings.TrimSpace(cfg.Firmware) == "" {
+		cfg.Firmware = defaults.Firmware
+	}
+	if strings.TrimSpace(cfg.CandidateFirmware) == "" {
+		cfg.CandidateFirmware = defaults.CandidateFirmware
+	}
+	if strings.TrimSpace(cfg.PairingToken) == "" {
+		cfg.PairingToken = defaults.PairingToken
+	}
+	return &Server{
+		cfg:         cfg,
+		firmware:    strings.TrimSpace(cfg.Firmware),
+		activeTheme: "mini-classic",
+		assets:      make(map[string][]byte),
+	}
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.temporarilyUnavailable(w, r) {
+		return
+	}
+
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == "/hello":
+		s.handleHello(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/health":
+		s.handleHealth(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/api/pair":
+		s.handlePair(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/frame":
+		s.handleFrame(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/assets":
+		s.handleAssets(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/assets":
+		s.handleAssetUpload(w, r)
+	case r.Method == http.MethodDelete && r.URL.Path == "/assets":
+		s.handleAssetDelete(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/theme/active":
+		s.handleThemeActive(w, r)
+	case r.Method == http.MethodPost && (r.URL.Path == "/update" || r.URL.Path == "/update/firmware" || r.URL.Path == "/update/firmware.raw"):
+		s.handleFirmwareUpdate(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/framebuffer":
+		s.handleFramebuffer(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/__virtual/state":
+		s.writeJSON(w, r, http.StatusOK, s.Snapshot(), "")
+	default:
+		s.respond(w, r, http.StatusNotFound, "not found", "")
+	}
+}
+
+func (s *Server) Snapshot() Snapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	assets := make([]Asset, 0, len(s.assets))
+	for path, data := range s.assets {
+		assets = append(assets, Asset{Path: path, SizeBytes: int64(len(data)), SHA256: sha256Hex(data)})
+	}
+	sort.Slice(assets, func(i, j int) bool { return assets[i].Path < assets[j].Path })
+	return Snapshot{
+		DeviceID:          s.currentDeviceIDLocked(),
+		Firmware:          s.firmware,
+		ActiveTheme:       s.activeTheme,
+		ActiveThemePath:   s.activeThemePath,
+		ActiveThemeSHA256: s.activeThemeSHA256,
+		UpdateUploads:     s.updateUploads,
+		FramesAccepted:    s.framesAccepted,
+		LastFrame:         append(json.RawMessage(nil), s.lastFrame...),
+		Assets:            assets,
+		Violations:        append([]string(nil), s.violations...),
+		Events:            append([]Event(nil), s.events...),
+	}
+}
+
+func (s *Server) handleHello(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	firmware := s.firmware
+	deviceID := s.currentDeviceIDLocked()
+	s.mu.Unlock()
+	hello := protocol.DeviceHello{
+		Kind:                      "hello",
+		ProtocolVersion:           2,
+		SupportedProtocolVersions: []int{2, 1},
+		PreferredProtocolVersion:  2,
+		Board:                     s.cfg.Board,
+		Firmware:                  firmware,
+		DeviceID:                  deviceID,
+		NetworkMode:               "station",
+		Features:                  []string{protocol.FeatureTheme, protocol.FeatureThemeSpecV1},
+		MaxFrameBytes:             4096,
+		Capabilities: protocol.CapabilityBlock{
+			Display: protocol.DisplayCapabilities{WidthPx: 240, HeightPx: 240, ColorDepthBits: 16},
+			Theme: protocol.ThemeCapabilities{
+				SupportsThemeSpecV1: true,
+				MaxThemeSpecBytes:   4096,
+				MaxThemePrimitives:  64,
+				BuiltinThemes:       []string{"mini-classic", "claude-creature"},
+			},
+			Transport: protocol.TransportCapabilities{Active: "wifi", Supported: []string{"usb", "wifi"}, Mode: "station"},
+		},
+	}
+	s.writeJSON(w, r, http.StatusOK, hello, "")
+}
+
+func (s *Server) currentDeviceIDLocked() string {
+	if s.updateUploads > 0 && strings.TrimSpace(s.cfg.DeviceIDAfterUpdate) != "" {
+		return strings.TrimSpace(s.cfg.DeviceIDAfterUpdate)
+	}
+	return strings.TrimSpace(s.cfg.DeviceID)
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	payload := map[string]any{
+		"ok": !s.cfg.HealthUnhealthy,
+		"display": map[string]any{
+			"activeTheme": s.activeTheme,
+			"themeSpec": map[string]any{
+				"active":         s.activeThemePath != "",
+				"path":           s.activeThemePath,
+				"hash":           s.activeThemeSHA256,
+				"renderOk":       !s.cfg.RenderVerificationFails,
+				"renderError":    renderError(s.cfg.RenderVerificationFails),
+				"renderFailures": boolInt(s.cfg.RenderVerificationFails),
+			},
+		},
+		"stream": map[string]any{
+			"healthy": !s.cfg.StreamRestartFails,
+		},
+	}
+	s.mu.Unlock()
+	s.writeJSON(w, r, http.StatusOK, payload, "")
+}
+
+func (s *Server) handlePair(w http.ResponseWriter, r *http.Request) {
+	s.writeJSON(w, r, http.StatusOK, map[string]any{"ok": true, "token": s.cfg.PairingToken}, "paired")
+}
+
+func (s *Server) handleFrame(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(w, r) {
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 4097))
+	if err != nil || len(body) == 0 || len(body) > 4096 || !json.Valid(body) {
+		s.respond(w, r, http.StatusBadRequest, "invalid frame", "invalid frame")
+		return
+	}
+	s.mu.Lock()
+	s.lastFrame = append(s.lastFrame[:0], body...)
+	s.framesAccepted++
+	s.mu.Unlock()
+	s.respond(w, r, http.StatusOK, "ok", "frame accepted")
+}
+
+func (s *Server) handleAssets(w http.ResponseWriter, r *http.Request) {
+	snapshot := s.Snapshot()
+	s.writeJSON(w, r, http.StatusOK, map[string]any{"mounted": true, "assets": snapshot.Assets}, "")
+}
+
+func (s *Server) handleAssetUpload(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(w, r) {
+		return
+	}
+	path := cleanAssetPath(r.URL.Query().Get("path"))
+	if path == "" {
+		s.respond(w, r, http.StatusBadRequest, "asset path required", "missing asset path")
+		return
+	}
+	data, err := readMultipartFile(r, "asset")
+	if err != nil {
+		s.respond(w, r, http.StatusBadRequest, err.Error(), "invalid asset")
+		return
+	}
+	s.mu.Lock()
+	s.assets[path] = append([]byte(nil), data...)
+	s.mu.Unlock()
+	s.respond(w, r, http.StatusOK, "ok", "asset uploaded "+path)
+}
+
+func (s *Server) handleAssetDelete(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(w, r) {
+		return
+	}
+	path := cleanAssetPath(r.URL.Query().Get("path"))
+	s.mu.Lock()
+	if path == s.activeThemePath {
+		s.mu.Unlock()
+		s.respond(w, r, http.StatusConflict, "active theme cannot be deleted", "active asset delete rejected")
+		return
+	}
+	delete(s.assets, path)
+	s.mu.Unlock()
+	s.respond(w, r, http.StatusOK, "ok", "asset deleted "+path)
+}
+
+func (s *Server) handleThemeActive(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(w, r) {
+		return
+	}
+	var request struct {
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&request); err != nil {
+		s.respond(w, r, http.StatusBadRequest, "invalid theme activation", "invalid theme activation")
+		return
+	}
+	path := cleanAssetPath(request.Path)
+	s.mu.Lock()
+	data, ok := s.assets[path]
+	if ok {
+		s.activeThemePath = path
+		s.activeTheme = strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		s.activeThemeSHA256 = sha256Hex(data)
+	}
+	s.mu.Unlock()
+	if !ok {
+		s.respond(w, r, http.StatusNotFound, "theme not found", "theme activation missing asset")
+		return
+	}
+	s.writeJSON(w, r, http.StatusOK, map[string]any{"ok": true, "path": path, "hash": sha256Hex(data)}, "theme activated "+path)
+}
+
+func (s *Server) handleFirmwareUpdate(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(w, r) {
+		return
+	}
+	data, err := readFirmwareBody(r)
+	if err != nil {
+		s.respond(w, r, http.StatusBadRequest, err.Error(), "invalid firmware upload")
+		return
+	}
+	actualSHA := sha256Hex(data)
+	expectedSHA := strings.ToLower(strings.TrimSpace(s.cfg.ExpectedFirmwareSHA256))
+	if expectedSHA != "" && actualSHA != expectedSHA {
+		s.respond(w, r, http.StatusUnprocessableEntity, "firmware sha256 mismatch", "firmware sha256 mismatch")
+		return
+	}
+
+	s.mu.Lock()
+	if s.cfg.RejectUnnecessarySecondFlash && s.firmware == strings.TrimSpace(s.cfg.CandidateFirmware) {
+		s.violations = append(s.violations, "unnecessary second firmware flash")
+		s.mu.Unlock()
+		s.respond(w, r, http.StatusConflict, "firmware already current", "second flash rejected")
+		return
+	}
+	s.updateUploads++
+	s.firmware = strings.TrimSpace(s.cfg.CandidateFirmware)
+	s.offlineRequestsLeft = s.cfg.RebootUnavailableRequests
+	dropReply := s.cfg.DropUpdateResponseAfterAccept && !s.droppedUpdateReply
+	if dropReply {
+		s.droppedUpdateReply = true
+	}
+	s.mu.Unlock()
+
+	if dropReply {
+		s.record(r, 0, "firmware accepted; response connection dropped")
+		if hijacker, ok := w.(http.Hijacker); ok {
+			conn, _, hijackErr := hijacker.Hijack()
+			if hijackErr == nil {
+				_ = conn.Close()
+				return
+			}
+		}
+		return
+	}
+	s.respond(w, r, http.StatusOK, "ok", "firmware accepted sha256="+actualSHA)
+}
+
+func (s *Server) handleFramebuffer(w http.ResponseWriter, r *http.Request) {
+	snapshot := s.Snapshot()
+	s.writeJSON(w, r, http.StatusOK, map[string]any{
+		"renderOk": !s.cfg.RenderVerificationFails,
+		"frame":    snapshot.LastFrame,
+	}, "")
+}
+
+func (s *Server) temporarilyUnavailable(w http.ResponseWriter, r *http.Request) bool {
+	s.mu.Lock()
+	unavailable := false
+	if s.cfg.NeverReturnsAfterUpdate && s.updateUploads > 0 {
+		unavailable = true
+	} else if s.offlineRequestsLeft > 0 {
+		s.offlineRequestsLeft--
+		unavailable = true
+	}
+	s.mu.Unlock()
+	if unavailable {
+		s.respond(w, r, http.StatusServiceUnavailable, "rebooting", "temporarily unavailable")
+	}
+	return unavailable
+}
+
+func (s *Server) authorize(w http.ResponseWriter, r *http.Request) bool {
+	expected := strings.TrimSpace(s.cfg.PairingToken)
+	if expected == "" || r.Header.Get("X-VibeTV-Token") == expected || r.URL.Query().Get("token") == expected {
+		return true
+	}
+	s.respond(w, r, http.StatusUnauthorized, "pairing token required", "authentication rejected")
+	return false
+}
+
+func (s *Server) writeJSON(w http.ResponseWriter, r *http.Request, status int, payload any, detail string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+	s.record(r, status, detail)
+}
+
+func (s *Server) respond(w http.ResponseWriter, r *http.Request, status int, body, detail string) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, body)
+	s.record(r, status, detail)
+}
+
+func (s *Server) record(r *http.Request, status int, detail string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, Event{
+		Sequence: len(s.events) + 1,
+		At:       time.Now().UTC().Format(time.RFC3339Nano),
+		Method:   r.Method,
+		Path:     r.URL.Path,
+		Status:   status,
+		Detail:   detail,
+	})
+}
+
+func readFirmwareBody(r *http.Request) ([]byte, error) {
+	if strings.HasPrefix(strings.ToLower(r.Header.Get("Content-Type")), "multipart/form-data") {
+		return readMultipartFile(r, "firmware")
+	}
+	data, err := io.ReadAll(io.LimitReader(r.Body, maxUploadBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("firmware body required")
+	}
+	if len(data) > maxUploadBytes {
+		return nil, fmt.Errorf("firmware body too large")
+	}
+	return data, nil
+}
+
+func readMultipartFile(r *http.Request, field string) ([]byte, error) {
+	if err := r.ParseMultipartForm(maxUploadBytes); err != nil {
+		return nil, fmt.Errorf("parse multipart: %w", err)
+	}
+	file, _, err := r.FormFile(field)
+	if err != nil {
+		return nil, fmt.Errorf("multipart field %q required: %w", field, err)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maxUploadBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxUploadBytes {
+		return nil, fmt.Errorf("multipart field %q too large", field)
+	}
+	return data, nil
+}
+
+func cleanAssetPath(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || !strings.HasPrefix(raw, "/") || strings.Contains(raw, "..") {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(raw))
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func renderError(failed bool) string {
+	if failed {
+		return "simulated render verification failure"
+	}
+	return ""
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/companion/internal/virtualvibetv/server_test.go
+++ b/companion/internal/virtualvibetv/server_test.go
@@ -1,0 +1,226 @@
+package virtualvibetv
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/transport"
+)
+
+func TestVirtualVibeTVImplementsCompanionFrameAndThemeContract(t *testing.T) {
+	device := New(DefaultConfig())
+	server := httptest.NewServer(device)
+	defer server.Close()
+
+	wifi := transport.NewWiFiTransportWithClient(server.Client())
+	target := server.URL + "?token=virtual-pair-token"
+	caps, err := wifi.DeviceCapabilities(target)
+	if err != nil {
+		t.Fatalf("device capabilities: %v", err)
+	}
+	if !caps.Known || caps.Board != "esp8266-smalltv-st7789" || caps.Firmware != "1.0.0" {
+		t.Fatalf("unexpected capabilities: %+v", caps)
+	}
+	if err := wifi.SendLine(target, []byte(`{"v":1,"theme":"mini-classic","label":"virtual"}`)); err != nil {
+		t.Fatalf("send frame: %v", err)
+	}
+	theme := []byte(`{"v":1,"id":"test-theme","rev":1,"fb":"mini"}`)
+	if err := wifi.UploadAsset(target, "/themes/u/test-theme.json", "test-theme.json", theme); err != nil {
+		t.Fatalf("upload theme: %v", err)
+	}
+	if err := wifi.ActivateStoredTheme(target, "/themes/u/test-theme.json"); err != nil {
+		t.Fatalf("activate theme: %v", err)
+	}
+	health, err := wifi.DeviceHealthSnapshot(target)
+	if err != nil {
+		t.Fatalf("device health: %v", err)
+	}
+	if !health.OK || health.Display.ThemeSpec.Path != "/themes/u/test-theme.json" || !health.Display.ThemeSpec.RenderOk {
+		t.Fatalf("unexpected health: %+v", health)
+	}
+
+	snapshot := device.Snapshot()
+	if snapshot.FramesAccepted != 1 || snapshot.ActiveTheme != "test-theme" || len(snapshot.Assets) != 1 {
+		t.Fatalf("unexpected simulator snapshot: %+v", snapshot)
+	}
+}
+
+func TestVirtualVibeTVValidatesFirmwareAndRejectsSecondFlash(t *testing.T) {
+	firmware := []byte("candidate firmware")
+	sum := sha256.Sum256(firmware)
+	cfg := DefaultConfig()
+	cfg.ExpectedFirmwareSHA256 = hex.EncodeToString(sum[:])
+	cfg.RebootUnavailableRequests = 0
+	device := New(cfg)
+	server := httptest.NewServer(device)
+	defer server.Close()
+
+	upload := func(body []byte) *http.Response {
+		req, err := http.NewRequest(http.MethodPost, server.URL+"/update/firmware", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("X-VibeTV-Token", cfg.PairingToken)
+		resp, err := server.Client().Do(req)
+		if err != nil {
+			t.Fatalf("firmware upload: %v", err)
+		}
+		return resp
+	}
+
+	bad := upload([]byte("wrong firmware"))
+	_ = bad.Body.Close()
+	if bad.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("bad firmware status=%d", bad.StatusCode)
+	}
+	good := upload(firmware)
+	_ = good.Body.Close()
+	if good.StatusCode != http.StatusOK {
+		t.Fatalf("good firmware status=%d", good.StatusCode)
+	}
+	second := upload(firmware)
+	_ = second.Body.Close()
+	if second.StatusCode != http.StatusConflict {
+		t.Fatalf("second firmware status=%d", second.StatusCode)
+	}
+
+	snapshot := device.Snapshot()
+	if snapshot.Firmware != cfg.CandidateFirmware || snapshot.UpdateUploads != 1 || len(snapshot.Violations) != 1 {
+		t.Fatalf("unexpected update snapshot: %+v", snapshot)
+	}
+}
+
+func TestVirtualVibeTVScenarioReportsUnhealthyRenderAndFramebuffer(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.HealthUnhealthy = true
+	cfg.RenderVerificationFails = true
+	device := New(cfg)
+	server := httptest.NewServer(device)
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var health struct {
+		OK      bool `json:"ok"`
+		Display struct {
+			ThemeSpec struct {
+				RenderOK bool `json:"renderOk"`
+			} `json:"themeSpec"`
+		} `json:"display"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		t.Fatal(err)
+	}
+	if health.OK || health.Display.ThemeSpec.RenderOK {
+		t.Fatalf("scenario unexpectedly healthy: %+v", health)
+	}
+}
+
+func TestVirtualVibeTVDifferentDeviceScenarioRequiresAuthentication(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DeviceID = "expected-device"
+	cfg.DeviceIDAfterUpdate = "different-device"
+	cfg.RebootUnavailableRequests = 0
+	device := New(cfg)
+	server := httptest.NewServer(device)
+	defer server.Close()
+
+	unauthorized, err := http.Post(server.URL+"/update/firmware", "application/octet-stream", bytes.NewReader([]byte("firmware")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = unauthorized.Body.Close()
+	if unauthorized.StatusCode != http.StatusUnauthorized || device.Snapshot().UpdateUploads != 0 {
+		t.Fatalf("unauthorized update was not rejected: status=%d snapshot=%+v", unauthorized.StatusCode, device.Snapshot())
+	}
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/update/firmware", bytes.NewReader([]byte("firmware")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-VibeTV-Token", cfg.PairingToken)
+	updated, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = updated.Body.Close()
+	if updated.StatusCode != http.StatusOK {
+		t.Fatalf("authenticated update status=%d", updated.StatusCode)
+	}
+
+	helloResponse, err := server.Client().Get(server.URL + "/hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer helloResponse.Body.Close()
+	var hello struct {
+		DeviceID string `json:"deviceId"`
+		Firmware string `json:"firmware"`
+	}
+	if err := json.NewDecoder(helloResponse.Body).Decode(&hello); err != nil {
+		t.Fatal(err)
+	}
+	if hello.DeviceID != cfg.DeviceIDAfterUpdate || hello.Firmware != cfg.CandidateFirmware {
+		t.Fatalf("unexpected post-update identity: %+v", hello)
+	}
+}
+
+func TestVirtualVibeTVNeverReturnsAndStreamFailureScenarios(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.NeverReturnsAfterUpdate = true
+	cfg.StreamRestartFails = true
+	cfg.RebootUnavailableRequests = 0
+	device := New(cfg)
+	server := httptest.NewServer(device)
+	defer server.Close()
+
+	healthResponse, err := server.Client().Get(server.URL + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var health struct {
+		Stream struct {
+			Healthy bool `json:"healthy"`
+		} `json:"stream"`
+	}
+	if err := json.NewDecoder(healthResponse.Body).Decode(&health); err != nil {
+		_ = healthResponse.Body.Close()
+		t.Fatal(err)
+	}
+	_ = healthResponse.Body.Close()
+	if health.Stream.Healthy {
+		t.Fatal("stream-restart-fails scenario reported a healthy stream")
+	}
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/update/firmware", bytes.NewReader([]byte("firmware")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-VibeTV-Token", cfg.PairingToken)
+	updated, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = updated.Body.Close()
+	if updated.StatusCode != http.StatusOK {
+		t.Fatalf("update status=%d", updated.StatusCode)
+	}
+	for attempt := 0; attempt < 2; attempt++ {
+		response, err := server.Client().Get(server.URL + "/hello")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = response.Body.Close()
+		if response.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("never-returns attempt %d status=%d", attempt+1, response.StatusCode)
+		}
+	}
+}

--- a/docs/virtual-vibetv.md
+++ b/docs/virtual-vibetv.md
@@ -1,0 +1,64 @@
+# Virtual VibeTV
+
+Virtual VibeTV is a lightweight, protocol-faithful simulator of the observable
+VibeTV device behavior. It reproduces the real Companion HTTP, theme, frame, and
+OTA flow without physical hardware, so the update client can be exercised
+deterministically on every commit. It does **not** emulate the ESP8266 processor,
+Wi-Fi, bootloader, flash timing, or display timing.
+
+This is the first layer of the release-candidate testing described in issue #177.
+The macOS VM snapshot and private-candidate-artifact layers are added separately.
+
+## What it simulates
+
+Virtual VibeTV supports:
+
+- stable `deviceId`, firmware version, capabilities, and pairing token;
+- `GET /hello`, `GET /health`, and `GET /assets`;
+- authenticated `POST /frame`, asset upload/delete, and `POST /theme/active`;
+- `POST /update`, `POST /update/firmware`, and `POST /update/firmware.raw`;
+- candidate SHA-256 validation and simulated reboot unavailability;
+- prevention and reporting of an unnecessary second flash;
+- unhealthy health, render failure, stream restart failure, device-never-returns,
+  and accepted-upload/transport-error scenarios;
+- wrong-device rejection and same-`deviceId` rediscovery at a changed address;
+- a status timeline and virtual framebuffer.
+
+Simulator-only read endpoints are:
+
+- `GET /__virtual/state`: machine-readable state, writes, violations, and event timeline;
+- `GET /framebuffer`: last accepted frame and render result.
+
+## Scenarios
+
+`--scenario` selects one deterministic behavior:
+
+| Scenario                   | Behavior verified                                                        |
+| -------------------------- | ------------------------------------------------------------------------ |
+| `normal`                   | full happy-path OTA, reboot, rediscovery, health, stream, render         |
+| `different-device`         | a different `deviceId` responds after the update and is rejected         |
+| `never-returns`            | the device never comes back after the update                            |
+| `health-unhealthy`         | `/health` keeps reporting an unhealthy device                            |
+| `render-fails`             | render verification fails                                                 |
+| `stream-restart-fails`     | the stream does not restart cleanly                                      |
+| `accepted-transport-error` | the OTA is accepted but the HTTP acknowledgement is dropped              |
+
+## Run it locally
+
+```bash
+cd companion
+go run ./cmd/virtual-vibetv \
+  --firmware 1.0.43 \
+  --candidate-firmware 1.0.44 \
+  --scenario normal
+```
+
+The real firmware update client is exercised against the simulator by the Go
+integration tests in `companion/cmd/codexbar-display/release_commands_test.go`,
+which run as part of `go test ./...` on every commit. Those tests prove, among
+other things, that:
+
+- `already_current` firmware performs no OTA upload and reports no second flash;
+- an accepted OTA that then drops its HTTP acknowledgement is not blindly
+  re-flashed — the client verifies the candidate version before retrying;
+- rediscovery only accepts a device reporting the original `deviceId`.


### PR DESCRIPTION
Part 1 of 2 splitting issue #177 into a fully-CI-verifiable deterministic core and a hardware-gated VM layer (#177 part 2/2 stacks on this branch).

## What this adds
The first two layers of the issue's test pyramid — native tests and a protocol-faithful **Virtual VibeTV** — plus the real firmware-update-client hardening they verify. Everything here runs green under `go test ./...` today, with no dedicated hardware.

- **`internal/virtualvibetv`** — lightweight, deterministic simulator of observable VibeTV behavior (Companion HTTP, theme, frame, OTA). Configurable scenarios: `different-device`, `never-returns`, `health-unhealthy`, `render-fails`, `stream-restart-fails`, `accepted-transport-error`. Validates artifact SHA-256, simulates reboot unavailability, prevents/reports an unnecessary second flash, and exposes a framebuffer + event timeline. It does **not** emulate the ESP8266, Wi-Fi, bootloader, or flash timing — by design.
- **`cmd/virtual-vibetv`** — runnable entry point.
- **`release_commands.go`** — real update-client fixes exercised by the simulator:
  - an accepted OTA whose HTTP acknowledgement is dropped is **not** blindly re-flashed; the client verifies the candidate version first.
  - rediscovery rejects a device whose `deviceId` differs from the original.
- **`release_commands_test.go`** — drives the real OTA client against the simulator across all scenarios.

## Acceptance criteria covered (from #177)
- `already_current` performs no OTA upload.
- An accepted OTA is not blindly repeated after a temporary follow-up failure.
- Wrong-device, never-returns, health, stream, and render scenarios are automated and deterministic.

## Deferred to part 2/2
macOS VM snapshots (Tart), private candidate artifacts, Sparkle signing/notarization, and the single-command orchestrator — those need the `codex-vibetv-rc` Apple-Silicon runner to be verifiable, so they land separately once that runner exists.

Refs #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)