### PR TITLE
CODEX: Add macOS VM + private candidate release-candidate layer (#177 part 2/2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
         working-directory: companion
         run: go test ./...
 
+      - name: Test release-candidate infrastructure contract
+        run: ./scripts/test-release-candidate-contract.sh
+
       - name: Install staticcheck
         working-directory: companion
         run: go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,284 @@
+name: CODEX Test VibeTV Release Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Candidate commit SHA or branch
+        required: true
+        type: string
+      candidate:
+        description: Candidate Mac App SemVer
+        required: true
+        type: string
+      candidate_firmware:
+        description: Candidate firmware SemVer
+        required: true
+        type: string
+      from_app:
+        description: Currently public Mac App SemVer
+        required: true
+        type: string
+      legacy_app:
+        description: Previous public or migration-floor Mac App SemVer
+        required: true
+        type: string
+      from_firmware:
+        description: Currently public firmware SemVer
+        required: true
+        type: string
+      run_vm:
+        description: Run clean, legacy, and native Tart snapshots
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codex-vibetv-release-candidate
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - name: Checkout requested source without credentials
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref }}
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: companion/go.mod
+          cache-dependency-path: companion/go.sum
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: apps/control-center/package-lock.json
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Validate candidate inputs
+        env:
+          CANDIDATE: ${{ inputs.candidate }}
+          CANDIDATE_FIRMWARE: ${{ inputs.candidate_firmware }}
+        run: |
+          set -euo pipefail
+          semver='^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'
+          [[ "${CANDIDATE#v}" =~ $semver ]]
+          [[ "${CANDIDATE_FIRMWARE#v}" =~ $semver ]]
+
+      - name: Build private candidate inputs
+        env:
+          CANDIDATE: ${{ inputs.candidate }}
+          CANDIDATE_FIRMWARE: ${{ inputs.candidate_firmware }}
+        run: |
+          set -euo pipefail
+          candidate="${CANDIDATE#v}"
+          candidate_firmware="${CANDIDATE_FIRMWARE#v}"
+          source_sha="$(git rev-parse HEAD)"
+          mkdir -p tmp/release-candidate dist/macos
+
+          (
+            cd apps/control-center
+            npm ci
+            npm run build:local
+          )
+          rm -rf companion/internal/companionapi/controlcenter_static
+          mkdir -p companion/internal/companionapi/controlcenter_static
+          cp -R apps/control-center/out-local/. companion/internal/companionapi/controlcenter_static/
+
+          (
+            cd companion
+            for arch in amd64 arm64; do
+              GOOS=darwin GOARCH="${arch}" CGO_ENABLED=0 \
+                go build \
+                -ldflags "-s -w -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Version=${candidate} -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Commit=${source_sha}" \
+                -o "../tmp/release-candidate/codexbar-display-${arch}" ./cmd/codexbar-display
+            done
+            GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 \
+              go build -o ../tmp/release-candidate/virtual-vibetv ./cmd/virtual-vibetv
+          )
+          lipo -create \
+            -output tmp/release-candidate/codexbar-display \
+            tmp/release-candidate/codexbar-display-amd64 \
+            tmp/release-candidate/codexbar-display-arm64
+
+          ./scripts/build-macos-control-center-app.sh \
+            --version "$candidate" \
+            --build "${GITHUB_RUN_NUMBER}" \
+            --universal \
+            --companion-binary tmp/release-candidate/codexbar-display \
+            --output "dist/macos/VibeTV Control Center.app"
+
+          ./scripts/release-candidate/build-sparkle-cli.sh \
+            --output tmp/release-candidate/sparkle-cli.tar.gz
+
+          (
+            cd firmware_esp8266
+            CODEXBAR_DISPLAY_FW_VERSION="$candidate_firmware" pio run -e esp8266_smalltv_st7789
+          )
+          cp firmware_esp8266/.pio/build/esp8266_smalltv_st7789/firmware.bin \
+            tmp/release-candidate/firmware.bin
+          printf '%s\n' "$source_sha" > tmp/release-candidate/source-sha.txt
+          COPYFILE_DISABLE=1 tar -czf tmp/release-candidate/app.tar.gz \
+            -C dist/macos "VibeTV Control Center.app"
+
+      - name: Upload unsigned candidate inputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: CODEX-vibetv-candidate-inputs-${{ github.run_id }}
+          path: |
+            tmp/release-candidate/app.tar.gz
+            tmp/release-candidate/firmware.bin
+            tmp/release-candidate/virtual-vibetv
+            tmp/release-candidate/sparkle-cli.tar.gz
+            tmp/release-candidate/source-sha.txt
+          retention-days: 1
+
+  sign-and-package:
+    needs: build
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - name: Checkout trusted candidate and signing tools
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Download unsigned candidate inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: CODEX-vibetv-candidate-inputs-${{ github.run_id }}
+          path: tmp/release-candidate
+
+      - name: Extract candidate app
+        run: |
+          ./scripts/release-candidate/extract-candidate-app-archive.sh \
+            --archive tmp/release-candidate/app.tar.gz \
+            --output dist/macos
+
+      - name: Sign and notarize private candidate DMG
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_SIGNING_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_SIGNING_CERTIFICATE_P12_BASE64 }}
+          APPLE_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
+        run: |
+          set -euo pipefail
+          ./scripts/sign-notarize-macos-control-center.sh \
+            --app "dist/macos/VibeTV Control Center.app" \
+            --sign-app-only \
+            --allow-internal-xprotect-preflight-error
+          ./scripts/build-macos-control-center-dmg.sh \
+            --app "dist/macos/VibeTV Control Center.app" \
+            --output dist/macos/VibeTV-Control-Center.dmg \
+            --staging-dir tmp/release-candidate/dmg-stage
+          ./scripts/sign-notarize-macos-control-center.sh \
+            --app "dist/macos/VibeTV Control Center.app" \
+            --dmg dist/macos/VibeTV-Control-Center.dmg \
+            --skip-app-sign
+          ./scripts/verify-macos-control-center-dmg.sh \
+            --dmg dist/macos/VibeTV-Control-Center.dmg
+
+      - name: Build signed private candidate bundle
+        env:
+          CANDIDATE: ${{ inputs.candidate }}
+          CANDIDATE_FIRMWARE: ${{ inputs.candidate_firmware }}
+          FROM_APP: ${{ inputs.from_app }}
+          SPARKLE_ED_PRIVATE_KEY_BASE64: ${{ secrets.SPARKLE_ED_PRIVATE_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          [[ "${FROM_APP#v}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
+            || { echo 'from_app must be a SemVer release version' >&2; exit 1; }
+          key_file="$(mktemp)"
+          cleanup() {
+            rm -f "$key_file"
+          }
+          trap cleanup EXIT HUP INT TERM
+          [[ -n "$SPARKLE_ED_PRIVATE_KEY_BASE64" ]] \
+            || { echo 'Missing SPARKLE_ED_PRIVATE_KEY_BASE64' >&2; exit 1; }
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY_BASE64" | base64 -D > "$key_file"
+          chmod 600 "$key_file"
+          source_sha="$(cat tmp/release-candidate/source-sha.txt)"
+          curl -fsSL \
+            "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v${FROM_APP#v}/VibeTV-Control-Center.dmg" \
+            -o tmp/release-candidate/public-baseline.dmg
+          ./scripts/verify-macos-control-center-dmg.sh \
+            --dmg tmp/release-candidate/public-baseline.dmg
+          ./scripts/release-candidate/create-candidate-bundle.sh \
+            --dmg dist/macos/VibeTV-Control-Center.dmg \
+            --baseline-dmg tmp/release-candidate/public-baseline.dmg \
+            --baseline-version "${FROM_APP#v}" \
+            --firmware tmp/release-candidate/firmware.bin \
+            --virtual-vibetv tmp/release-candidate/virtual-vibetv \
+            --sparkle-cli-archive tmp/release-candidate/sparkle-cli.tar.gz \
+            --candidate "${CANDIDATE#v}" \
+            --candidate-firmware "${CANDIDATE_FIRMWARE#v}" \
+            --build "$GITHUB_RUN_NUMBER" \
+            --source-sha "$source_sha" \
+            --sparkle-key-file "$key_file" \
+            --output dist/release-candidate
+
+      - name: Upload private candidate bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: CODEX-vibetv-release-candidate-${{ inputs.candidate }}-${{ github.run_id }}
+          path: dist/release-candidate
+          retention-days: 1
+          compression-level: 0
+
+  vm-test:
+    if: ${{ inputs.run_vm }}
+    needs: sign-and-package
+    runs-on: [self-hosted, macOS, ARM64, codex-vibetv-rc]
+    timeout-minutes: 90
+    steps:
+      - name: Checkout trusted test orchestration
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Download private candidate bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: CODEX-vibetv-release-candidate-${{ inputs.candidate }}-${{ github.run_id }}
+          path: tmp/release-candidate-bundle
+
+      - name: Run disposable macOS snapshot matrix
+        run: |
+          ./scripts/test-release-candidate.sh \
+            --from-app "${{ inputs.from_app }}" \
+            --legacy-app "${{ inputs.legacy_app }}" \
+            --from-firmware "${{ inputs.from_firmware }}" \
+            --candidate "${{ inputs.candidate }}" \
+            --candidate-firmware "${{ inputs.candidate_firmware }}" \
+            --bundle tmp/release-candidate-bundle \
+            --vm-driver tart \
+            --output tmp/release-candidate-results
+
+      - name: Upload release-candidate results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: CODEX-vibetv-release-candidate-results-${{ github.run_id }}
+          path: tmp/release-candidate-results
+          retention-days: 7

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -68,6 +68,7 @@ const (
 	macAppUpdateJobTime       = 8 * time.Minute
 	usageFallbackFetchTime    = 15 * time.Second
 	macAppInstallerURL        = "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install-control-center-companion.sh"
+	macAppInstallerURLEnvVar  = "CODEXBAR_DISPLAY_MAC_APP_INSTALLER_URL"
 	macAppReleaseAPIEnvVar    = "CODEXBAR_DISPLAY_MAC_APP_RELEASE_API_URL"
 	macAppReleaseAPIURL       = "https://api.github.com/repos/DreamyTalesPAN/CodexBar-Display/releases/latest"
 	macAppReleaseCheckGap     = 6 * time.Hour
@@ -3721,7 +3722,7 @@ installer_url="$1"
 shift
 curl -fsSL "$installer_url" | bash -s -- "$@"
 `
-	cmdArgs := append([]string{"-c", script, "vibetv-mac-app-update", macAppInstallerURL}, args...)
+	cmdArgs := append([]string{"-c", script, "vibetv-mac-app-update", macAppInstallerURLForEnvironment()}, args...)
 	cmd := exec.CommandContext(ctx, "/bin/bash", cmdArgs...)
 	cmd.Stdout = out
 	cmd.Stderr = out
@@ -3732,6 +3733,13 @@ curl -fsSL "$installer_url" | bash -s -- "$@"
 		return fmt.Errorf("mac app update command failed: %w", err)
 	}
 	return nil
+}
+
+func macAppInstallerURLForEnvironment() string {
+	if candidate := strings.TrimSpace(os.Getenv(macAppInstallerURLEnvVar)); candidate != "" {
+		return candidate
+	}
+	return macAppInstallerURL
 }
 
 func (s *Server) requireThemeInstallPreflight(w http.ResponseWriter, r *http.Request, cfg runtimeconfig.Config, hello protocol.DeviceHello) bool {

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -4375,6 +4375,17 @@ func TestFirmwareUpdateAsyncReportsCustomerError(t *testing.T) {
 	}
 }
 
+func TestMacAppInstallerURLCanUsePrivateCandidateSource(t *testing.T) {
+	t.Setenv(macAppInstallerURLEnvVar, "  http://127.0.0.1:47835/install-candidate-mac-app.sh  ")
+	if got := macAppInstallerURLForEnvironment(); got != "http://127.0.0.1:47835/install-candidate-mac-app.sh" {
+		t.Fatalf("private candidate installer URL=%q", got)
+	}
+	t.Setenv(macAppInstallerURLEnvVar, "")
+	if got := macAppInstallerURLForEnvironment(); got != macAppInstallerURL {
+		t.Fatalf("default installer URL=%q", got)
+	}
+}
+
 func TestMacAppUpdateAsyncReportsCustomerProgress(t *testing.T) {
 	server := newTestServer(t, runtimeconfig.Config{})
 	server.allowMacAppSelfUpdate = true

--- a/docs/virtual-vibetv.md
+++ b/docs/virtual-vibetv.md
@@ -1,15 +1,14 @@
-# Virtual VibeTV
+# Release-candidate testing with Virtual VibeTV
 
-Virtual VibeTV is a lightweight, protocol-faithful simulator of the observable
-VibeTV device behavior. It reproduces the real Companion HTTP, theme, frame, and
-OTA flow without physical hardware, so the update client can be exercised
-deterministically on every commit. It does **not** emulate the ESP8266 processor,
-Wi-Fi, bootloader, flash timing, or display timing.
+Issue #177 is implemented as three isolated layers:
 
-This is the first layer of the release-candidate testing described in issue #177.
-The macOS VM snapshot and private-candidate-artifact layers are added separately.
+1. native Go and firmware tests run on every commit;
+2. Virtual VibeTV runs the real Companion HTTP, theme, frame, and OTA flow without physical hardware;
+3. disposable Tart clones run the complete Mac installation and update journey from clean, legacy, and current-native source snapshots.
 
-## What it simulates
+The candidate path does not merge `main`, create a Git tag, create a GitHub Release, or change production endpoints. The physical VibeTV remains a separate, explicitly approved final canary.
+
+## Virtual VibeTV
 
 Virtual VibeTV supports:
 
@@ -19,8 +18,7 @@ Virtual VibeTV supports:
 - `POST /update`, `POST /update/firmware`, and `POST /update/firmware.raw`;
 - candidate SHA-256 validation and simulated reboot unavailability;
 - prevention and reporting of an unnecessary second flash;
-- unhealthy health, render failure, stream restart failure, device-never-returns,
-  and accepted-upload/transport-error scenarios;
+- unhealthy health, render failure, stream restart failure, device-never-returns, and accepted-upload/transport-error scenarios;
 - wrong-device rejection and same-`deviceId` rediscovery at a changed address;
 - a status timeline and virtual framebuffer.
 
@@ -29,21 +27,7 @@ Simulator-only read endpoints are:
 - `GET /__virtual/state`: machine-readable state, writes, violations, and event timeline;
 - `GET /framebuffer`: last accepted frame and render result.
 
-## Scenarios
-
-`--scenario` selects one deterministic behavior:
-
-| Scenario                   | Behavior verified                                                        |
-| -------------------------- | ------------------------------------------------------------------------ |
-| `normal`                   | full happy-path OTA, reboot, rediscovery, health, stream, render         |
-| `different-device`         | a different `deviceId` responds after the update and is rejected         |
-| `never-returns`            | the device never comes back after the update                            |
-| `health-unhealthy`         | `/health` keeps reporting an unhealthy device                            |
-| `render-fails`             | render verification fails                                                 |
-| `stream-restart-fails`     | the stream does not restart cleanly                                      |
-| `accepted-transport-error` | the OTA is accepted but the HTTP acknowledgement is dropped              |
-
-## Run it locally
+Run it locally:
 
 ```bash
 cd companion
@@ -53,12 +37,119 @@ go run ./cmd/virtual-vibetv \
   --scenario normal
 ```
 
-The real firmware update client is exercised against the simulator by the Go
-integration tests in `companion/cmd/codexbar-display/release_commands_test.go`,
-which run as part of `go test ./...` on every commit. Those tests prove, among
-other things, that:
+## Private candidate bundle
 
-- `already_current` firmware performs no OTA upload and reports no second flash;
-- an accepted OTA that then drops its HTTP acknowledgement is not blindly
-  re-flashed — the client verifies the candidate version before retrying;
-- rediscovery only accepts a device reporting the original `deviceId`.
+The candidate bundle contains only short-lived test inputs:
+
+- signed and notarized `VibeTV-Control-Center.dmg`;
+- the verified current-public baseline DMG;
+- EdDSA-signed update enclosure and signed private Sparkle `appcast.xml`;
+- Sparkle's official external CLI updater, built from checksum-pinned 2.9.4 source;
+- candidate firmware and local-only firmware manifest;
+- local-only Mac App release metadata and installer;
+- a Darwin-arm64 Virtual VibeTV binary;
+- SHA-256 checksums and candidate build metadata.
+
+All candidate URLs point to `127.0.0.1:47835` inside the guest. Production endpoints are never changed.
+
+Build a bundle from prepared artifacts:
+
+```bash
+./scripts/release-candidate/create-candidate-bundle.sh \
+  --dmg dist/macos/VibeTV-Control-Center.dmg \
+  --baseline-dmg tmp/public-baseline.dmg \
+  --baseline-version 1.0.44 \
+  --firmware firmware_esp8266/.pio/build/esp8266_smalltv_st7789/firmware.bin \
+  --virtual-vibetv tmp/virtual-vibetv \
+  --sparkle-cli-archive tmp/sparkle-cli.tar.gz \
+  --candidate 1.0.45 \
+  --candidate-firmware 1.0.37 \
+  --build 123 \
+  --source-sha "$(git rev-parse HEAD)" \
+  --sparkle-key-file /secure/path/sparkle-private-key \
+  --output tmp/release-candidate-bundle
+```
+
+`--allow-unsigned-appcast` exists only for the fast infrastructure contract test. A real VM run rejects an unsigned appcast.
+
+The manual GitHub Actions workflow `CODEX Test VibeTV Release Candidate` builds the candidate from any requested source ref, builds Sparkle's official CLI from pinned source, signs and notarizes the candidate in a separate trusted job, verifies the requested public baseline DMG, signs the update and private feed with Sparkle 2.9.4, and uploads the bundle with one-day retention. It publishes no release.
+
+## macOS source snapshots
+
+Tart uses Apple's Virtualization framework and requires an Apple-Silicon Mac. Install Tart once:
+
+```bash
+brew install cirruslabs/cli/tart
+```
+
+Prepare the three reusable source snapshots:
+
+```bash
+./scripts/prepare-release-candidate-vms.sh \
+  --from-app <current-public-version> \
+  --legacy-app <previous-public-or-migration-floor-version>
+```
+
+This creates:
+
+- `CODEX-vibetv-clean`;
+- `CODEX-vibetv-legacy-<resolved-version>`;
+- `CODEX-vibetv-native-<current-public-version>`.
+
+No legacy version is built into the scripts. The current local/Tart path requires the chosen migration baseline explicitly. The cloud target should instead resolve `current_public` and `previous_public` from stable release metadata at the beginning of every run, while keeping a separately governed `migration_floor` only when an older installation topology remains supported.
+
+The source images are not modified during tests. Every test creates a uniquely named `CODEX-rc-*` clone. The clone is stopped and deleted after the run, even on failure. `--keep-failed-vm` is the only explicit exception and is intended for debugging.
+
+The default clean base is `ghcr.io/cirruslabs/macos-sequoia-base:latest`, whose Tart Guest Agent allows non-interactive `tart exec` commands. A different source can be passed with `--base-image`.
+
+## One reproducible command
+
+Run all three customer states:
+
+```bash
+./scripts/test-release-candidate.sh \
+  --from-app 1.0.44 \
+  --legacy-app 1.0.43 \
+  --from-firmware 1.0.36 \
+  --candidate 1.0.45 \
+  --candidate-firmware 1.0.37 \
+  --bundle tmp/release-candidate-bundle
+```
+
+Use `--skip-mac-update` for a firmware-only run or `--skip-firmware-update` for a Mac-only run. A skipped component is recorded explicitly in `result.json`; it is not reported as an update success.
+
+For each state the guest verifies:
+
+- installation under `/Applications`;
+- candidate app version and bundle build;
+- background runtime version;
+- the expected `SMAppService` and its unique PID;
+- sole ownership of port `127.0.0.1:47832`;
+- absence of duplicate legacy services;
+- current-public first install or legacy migration before the candidate update;
+- real Sparkle download, app replacement, and relaunch from private sources;
+- private candidate sources, signed update, and signed feed;
+- firmware OTA and reboot recovery;
+- rediscovery using the same `deviceId`;
+- healthy `/health`, stream, and render state;
+- a second update is `already_current` and performs no second OTA upload.
+
+The output directory contains:
+
+- `result.json`: aggregate machine result;
+- `summary.md`: human result;
+- one result directory per source state;
+- status, update-job, device, and Virtual VibeTV JSON evidence;
+- event timelines, logs, and final screenshots;
+- host VM lifecycle log proving clone disposal.
+
+Mac App and firmware candidates can be tested together or independently with the explicit skip flags. If the candidate firmware version already equals the public source version, the normal firmware path additionally proves that the update is a zero-upload no-op.
+
+## CI pyramid
+
+- Every commit: `go test ./...` covers native behavior and Virtual VibeTV integration; `test-release-candidate-contract.sh` covers bundle creation, three-state VM orchestration, result aggregation, and clone disposal with a fake driver.
+- Every candidate: the manual workflow creates private one-day artifacts.
+- Optional full candidate gate: a prepared Apple-Silicon runner with labels `self-hosted`, `macOS`, `ARM64`, and `codex-vibetv-rc` runs the Tart matrix.
+- Before release: one separately approved physical VibeTV canary. This infrastructure never performs that hardware write automatically.
+
+The VM design follows Apple's Virtualization framework model and Tart's documented clone, shared-directory, Guest Agent, and command-execution flow. Sparkle's pinned official `sign_update` tool signs both the candidate DMG entry and the private feed. The guest then uses Sparkle's official CLI to terminate the running public app, download and verify the candidate, replace it, and relaunch it.

--- a/scripts/prepare-release-candidate-vms.sh
+++ b/scripts/prepare-release-candidate-vms.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DRIVER="$ROOT/scripts/release-candidate/drivers/tart.sh"
+BASE_IMAGE="ghcr.io/cirruslabs/macos-sequoia-base:latest"
+FROM_APP=""
+LEGACY_APP=""
+REPLACE=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/prepare-release-candidate-vms.sh \
+    --from-app <current-public-native-version> \
+    --legacy-app <previous-public-or-migration-floor-version> \
+    [--base-image image] [--replace]
+
+Creates these reusable Tart source snapshots:
+  CODEX-vibetv-clean
+  CODEX-vibetv-legacy-<version>
+  CODEX-vibetv-native-<version>
+
+Each actual candidate test clones these sources and deletes the clone afterward.
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --from-app) FROM_APP="${2#v}"; shift 2 ;;
+    --legacy-app) LEGACY_APP="${2#v}"; shift 2 ;;
+    --base-image) BASE_IMAGE="$2"; shift 2 ;;
+    --replace) REPLACE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+for version in "$FROM_APP" "$LEGACY_APP"; do
+  [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || die "valid versions required"
+done
+"$DRIVER" check
+
+exists() {
+  tart get "$1" >/dev/null 2>&1
+}
+
+replace_or_fail() {
+  local name="$1"
+  if ! exists "$name"; then
+    return 0
+  fi
+  [[ "$REPLACE" == "1" ]] || die "snapshot already exists: $name (use --replace)"
+  tart stop "$name" >/dev/null 2>&1 || true
+  tart delete "$name"
+}
+
+clean="CODEX-vibetv-clean"
+replace_or_fail "$clean"
+if ! exists "$clean"; then
+  tart clone "$BASE_IMAGE" "$clean"
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-vm-prep.XXXXXX")"
+ACTIVE=""
+cleanup() {
+  if [[ -n "$ACTIVE" ]]; then
+    "$DRIVER" stop "$ACTIVE" >/dev/null 2>&1 || true
+    "$DRIVER" delete "$ACTIVE" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$WORK"
+}
+trap cleanup EXIT HUP INT TERM
+cp "$ROOT/scripts/release-candidate/prepare-guest-state.sh" "$WORK/prepare-guest-state.sh"
+chmod 755 "$WORK/prepare-guest-state.sh"
+
+prepare_state() {
+  local state="$1"
+  local version="$2"
+  local final="CODEX-vibetv-${state}-${version}"
+  local temp="CODEX-prep-${state}-${version//[^0-9A-Za-z]/-}-$$"
+  replace_or_fail "$final"
+  ACTIVE="$temp"
+  "$DRIVER" clone "$clean" "$temp"
+  "$DRIVER" run "$temp" "$WORK" "$WORK/$state"
+  "$DRIVER" exec "$temp" \
+    "/Volumes/My Shared Files/codex-rc/prepare-guest-state.sh" \
+    --state "$state" \
+    --version "$version"
+  "$DRIVER" stop "$temp"
+  tart clone "$temp" "$final"
+  "$DRIVER" delete "$temp"
+  ACTIVE=""
+  printf 'Prepared snapshot: %s\n' "$final"
+}
+
+prepare_state legacy "$LEGACY_APP"
+prepare_state native "$FROM_APP"
+printf 'Prepared snapshot: %s\n' "$clean"

--- a/scripts/release-candidate/build-sparkle-cli.sh
+++ b/scripts/release-candidate/build-sparkle-cli.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SPARKLE_VERSION="2.9.4"
+SPARKLE_SOURCE_SHA256="f22982ba6e1a951be4b60bdd0733e74e99b28eed6c3013edd99765af87c79d49"
+SPARKLE_SOURCE_URL="https://github.com/sparkle-project/Sparkle/archive/refs/tags/${SPARKLE_VERSION}.tar.gz"
+OUTPUT=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  build-sparkle-cli.sh --output path/to/sparkle-cli.tar.gz
+
+Builds Sparkle's official external updater from pinned source, applies an
+ad-hoc signature for the disposable VM test environment, and archives the
+complete sparkle.app bundle with framework symlinks preserved.
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output) [[ -n "${2:-}" ]] || die "--output needs a value"; OUTPUT="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$OUTPUT" && "$OUTPUT" != "/" ]] || die "safe --output path is required"
+[[ "$(uname -s)" == "Darwin" ]] || die "Sparkle CLI must be built on macOS"
+for command in codesign curl shasum tar xcodebuild; do
+  command -v "$command" >/dev/null 2>&1 || die "required command is missing: $command"
+done
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-sparkle-cli.XXXXXX")"
+cleanup() {
+  rm -rf "$WORK"
+}
+trap cleanup EXIT HUP INT TERM
+
+archive="$WORK/Sparkle-source.tar.gz"
+curl -fsSL "$SPARKLE_SOURCE_URL" -o "$archive"
+[[ "$(shasum -a 256 "$archive" | awk '{print $1}')" == "$SPARKLE_SOURCE_SHA256" ]] \
+  || die "Sparkle source checksum mismatch"
+tar -xzf "$archive" -C "$WORK"
+
+source="$WORK/Sparkle-${SPARKLE_VERSION}"
+derived="$WORK/DerivedData"
+xcodebuild \
+  -project "$source/Sparkle.xcodeproj" \
+  -scheme sparkle-cli \
+  -configuration Release \
+  -derivedDataPath "$derived" \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+
+app="$derived/Build/Products/Release/sparkle.app"
+[[ -d "$app" ]] || die "Sparkle CLI build did not produce sparkle.app"
+framework="$app/Contents/Frameworks/Sparkle.framework"
+[[ -d "$framework" ]] || die "Sparkle CLI is missing Sparkle.framework"
+
+sign_component() {
+  local path="$1"
+  shift
+  if [[ -e "$path" ]]; then
+    codesign --force --options runtime "$@" --sign - "$path"
+  fi
+}
+
+# Sparkle documents this inside-out signing order for manually embedded
+# frameworks. The CLI is used only inside disposable VMs and is ad-hoc signed.
+sign_component "$framework/Versions/B/XPCServices/Installer.xpc"
+sign_component "$framework/Versions/B/XPCServices/Downloader.xpc" --preserve-metadata=entitlements
+sign_component "$framework/Versions/B/Autoupdate"
+sign_component "$framework/Versions/B/Updater.app"
+sign_component "$framework"
+sign_component "$app"
+codesign --verify --deep --strict --verbose=2 "$app"
+
+mkdir -p "$(dirname "$OUTPUT")"
+rm -f "$OUTPUT"
+COPYFILE_DISABLE=1 tar -czf "$OUTPUT" -C "$(dirname "$app")" "$(basename "$app")"
+[[ -s "$OUTPUT" ]] || die "Sparkle CLI archive was not created"
+printf 'Built pinned Sparkle CLI archive: %s\n' "$OUTPUT"

--- a/scripts/release-candidate/create-candidate-bundle.sh
+++ b/scripts/release-candidate/create-candidate-bundle.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SPARKLE_VERSION="2.9.4"
+SPARKLE_SHA256="ce89daf967db1e1893ed3ebd67575ed82d3902563e3191ca92aaec9164fbdef9"
+SPARKLE_URL="https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+
+DMG=""
+FIRMWARE=""
+VIRTUAL_VIBETV=""
+BASELINE_DMG=""
+BASELINE_VERSION=""
+SPARKLE_CLI_ARCHIVE=""
+CANDIDATE=""
+CANDIDATE_FIRMWARE=""
+BUILD=""
+SOURCE_SHA=""
+OUTPUT=""
+SPARKLE_KEY_FILE=""
+ALLOW_UNSIGNED=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  create-candidate-bundle.sh \
+    --dmg path.dmg --baseline-dmg public.dmg --baseline-version x.y.z \
+    --firmware firmware.bin --virtual-vibetv path --sparkle-cli-archive path.tar.gz \
+    --candidate x.y.z [--candidate-firmware x.y.z] --build n --source-sha sha --output dir \
+    --sparkle-key-file private-key
+
+Creates a short-lived, private release-candidate bundle. Use
+--allow-unsigned-appcast only for local contract tests; real candidate bundles
+must use Sparkle's EdDSA-signed appcast.
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_value() {
+  [[ -n "${2:-}" ]] || die "$1 needs a value"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dmg) need_value "$1" "${2:-}"; DMG="$2"; shift 2 ;;
+    --baseline-dmg) need_value "$1" "${2:-}"; BASELINE_DMG="$2"; shift 2 ;;
+    --baseline-version) need_value "$1" "${2:-}"; BASELINE_VERSION="${2#v}"; shift 2 ;;
+    --firmware) need_value "$1" "${2:-}"; FIRMWARE="$2"; shift 2 ;;
+    --virtual-vibetv) need_value "$1" "${2:-}"; VIRTUAL_VIBETV="$2"; shift 2 ;;
+    --sparkle-cli-archive) need_value "$1" "${2:-}"; SPARKLE_CLI_ARCHIVE="$2"; shift 2 ;;
+    --candidate) need_value "$1" "${2:-}"; CANDIDATE="${2#v}"; shift 2 ;;
+    --candidate-firmware) need_value "$1" "${2:-}"; CANDIDATE_FIRMWARE="${2#v}"; shift 2 ;;
+    --build) need_value "$1" "${2:-}"; BUILD="$2"; shift 2 ;;
+    --source-sha) need_value "$1" "${2:-}"; SOURCE_SHA="$2"; shift 2 ;;
+    --output) need_value "$1" "${2:-}"; OUTPUT="$2"; shift 2 ;;
+    --sparkle-key-file) need_value "$1" "${2:-}"; SPARKLE_KEY_FILE="$2"; shift 2 ;;
+    --allow-unsigned-appcast) ALLOW_UNSIGNED=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ "$CANDIDATE" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
+  || die "--candidate must be a SemVer release version"
+[[ "$BASELINE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
+  || die "--baseline-version must be a SemVer release version"
+[[ -n "$CANDIDATE_FIRMWARE" ]] || CANDIDATE_FIRMWARE="$CANDIDATE"
+[[ "$CANDIDATE_FIRMWARE" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
+  || die "--candidate-firmware must be a SemVer release version"
+[[ "$BUILD" =~ ^[0-9]+$ ]] || die "--build must be numeric"
+[[ "$SOURCE_SHA" =~ ^[0-9a-fA-F]{7,64}$ ]] || die "--source-sha must be a git SHA"
+[[ -f "$DMG" ]] || die "DMG not found: $DMG"
+[[ -f "$BASELINE_DMG" ]] || die "baseline DMG not found: $BASELINE_DMG"
+[[ -f "$FIRMWARE" ]] || die "firmware not found: $FIRMWARE"
+[[ -x "$VIRTUAL_VIBETV" ]] || die "Virtual VibeTV binary is not executable: $VIRTUAL_VIBETV"
+[[ -f "$SPARKLE_CLI_ARCHIVE" ]] || die "Sparkle CLI archive not found: $SPARKLE_CLI_ARCHIVE"
+[[ -n "$OUTPUT" && "$OUTPUT" != "/" ]] || die "safe --output directory is required"
+if [[ -z "$SPARKLE_KEY_FILE" && "$ALLOW_UNSIGNED" != "1" ]]; then
+  die "real candidate bundles require --sparkle-key-file"
+fi
+if [[ -n "$SPARKLE_KEY_FILE" ]]; then
+  [[ -f "$SPARKLE_KEY_FILE" ]] || die "Sparkle private key file not found"
+  [[ "$(stat -f '%Lp' "$SPARKLE_KEY_FILE" 2>/dev/null || stat -c '%a' "$SPARKLE_KEY_FILE")" == "600" ]] \
+    || die "Sparkle private key file must have mode 600"
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-candidate.XXXXXX")"
+cleanup() {
+  rm -rf "$WORK"
+}
+trap cleanup EXIT HUP INT TERM
+
+if [[ -d "$OUTPUT" ]] && find "$OUTPUT" -mindepth 1 -maxdepth 1 | grep -q .; then
+  die "output directory must be empty: $OUTPUT"
+fi
+mkdir -p "$OUTPUT"
+cp "$DMG" "$OUTPUT/VibeTV-Control-Center.dmg"
+cp "$BASELINE_DMG" "$OUTPUT/public-baseline.dmg"
+cp "$FIRMWARE" "$OUTPUT/firmware.bin"
+cp "$SPARKLE_CLI_ARCHIVE" "$OUTPUT/sparkle-cli.tar.gz"
+cp "$VIRTUAL_VIBETV" "$OUTPUT/virtual-vibetv"
+chmod 755 "$OUTPUT/virtual-vibetv"
+cp "$ROOT/scripts/release-candidate/install-candidate-mac-app.sh" "$OUTPUT/install-candidate-mac-app.sh"
+chmod 755 "$OUTPUT/install-candidate-mac-app.sh"
+
+firmware_sha="$(shasum -a 256 "$OUTPUT/firmware.bin" | awk '{print $1}')"
+dmg_sha="$(shasum -a 256 "$OUTPUT/VibeTV-Control-Center.dmg" | awk '{print $1}')"
+baseline_dmg_sha="$(shasum -a 256 "$OUTPUT/public-baseline.dmg" | awk '{print $1}')"
+sparkle_cli_sha="$(shasum -a 256 "$OUTPUT/sparkle-cli.tar.gz" | awk '{print $1}')"
+
+python3 - "$OUTPUT" "$CANDIDATE" "$CANDIDATE_FIRMWARE" "$BUILD" "$SOURCE_SHA" \
+  "$BASELINE_VERSION" "$firmware_sha" "$dmg_sha" "$baseline_dmg_sha" "$sparkle_cli_sha" <<'PY'
+import json
+import pathlib
+import sys
+
+out = pathlib.Path(sys.argv[1])
+(
+    candidate, candidate_firmware, build, source_sha, baseline_version,
+    firmware_sha, dmg_sha, baseline_dmg_sha, sparkle_cli_sha,
+) = sys.argv[2:]
+base = "http://127.0.0.1:47835"
+
+firmware_manifest = {
+    "schemaVersion": 1,
+    "release": f"v{candidate}",
+    "artifacts": [{
+        "firmwareEnv": "esp8266_smalltv_st7789",
+        "board": "esp8266-smalltv-st7789",
+        "firmwareVersion": candidate_firmware,
+        "asset": "firmware.bin",
+        "firmwareUrl": f"{base}/firmware.bin",
+        "sha256": firmware_sha,
+        "message": "Private release-candidate firmware.",
+    }],
+}
+release = {
+    "tag_name": f"v{candidate}",
+    "draft": True,
+    "prerelease": True,
+    "assets": [{
+        "name": "VibeTV-Control-Center.dmg",
+        "browser_download_url": f"{base}/VibeTV-Control-Center.dmg",
+        "size": (out / "VibeTV-Control-Center.dmg").stat().st_size,
+    }],
+}
+metadata = {
+    "schemaVersion": 1,
+    "candidate": candidate,
+    "candidateFirmware": candidate_firmware,
+    "baselineApp": baseline_version,
+    "build": build,
+    "sourceSha": source_sha,
+    "private": True,
+    "expiresAfterHours": 24,
+    "endpoints": {
+        "appcast": f"{base}/appcast.xml",
+        "macAppRelease": f"{base}/mac-app-release.json",
+        "macAppInstaller": f"{base}/install-candidate-mac-app.sh",
+        "firmwareManifest": f"{base}/firmware-manifest.json",
+    },
+    "artifacts": {
+        "dmg": {"path": "VibeTV-Control-Center.dmg", "sha256": dmg_sha},
+        "baselineDmg": {"path": "public-baseline.dmg", "sha256": baseline_dmg_sha},
+        "firmware": {"path": "firmware.bin", "sha256": firmware_sha},
+        "sparkleCLI": {"path": "sparkle-cli.tar.gz", "sha256": sparkle_cli_sha},
+        "virtualVibeTV": {"path": "virtual-vibetv"},
+    },
+}
+
+for name, payload in (
+    ("firmware-manifest.json", firmware_manifest),
+    ("mac-app-release.json", release),
+    ("candidate.json", metadata),
+):
+    with (out / name).open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+PY
+
+if [[ -n "$SPARKLE_KEY_FILE" ]]; then
+  archive="$WORK/Sparkle-${SPARKLE_VERSION}.tar.xz"
+  curl -fsSL "$SPARKLE_URL" -o "$archive"
+  [[ "$(shasum -a 256 "$archive" | awk '{print $1}')" == "$SPARKLE_SHA256" ]] \
+    || die "Sparkle tool archive checksum mismatch"
+  tar -xJf "$archive" -C "$WORK"
+  update_signature="$(
+    "$WORK/bin/sign_update" \
+      --ed-key-file "$SPARKLE_KEY_FILE" \
+      "$OUTPUT/VibeTV-Control-Center.dmg"
+  )"
+  python3 - "$OUTPUT/appcast.xml" "$CANDIDATE" "$BUILD" "$update_signature" <<'PY'
+import html
+import pathlib
+import re
+import sys
+
+output = pathlib.Path(sys.argv[1])
+candidate, build, signature_fragment = sys.argv[2:]
+signature = re.fullmatch(
+    r'sparkle:edSignature="([A-Za-z0-9+/=]+)" length="([0-9]+)"',
+    signature_fragment.strip(),
+)
+if signature is None:
+    raise SystemExit("Sparkle sign_update returned an unexpected signature fragment")
+
+ed_signature, length = map(html.escape, signature.groups())
+output.write_text(f'''<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>VibeTV private release candidate</title>
+    <item>
+      <title>VibeTV Control Center {html.escape(candidate)}</title>
+      <sparkle:version>{html.escape(build)}</sparkle:version>
+      <sparkle:shortVersionString>{html.escape(candidate)}</sparkle:shortVersionString>
+      <enclosure
+        url="http://127.0.0.1:47835/VibeTV-Control-Center.dmg"
+        sparkle:edSignature="{ed_signature}"
+        length="{length}"
+        type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>
+''', encoding="utf-8")
+PY
+  "$WORK/bin/sign_update" \
+    --ed-key-file "$SPARKLE_KEY_FILE" \
+    "$OUTPUT/appcast.xml"
+  grep -q 'sparkle:edSignature=' "$OUTPUT/appcast.xml" \
+    || die "generated Sparkle appcast has no EdDSA update signature"
+  grep -q '<!-- sparkle-signatures:' "$OUTPUT/appcast.xml" \
+    || die "generated Sparkle appcast has no signed-feed signature"
+else
+  cat > "$OUTPUT/appcast.xml" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>VibeTV private release candidate</title>
+    <item>
+      <title>VibeTV Control Center ${CANDIDATE}</title>
+      <sparkle:version>${BUILD}</sparkle:version>
+      <sparkle:shortVersionString>${CANDIDATE}</sparkle:shortVersionString>
+      <enclosure url="http://127.0.0.1:47835/VibeTV-Control-Center.dmg" type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>
+EOF
+fi
+
+(
+  cd "$OUTPUT"
+  shasum -a 256 \
+    VibeTV-Control-Center.dmg \
+    public-baseline.dmg \
+    firmware.bin \
+    sparkle-cli.tar.gz \
+    virtual-vibetv \
+    install-candidate-mac-app.sh \
+    firmware-manifest.json \
+    mac-app-release.json \
+    appcast.xml \
+    candidate.json > checksums.txt
+)
+
+for required in \
+  VibeTV-Control-Center.dmg \
+  public-baseline.dmg \
+  firmware.bin \
+  sparkle-cli.tar.gz \
+  virtual-vibetv \
+  install-candidate-mac-app.sh \
+  firmware-manifest.json \
+  mac-app-release.json \
+  appcast.xml \
+  candidate.json \
+  checksums.txt; do
+  [[ -f "$OUTPUT/$required" ]] || die "candidate bundle is incomplete: missing $required"
+done
+(
+  cd "$OUTPUT"
+  shasum -a 256 -c checksums.txt >/dev/null
+) || die "candidate bundle checksum verification failed"
+
+printf 'Candidate bundle ready: %s\n' "$OUTPUT"
+printf '  candidate=%s firmware=%s build=%s source=%s\n' "$CANDIDATE" "$CANDIDATE_FIRMWARE" "$BUILD" "$SOURCE_SHA"
+printf '  appcast=%s\n' "$([[ -n "$SPARKLE_KEY_FILE" ]] && printf signed || printf unsigned-contract-test)"

--- a/scripts/release-candidate/drivers/fake.sh
+++ b/scripts/release-candidate/drivers/fake.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="${1:-}"
+shift || true
+log_file="${VIBETV_RC_FAKE_DRIVER_LOG:-/dev/null}"
+printf '%s %s\n' "$command_name" "$*" >> "$log_file"
+
+case "$command_name" in
+  check|clone|run|stop|delete)
+    exit 0
+    ;;
+  exec)
+    vm_name="${1:?VM name required}"
+    shift
+    state=""
+    results=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --state) state="$2"; shift 2 ;;
+        --results) results="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    [[ -n "$state" && -n "$results" ]] || exit 2
+    host_results="${VIBETV_RC_FAKE_SHARE_DIR:?}/${results#/Volumes/My Shared Files/codex-rc/}"
+    mkdir -p "$host_results/screenshots"
+    status="${VIBETV_RC_FAKE_STATUS:-passed}"
+    python3 - "$host_results/result.json" "$state" "$status" "$vm_name" <<'PY'
+import json, pathlib, sys
+path, state, status, vm = sys.argv[1:]
+payload = {
+    "schemaVersion": 1,
+    "state": state,
+    "status": status,
+    "vm": vm,
+    "checks": {
+        "macMigration": status == "passed",
+        "sparkleUpdate": status == "passed",
+        "appRelaunch": status == "passed",
+        "macUpdateSkipped": False,
+        "firmwareUpdateSkipped": False,
+        "appVersion": status == "passed",
+        "appBuild": status == "passed",
+        "runtimeVersion": status == "passed",
+        "listenerOwnership": status == "passed",
+        "firmwareOTA": status == "passed",
+        "sameDeviceId": status == "passed",
+        "health": status == "passed",
+        "stream": status == "passed",
+        "render": status == "passed",
+        "secondFlashPrevented": status == "passed",
+        "snapshotDisposed": False,
+    },
+}
+pathlib.Path(path).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+    printf '# %s\n\nStatus: %s\n' "$state" "$status" > "$host_results/summary.md"
+    printf '{"event":"fake guest complete","state":"%s"}\n' "$state" > "$host_results/timeline.jsonl"
+    : > "$host_results/screenshots/final.png"
+    [[ "$status" == "passed" ]]
+    ;;
+  *)
+    exit 2
+    ;;
+esac

--- a/scripts/release-candidate/drivers/tart.sh
+++ b/scripts/release-candidate/drivers/tart.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="${1:-}"
+shift || true
+
+die() {
+  printf 'error: Tart driver: %s\n' "$*" >&2
+  exit 1
+}
+
+case "$command_name" in
+  check)
+    [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]] \
+      || die "real macOS guests require an Apple-Silicon Mac"
+    command -v tart >/dev/null 2>&1 || die "tart is missing; install it with: brew install cirruslabs/cli/tart"
+    ;;
+  clone)
+    source_image="${1:?source image required}"
+    vm_name="${2:?VM name required}"
+    tart clone "$source_image" "$vm_name"
+    ;;
+  run)
+    vm_name="${1:?VM name required}"
+    share_dir="${2:?share directory required}"
+    run_dir="${3:?run directory required}"
+    mkdir -p "$run_dir"
+    tart run "$vm_name" --no-graphics --dir="codex-rc:${share_dir}" \
+      >"$run_dir/tart.log" 2>&1 &
+    printf '%s\n' "$!" > "$run_dir/tart.pid"
+    deadline=$((SECONDS + 120))
+    until tart exec "$vm_name" /usr/bin/true >/dev/null 2>&1; do
+      (( SECONDS < deadline )) || die "guest agent did not become ready within 120 seconds"
+      sleep 2
+    done
+    ;;
+  exec)
+    vm_name="${1:?VM name required}"
+    shift
+    tart exec "$vm_name" "$@"
+    ;;
+  stop)
+    vm_name="${1:?VM name required}"
+    tart stop "$vm_name" >/dev/null 2>&1 || tart stop "$vm_name" --force >/dev/null 2>&1 || true
+    ;;
+  delete)
+    vm_name="${1:?VM name required}"
+    tart delete "$vm_name"
+    ;;
+  *)
+    die "unknown command ${command_name:-<empty>}"
+    ;;
+esac

--- a/scripts/release-candidate/extract-candidate-app-archive.sh
+++ b/scripts/release-candidate/extract-candidate-app-archive.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCHIVE=""
+OUTPUT=""
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --archive) [[ -n "${2:-}" ]] || die "--archive needs a value"; ARCHIVE="$2"; shift 2 ;;
+    --output) [[ -n "${2:-}" ]] || die "--output needs a value"; OUTPUT="$2"; shift 2 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -f "$ARCHIVE" ]] || die "candidate app archive not found: $ARCHIVE"
+[[ -n "$OUTPUT" && "$OUTPUT" != "/" ]] || die "safe --output directory is required"
+[[ ! -e "$OUTPUT" ]] || die "output path must not exist: $OUTPUT"
+
+python3 - "$ARCHIVE" "$OUTPUT" <<'PY'
+import pathlib
+import shutil
+import sys
+import tarfile
+
+archive = pathlib.Path(sys.argv[1])
+output = pathlib.Path(sys.argv[2])
+expected_root = "VibeTV Control Center.app"
+
+with tarfile.open(archive, "r:gz") as candidate:
+    members = candidate.getmembers()
+    if not members:
+        raise SystemExit("candidate app archive is empty")
+    for member in members:
+        path = pathlib.PurePosixPath(member.name)
+        if path.is_absolute() or ".." in path.parts:
+            raise SystemExit(f"unsafe candidate archive path: {member.name}")
+        if not path.parts or path.parts[0] != expected_root:
+            raise SystemExit(f"unexpected candidate archive root: {member.name}")
+        if not (member.isdir() or member.isfile()):
+            raise SystemExit(f"candidate archive contains a non-regular entry: {member.name}")
+    output.mkdir(parents=True)
+    candidate.extractall(output)
+
+app = output / expected_root
+if not (app / "Contents" / "Info.plist").is_file():
+    shutil.rmtree(output)
+    raise SystemExit("candidate archive has no valid app Info.plist")
+PY
+
+printf 'Safely extracted candidate app archive: %s\n' "$OUTPUT"

--- a/scripts/release-candidate/guest-run.sh
+++ b/scripts/release-candidate/guest-run.sh
@@ -1,0 +1,444 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE=""
+BUNDLE=""
+RESULTS=""
+FROM_APP=""
+FROM_FIRMWARE=""
+CANDIDATE=""
+CANDIDATE_FIRMWARE=""
+SKIP_MAC_UPDATE=0
+SKIP_FIRMWARE_UPDATE=0
+CURRENT_STAGE="preflight"
+FAILURE=""
+ARTIFACT_SERVER_PID=""
+DEVICE_PID=""
+BASELINE_MOUNT=""
+BASELINE_WORK=""
+STATUS_URL="http://127.0.0.1:47832/v1/status"
+DEVICE_URL="http://127.0.0.1:47834"
+TOKEN="virtual-pair-token"
+APP="/Applications/VibeTV Control Center.app"
+
+mac_migration=false
+sparkle_update=false
+app_relaunch=false
+mac_update_skipped=false
+firmware_update_skipped=false
+app_version=false
+app_build=false
+runtime_version=false
+listener_ownership=false
+single_runtime=false
+firmware_ota=false
+same_device_id=false
+health=false
+stream=false
+render=false
+second_flash_prevented=false
+
+die() {
+  FAILURE="$*"
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --state) STATE="$2"; shift 2 ;;
+    --bundle) BUNDLE="$2"; shift 2 ;;
+    --results) RESULTS="$2"; shift 2 ;;
+    --from-app) FROM_APP="${2#v}"; shift 2 ;;
+    --from-firmware) FROM_FIRMWARE="${2#v}"; shift 2 ;;
+    --candidate) CANDIDATE="${2#v}"; shift 2 ;;
+    --candidate-firmware) CANDIDATE_FIRMWARE="${2#v}"; shift 2 ;;
+    --skip-mac-update) SKIP_MAC_UPDATE=1; shift ;;
+    --skip-firmware-update) SKIP_FIRMWARE_UPDATE=1; shift ;;
+    *) die "unknown guest argument: $1" ;;
+  esac
+done
+
+[[ "$STATE" == "clean" || "$STATE" == "legacy" || "$STATE" == "native" ]] || die "invalid state"
+[[ -d "$BUNDLE" && -n "$RESULTS" ]] || die "bundle and results are required"
+mkdir -p "$RESULTS/screenshots"
+TIMELINE="$RESULTS/timeline.jsonl"
+: > "$TIMELINE"
+
+timeline() {
+  python3 - "$TIMELINE" "$CURRENT_STAGE" "$1" <<'PY'
+import datetime, json, sys
+with open(sys.argv[1], "a", encoding="utf-8") as handle:
+    handle.write(json.dumps({
+        "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "stage": sys.argv[2],
+        "detail": sys.argv[3],
+    }) + "\n")
+PY
+}
+
+cleanup() {
+  launchctl unsetenv CODEXBAR_DISPLAY_MAC_APP_RELEASE_API_URL >/dev/null 2>&1 || true
+  launchctl unsetenv CODEXBAR_DISPLAY_FIRMWARE_MANIFEST_URL >/dev/null 2>&1 || true
+  [[ -z "$BASELINE_MOUNT" ]] || hdiutil detach "$BASELINE_MOUNT" -quiet >/dev/null 2>&1 || true
+  [[ -z "$BASELINE_WORK" ]] || rm -rf "$BASELINE_WORK"
+  [[ -z "$DEVICE_PID" ]] || kill "$DEVICE_PID" >/dev/null 2>&1 || true
+  [[ -z "$ARTIFACT_SERVER_PID" ]] || kill "$ARTIFACT_SERVER_PID" >/dev/null 2>&1 || true
+}
+
+write_result() {
+  status="$1"
+  if command -v screencapture >/dev/null 2>&1; then
+    screencapture -x "$RESULTS/screenshots/final.png" >/dev/null 2>&1 || true
+  fi
+  python3 - "$RESULTS/result.json" \
+    "$STATE" "$status" "$CURRENT_STAGE" "$FAILURE" "$FROM_APP" "$FROM_FIRMWARE" \
+    "$CANDIDATE" "$CANDIDATE_FIRMWARE" \
+    "$mac_migration" "$sparkle_update" "$app_relaunch" \
+    "$mac_update_skipped" "$firmware_update_skipped" \
+    "$app_version" "$app_build" "$runtime_version" \
+    "$listener_ownership" "$single_runtime" "$firmware_ota" "$same_device_id" \
+    "$health" "$stream" "$render" "$second_flash_prevented" <<'PY'
+import json, pathlib, sys
+(
+    path, state, status, stage, failure, from_app, from_firmware,
+    candidate, candidate_firmware, *checks
+) = sys.argv[1:]
+names = [
+    "macMigration", "sparkleUpdate", "appRelaunch", "macUpdateSkipped", "firmwareUpdateSkipped",
+    "appVersion", "appBuild", "runtimeVersion",
+    "listenerOwnership", "singleRuntime", "firmwareOTA", "sameDeviceId",
+    "health", "stream", "render", "secondFlashPrevented",
+]
+payload = {
+    "schemaVersion": 1,
+    "state": state,
+    "status": status,
+    "failedStage": stage if status != "passed" else "",
+    "failure": failure,
+    "from": {"app": from_app, "firmware": from_firmware},
+    "candidate": {"app": candidate, "firmware": candidate_firmware},
+    "checks": {name: value == "true" for name, value in zip(names, checks)},
+}
+pathlib.Path(path).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+  {
+    printf '# VibeTV release candidate: %s\n\n' "$STATE"
+    printf 'Status: **%s**\n\n' "$status"
+    printf -- '- Mac migration/install: %s\n' "$mac_migration"
+    printf -- '- Sparkle update/relaunch: %s / %s\n' "$sparkle_update" "$app_relaunch"
+    printf -- '- Skipped Mac/Firmware update: %s / %s\n' "$mac_update_skipped" "$firmware_update_skipped"
+    printf -- '- App version/build: %s / %s\n' "$app_version" "$app_build"
+    printf -- '- Runtime/listener: %s / %s\n' "$runtime_version" "$listener_ownership"
+    printf -- '- Firmware OTA/device identity: %s / %s\n' "$firmware_ota" "$same_device_id"
+    printf -- '- Health/stream/render: %s / %s / %s\n' "$health" "$stream" "$render"
+    printf -- '- Second flash prevented: %s\n' "$second_flash_prevented"
+    [[ -z "$FAILURE" ]] || printf '\nFailure at `%s`: %s\n' "$CURRENT_STAGE" "$FAILURE"
+  } > "$RESULTS/summary.md"
+}
+
+on_exit() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  if [[ "$status" == "0" ]]; then
+    write_result passed
+  else
+    [[ -n "$FAILURE" ]] || FAILURE="guest command failed with exit ${status}"
+    timeline "failed: $FAILURE"
+    write_result failed
+  fi
+  cleanup
+  exit "$status"
+}
+trap on_exit EXIT HUP INT TERM
+
+CURRENT_STAGE="preflight"
+timeline "validating private candidate bundle"
+for command in codesign curl ditto hdiutil launchctl lsof open pgrep plutil python3 shasum spctl tar; do
+  command -v "$command" >/dev/null 2>&1 || die "required guest command is missing: $command"
+done
+(
+  cd "$BUNDLE"
+  shasum -a 256 -c checksums.txt >/dev/null
+) || die "candidate bundle checksums failed"
+grep -q 'sparkle:edSignature=' "$BUNDLE/appcast.xml" \
+  || die "real VM tests require a signed private Sparkle appcast"
+grep -q '<!-- sparkle-signatures:' "$BUNDLE/appcast.xml" \
+  || die "real VM tests require the private Sparkle feed itself to be signed"
+bundle_build="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["build"])' "$BUNDLE/candidate.json")"
+bundle_candidate="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["candidate"])' "$BUNDLE/candidate.json")"
+bundle_baseline="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["baselineApp"])' "$BUNDLE/candidate.json")"
+[[ "$bundle_candidate" == "$CANDIDATE" ]] || die "candidate metadata mismatch"
+[[ "$bundle_baseline" == "$FROM_APP" ]] || die "public baseline metadata mismatch"
+
+CURRENT_STAGE="baseline"
+timeline "checking ${STATE} snapshot baseline"
+if [[ "$STATE" == "clean" ]]; then
+  [[ ! -e "$APP" ]] || die "clean snapshot already contains the app"
+else
+  [[ -e "$APP" || "$STATE" == "legacy" ]] || die "native snapshot is missing the public app"
+fi
+
+CURRENT_STAGE="candidate-sources"
+timeline "starting private artifact server and Virtual VibeTV"
+python3 -m http.server 47835 --bind 127.0.0.1 --directory "$BUNDLE" \
+  > "$RESULTS/artifact-server.log" 2>&1 &
+ARTIFACT_SERVER_PID="$!"
+firmware_sha="$(shasum -a 256 "$BUNDLE/firmware.bin" | awk '{print $1}')"
+"$BUNDLE/virtual-vibetv" \
+  --addr 127.0.0.1:47834 \
+  --device-id virtual-vibetv-rc-001 \
+  --firmware "$FROM_FIRMWARE" \
+  --candidate-firmware "$CANDIDATE_FIRMWARE" \
+  --expected-firmware-sha256 "$firmware_sha" \
+  --reboot-unavailable-requests 3 \
+  > "$RESULTS/virtual-vibetv.log" 2>&1 &
+DEVICE_PID="$!"
+for url in http://127.0.0.1:47835/candidate.json "$DEVICE_URL/hello"; do
+  deadline=$((SECONDS + 20))
+  until curl -fsS "$url" >/dev/null 2>&1; do
+    (( SECONDS < deadline )) || die "local candidate source did not start: $url"
+    sleep 1
+  done
+done
+
+mkdir -p "$HOME/Library/Application Support/codexbar-display"
+python3 - "$HOME/Library/Application Support/codexbar-display/config.json" "$DEVICE_URL" "$TOKEN" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+path.write_text(json.dumps({"deviceTarget": sys.argv[2], "deviceToken": sys.argv[3]}, indent=2) + "\n", encoding="utf-8")
+path.chmod(0o600)
+PY
+launchctl setenv CODEXBAR_DISPLAY_MAC_APP_RELEASE_API_URL http://127.0.0.1:47835/mac-app-release.json
+launchctl setenv CODEXBAR_DISPLAY_FIRMWARE_MANIFEST_URL http://127.0.0.1:47835/firmware-manifest.json
+
+wait_for_runtime_version() {
+  local expected="$1"
+  local output="$2"
+  local deadline=$((SECONDS + 180))
+  while (( SECONDS < deadline )); do
+    if curl -fsS "$STATUS_URL" > "$output" 2>/dev/null && \
+      python3 - "$output" "$expected" <<'PY'
+import json, sys
+status = json.load(open(sys.argv[1]))
+companion = status.get("companion") or {}
+raise SystemExit(
+    0 if status.get("ok") is True
+    and str(companion.get("version", "")).removeprefix("v") == sys.argv[2]
+    else 1
+)
+PY
+    then
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+install_public_baseline() {
+  local source_app version
+  BASELINE_WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-public-baseline.XXXXXX")"
+  BASELINE_MOUNT=""
+  cleanup_baseline() {
+    [[ -z "$BASELINE_MOUNT" ]] || hdiutil detach "$BASELINE_MOUNT" -quiet >/dev/null 2>&1 || true
+    [[ -z "$BASELINE_WORK" ]] || rm -rf "$BASELINE_WORK"
+    BASELINE_MOUNT=""
+    BASELINE_WORK=""
+  }
+  hdiutil attach -readonly -nobrowse -plist "$BUNDLE/public-baseline.dmg" > "$BASELINE_WORK/attach.plist"
+  BASELINE_MOUNT="$(python3 - "$BASELINE_WORK/attach.plist" <<'PY'
+import plistlib, sys
+for entity in plistlib.load(open(sys.argv[1], "rb")).get("system-entities", []):
+    if entity.get("mount-point"):
+        print(entity["mount-point"])
+        break
+PY
+)"
+  source_app="$BASELINE_MOUNT/VibeTV Control Center.app"
+  [[ -d "$source_app" ]] || die "public baseline DMG has no app bundle"
+  codesign --verify --deep --strict --verbose=2 "$source_app"
+  spctl --assess --type execute --verbose "$source_app"
+  version="$(plutil -extract CFBundleShortVersionString raw -o - "$source_app/Contents/Info.plist")"
+  [[ "${version#v}" == "$FROM_APP" ]] || die "public baseline DMG version mismatch"
+  rm -rf "$APP"
+  ditto "$source_app" "$APP"
+  cleanup_baseline
+}
+
+CURRENT_STAGE="public-baseline"
+timeline "preparing the current public app before the candidate update"
+if [[ "$STATE" == "clean" || "$STATE" == "legacy" ]]; then
+  install_public_baseline
+else
+  current_version="$(plutil -extract CFBundleShortVersionString raw -o - "$APP/Contents/Info.plist")"
+  [[ "${current_version#v}" == "$FROM_APP" ]] || die "native snapshot app version mismatch"
+fi
+open "$APP"
+wait_for_runtime_version "$FROM_APP" "$RESULTS/baseline-status.json" \
+  || die "public baseline runtime did not become healthy"
+app_pid_before="$(pgrep -f 'VibeTV Control Center.app/Contents/MacOS/VibeTVControlCenter' | head -n1 || true)"
+[[ -n "$app_pid_before" ]] || die "public baseline app is not running"
+mac_migration=true
+
+CURRENT_STAGE="mac-install-update"
+expected_app_version="$CANDIDATE"
+expected_runtime_version="$CANDIDATE"
+if [[ "$SKIP_MAC_UPDATE" == "1" ]]; then
+  timeline "skipping Mac candidate update by explicit request"
+  mac_update_skipped=true
+  expected_app_version="$FROM_APP"
+  expected_runtime_version="$FROM_APP"
+  cp "$RESULTS/baseline-status.json" "$RESULTS/status.json"
+else
+  timeline "updating the running public app through Sparkle"
+  sparkle_work="$RESULTS/sparkle-cli"
+  mkdir -p "$sparkle_work"
+  tar -xzf "$BUNDLE/sparkle-cli.tar.gz" -C "$sparkle_work"
+  sparkle_cli="$sparkle_work/sparkle.app/Contents/MacOS/sparkle"
+  [[ -x "$sparkle_cli" ]] || die "Sparkle CLI archive has no executable"
+  codesign --verify --deep --strict --verbose=2 "$sparkle_work/sparkle.app"
+  "$sparkle_cli" \
+    "$APP" \
+    --application "$APP" \
+    --check-immediately \
+    --allow-major-upgrades \
+    --feed-url http://127.0.0.1:47835/appcast.xml \
+    --user-agent-name CODEX-VibeTV-RC \
+    --verbose \
+    > "$RESULTS/mac-update.log" 2>&1 \
+    || die "Sparkle candidate update failed"
+  sparkle_update=true
+  wait_for_runtime_version "$CANDIDATE" "$RESULTS/status.json" \
+    || die "candidate runtime did not become healthy after Sparkle update"
+  app_pid_after="$(pgrep -f 'VibeTV Control Center.app/Contents/MacOS/VibeTVControlCenter' | head -n1 || true)"
+  [[ -n "$app_pid_after" && "$app_pid_after" != "$app_pid_before" ]] \
+    || die "Sparkle did not relaunch the candidate app with a new process"
+  app_relaunch=true
+fi
+
+CURRENT_STAGE="mac-final-state"
+timeline "verifying app bundle, runtime, SMAppService, and listener"
+installed_version="$(plutil -extract CFBundleShortVersionString raw -o - "$APP/Contents/Info.plist")"
+installed_build="$(plutil -extract CFBundleVersion raw -o - "$APP/Contents/Info.plist")"
+[[ "${installed_version#v}" == "$expected_app_version" ]] || die "installed app version mismatch"
+app_version=true
+if [[ "$SKIP_MAC_UPDATE" == "1" ]]; then
+  [[ -n "$installed_build" ]] || die "installed public app build is missing"
+else
+  [[ "$installed_build" == "$bundle_build" ]] || die "installed app build mismatch"
+fi
+app_build=true
+
+status_json="$RESULTS/status.json"
+python3 - "$status_json" "$expected_runtime_version" <<'PY' || exit 1
+import json, sys
+status = json.load(open(sys.argv[1]))
+companion = status.get("companion") or {}
+raise SystemExit(0 if status.get("ok") is True and str(companion.get("version", "")).removeprefix("v") == sys.argv[2] else 1)
+PY
+runtime_version=true
+runtime_pid="$(launchctl print "gui/$(id -u)/shop.vibetv.control-center.runtime" 2>/dev/null | sed -nE 's/^[[:space:]]*pid = ([0-9]+)$/\1/p')"
+[[ "$(printf '%s\n' "$runtime_pid" | awk 'NF{n++} END{print n+0}')" == "1" ]] || die "SMAppService runtime PID is not unique"
+listener_pid="$(lsof -nP -a -iTCP@127.0.0.1:47832 -sTCP:LISTEN -Fp 2>/dev/null | sed -nE 's/^p([0-9]+)$/\1/p' | sort -u)"
+[[ "$listener_pid" == "$runtime_pid" ]] || die "port 47832 is not owned by the SMAppService runtime"
+listener_ownership=true
+for legacy_label in com.codexbar-display.daemon com.codexbar-display.companion-api; do
+  ! launchctl print "gui/$(id -u)/${legacy_label}" >/dev/null 2>&1 || die "legacy service is still loaded: $legacy_label"
+done
+single_runtime=true
+
+wait_update_job() {
+  local start_file="$1"
+  local output_file="$2"
+  local job_id
+  job_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["job"]["id"])' "$start_file")"
+  deadline=$((SECONDS + 180))
+  while (( SECONDS < deadline )); do
+    curl -fsS "http://127.0.0.1:47832/v1/updates/install/status?jobId=${job_id}" > "$output_file"
+    phase="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["job"]["phase"])' "$output_file")"
+    [[ "$phase" == "complete" ]] && return 0
+    [[ "$phase" != "error" ]] || return 1
+    sleep 1
+  done
+  return 1
+}
+
+CURRENT_STAGE="firmware-ota"
+expected_device_firmware="$CANDIDATE_FIRMWARE"
+expected_uploads=1
+if [[ "$SKIP_FIRMWARE_UPDATE" == "1" ]]; then
+  timeline "skipping firmware candidate update by explicit request"
+  firmware_update_skipped=true
+  expected_device_firmware="$FROM_FIRMWARE"
+  expected_uploads=0
+else
+  timeline "updating candidate firmware through the real Companion job"
+  curl -fsS -X POST -H 'Content-Type: application/json' -d '{}' \
+    http://127.0.0.1:47832/v1/updates/install > "$RESULTS/firmware-start.json" \
+    || die "firmware update job did not start"
+  wait_update_job "$RESULTS/firmware-start.json" "$RESULTS/firmware-result.json" \
+    || die "firmware update job failed"
+  firmware_ota=true
+  [[ "$CANDIDATE_FIRMWARE" != "$FROM_FIRMWARE" ]] || expected_uploads=0
+fi
+
+CURRENT_STAGE="device-verification"
+timeline "verifying device identity, version, health, stream, and render"
+curl -fsS "$DEVICE_URL/hello" > "$RESULTS/device-hello.json"
+curl -fsS "$DEVICE_URL/health" > "$RESULTS/device-health.json"
+curl -fsS "$DEVICE_URL/__virtual/state" > "$RESULTS/device-state.json"
+python3 - "$RESULTS/device-hello.json" "$RESULTS/device-health.json" "$RESULTS/device-state.json" \
+  "$expected_device_firmware" "$expected_uploads" <<'PY' || exit 1
+import json, sys
+hello, health, state = (json.load(open(path)) for path in sys.argv[1:4])
+expected = sys.argv[4]
+expected_uploads = int(sys.argv[5])
+assert hello.get("deviceId") == "virtual-vibetv-rc-001"
+assert hello.get("firmware") == expected
+assert health.get("ok") is True
+assert (health.get("display") or {}).get("themeSpec", {}).get("renderOk") is True
+assert state.get("updateUploads") == expected_uploads
+PY
+same_device_id=true
+health=true
+render=true
+curl -fsS "$STATUS_URL" > "$RESULTS/final-status.json"
+deadline=$((SECONDS + 90))
+while true; do
+  curl -fsS "$STATUS_URL" > "$RESULTS/final-status.json"
+  if python3 - "$RESULTS/final-status.json" <<'PY'
+import json, sys
+status = json.load(open(sys.argv[1]))
+device = status.get("device") or {}
+stream = device.get("stream") or {}
+raise SystemExit(0 if device.get("connected") is True and stream.get("healthy") is True else 1)
+PY
+  then
+    break
+  fi
+  (( SECONDS < deadline )) || die "display stream did not become healthy"
+  sleep 2
+done
+stream=true
+
+CURRENT_STAGE="second-flash-guard"
+if [[ "$SKIP_FIRMWARE_UPDATE" == "1" ]]; then
+  timeline "proving the skipped firmware path performed no OTA upload"
+else
+  timeline "re-running update to prove already-current is a no-op"
+  curl -fsS -X POST -H 'Content-Type: application/json' -d '{}' \
+    http://127.0.0.1:47832/v1/updates/install > "$RESULTS/firmware-noop-start.json"
+  wait_update_job "$RESULTS/firmware-noop-start.json" "$RESULTS/firmware-noop-result.json" \
+    || die "already-current update did not complete as a no-op"
+fi
+curl -fsS "$DEVICE_URL/__virtual/state" > "$RESULTS/device-state-final.json"
+python3 - "$RESULTS/device-state-final.json" "$expected_uploads" <<'PY' || exit 1
+import json, sys
+state = json.load(open(sys.argv[1]))
+raise SystemExit(0 if state.get("updateUploads") == int(sys.argv[2]) and not state.get("violations") else 1)
+PY
+second_flash_prevented=true
+
+CURRENT_STAGE="complete"
+timeline "all candidate checks passed"

--- a/scripts/release-candidate/install-candidate-mac-app.sh
+++ b/scripts/release-candidate/install-candidate-mac-app.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="VibeTV Control Center"
+INSTALL_APP="/Applications/${APP_NAME}.app"
+DMG_URL="${VIBETV_CANDIDATE_DMG_URL:-http://127.0.0.1:47835/VibeTV-Control-Center.dmg}"
+EXPECTED_VERSION=""
+EXPECTED_BUILD="${VIBETV_CANDIDATE_BUILD:-}"
+ADDR="127.0.0.1:47832"
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) EXPECTED_VERSION="${2#v}"; shift 2 ;;
+    --addr) ADDR="$2"; shift 2 ;;
+    --skip-device-setup) shift ;;
+    --dmg-url) DMG_URL="$2"; shift 2 ;;
+    *) die "unknown candidate installer argument: $1" ;;
+  esac
+done
+
+[[ "${CODEX_ALLOW_RELEASE_CANDIDATE_INSTALL:-}" == "1" ]] \
+  || die "candidate install requires CODEX_ALLOW_RELEASE_CANDIDATE_INSTALL=1"
+[[ "$EXPECTED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
+  || die "candidate version is required"
+[[ "$(uname -s)" == "Darwin" ]] || die "candidate install requires macOS"
+for command in codesign curl ditto hdiutil lsof open plutil python3 spctl; do
+  command -v "$command" >/dev/null 2>&1 || die "missing command: $command"
+done
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-candidate-install.XXXXXX")"
+MOUNT=""
+BACKUP=""
+STAGED="/Applications/.${APP_NAME}.candidate.$$"
+cleanup() {
+  [[ -z "$MOUNT" ]] || hdiutil detach "$MOUNT" -quiet >/dev/null 2>&1 || true
+  rm -rf "$WORK" "$STAGED"
+}
+trap cleanup EXIT HUP INT TERM
+
+printf 'Downloading Mac App candidate...\n'
+curl -fsSL "$DMG_URL" -o "$WORK/candidate.dmg"
+attach_plist="$WORK/attach.plist"
+hdiutil attach -readonly -nobrowse -plist "$WORK/candidate.dmg" > "$attach_plist"
+MOUNT="$(plutil -extract system-entities xml1 -o - "$attach_plist" | python3 -c '
+import plistlib, sys
+entities = plistlib.load(sys.stdin.buffer)
+for entity in entities:
+    mount = entity.get("mount-point")
+    if mount:
+        print(mount)
+        break
+')"
+SOURCE_APP="$MOUNT/${APP_NAME}.app"
+[[ -d "$SOURCE_APP" ]] || die "candidate DMG does not contain ${APP_NAME}.app"
+codesign --verify --deep --strict --verbose=2 "$SOURCE_APP"
+spctl --assess --type execute --verbose=4 "$SOURCE_APP"
+
+version="$(plutil -extract CFBundleShortVersionString raw -o - "$SOURCE_APP/Contents/Info.plist")"
+build="$(plutil -extract CFBundleVersion raw -o - "$SOURCE_APP/Contents/Info.plist")"
+[[ "${version#v}" == "$EXPECTED_VERSION" ]] \
+  || die "candidate app version ${version:-missing} does not match ${EXPECTED_VERSION}"
+[[ -z "$EXPECTED_BUILD" || "$build" == "$EXPECTED_BUILD" ]] \
+  || die "candidate app build ${build:-missing} does not match ${EXPECTED_BUILD}"
+
+printf 'Stopping current Mac App...\n'
+pkill -x VibeTVControlCenter >/dev/null 2>&1 || true
+sleep 1
+ditto "$SOURCE_APP" "$STAGED"
+codesign --verify --deep --strict --verbose=2 "$STAGED"
+
+if [[ -e "$INSTALL_APP" ]]; then
+  BACKUP="$WORK/${APP_NAME}.previous.app"
+  mv "$INSTALL_APP" "$BACKUP"
+fi
+if ! mv "$STAGED" "$INSTALL_APP"; then
+  [[ -z "$BACKUP" ]] || mv "$BACKUP" "$INSTALL_APP"
+  die "could not replace app in /Applications"
+fi
+
+rollback() {
+  rm -rf "$INSTALL_APP"
+  [[ -z "$BACKUP" ]] || mv "$BACKUP" "$INSTALL_APP"
+  [[ ! -d "$INSTALL_APP" ]] || open "$INSTALL_APP" >/dev/null 2>&1 || true
+  die "$1"
+}
+
+printf 'Relaunching Mac App...\n'
+open "$INSTALL_APP"
+deadline=$((SECONDS + 120))
+while (( SECONDS < deadline )); do
+  if status="$(curl -fsS "http://${ADDR}/v1/status" 2>/dev/null)"; then
+    if python3 - "$EXPECTED_VERSION" "$status" <<'PY'
+import json, sys
+expected = sys.argv[1]
+status = json.loads(sys.argv[2])
+companion = status.get("companion") or {}
+raise SystemExit(0 if status.get("ok") is True and str(companion.get("version", "")).removeprefix("v") == expected else 1)
+PY
+    then
+      runtime_pid="$(launchctl print "gui/$(id -u)/shop.vibetv.control-center.runtime" 2>/dev/null | sed -nE 's/^[[:space:]]*pid = ([0-9]+)$/\1/p' | head -n1)"
+      listener_pid="$(lsof -nP -a -iTCP@127.0.0.1:47832 -sTCP:LISTEN -Fp 2>/dev/null | sed -nE 's/^p([0-9]+)$/\1/p' | sort -u)"
+      if [[ -n "$runtime_pid" && "$listener_pid" == "$runtime_pid" ]]; then
+        rm -rf "$BACKUP"
+        printf 'Verified Mac App %s build %s and runtime listener ownership.\n' "$EXPECTED_VERSION" "$build"
+        exit 0
+      fi
+    fi
+  fi
+  sleep 2
+done
+
+rollback "candidate app/runtime/listener verification timed out"

--- a/scripts/release-candidate/prepare-guest-state.sh
+++ b/scripts/release-candidate/prepare-guest-state.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE=""
+VERSION=""
+APP="/Applications/VibeTV Control Center.app"
+
+die() {
+  printf 'error: snapshot preparation: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --state) STATE="$2"; shift 2 ;;
+    --version) VERSION="${2#v}"; shift 2 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ "$STATE" == "native" || "$STATE" == "legacy" ]] || die "state must be native or legacy"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || die "valid version required"
+[[ "$(uname -s)" == "Darwin" ]] || die "macOS guest required"
+
+rm -rf "$HOME/Library/Application Support/codexbar-display"
+rm -f "$HOME/Library/Preferences/shop.vibetv.control-center.plist"
+launchctl bootout "gui/$(id -u)/shop.vibetv.control-center.runtime" >/dev/null 2>&1 || true
+launchctl bootout "gui/$(id -u)/com.codexbar-display.daemon" >/dev/null 2>&1 || true
+launchctl bootout "gui/$(id -u)/com.codexbar-display.companion-api" >/dev/null 2>&1 || true
+rm -rf "$APP" "$HOME/Applications/VibeTV Control Center.app"
+
+if [[ "$STATE" == "native" ]]; then
+  work="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-native-snapshot.XXXXXX")"
+  mount=""
+  cleanup() {
+    [[ -z "$mount" ]] || hdiutil detach "$mount" -quiet >/dev/null 2>&1 || true
+    rm -rf "$work"
+  }
+  trap cleanup EXIT HUP INT TERM
+  url="https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v${VERSION}/VibeTV-Control-Center.dmg"
+  curl -fsSL "$url" -o "$work/public.dmg"
+  hdiutil attach -readonly -nobrowse -plist "$work/public.dmg" > "$work/attach.plist"
+  mount="$(python3 - "$work/attach.plist" <<'PY'
+import plistlib, sys
+for entity in plistlib.load(open(sys.argv[1], "rb")).get("system-entities", []):
+    if entity.get("mount-point"):
+        print(entity["mount-point"])
+        break
+PY
+)"
+  source_app="$mount/VibeTV Control Center.app"
+  [[ -d "$source_app" ]] || die "public DMG has no app bundle"
+  codesign --verify --deep --strict --verbose=2 "$source_app"
+  ditto "$source_app" "$APP"
+  open "$APP"
+else
+  installer="https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v${VERSION}/install-control-center-companion.sh"
+  curl -fsSL "$installer" | bash -s -- \
+    --version "$VERSION" \
+    --skip-device-setup \
+    --addr 127.0.0.1:47832
+fi
+
+deadline=$((SECONDS + 120))
+while (( SECONDS < deadline )); do
+  if status="$(curl -fsS http://127.0.0.1:47832/v1/status 2>/dev/null)"; then
+    if python3 - "$VERSION" "$status" <<'PY'
+import json, sys
+status = json.loads(sys.argv[2])
+companion = status.get("companion") or {}
+raise SystemExit(0 if str(companion.get("version", "")).removeprefix("v") == sys.argv[1] else 1)
+PY
+    then
+      printf 'Prepared %s snapshot at version %s\n' "$STATE" "$VERSION"
+      exit 0
+    fi
+  fi
+  sleep 2
+done
+die "prepared state did not become healthy"

--- a/scripts/test-release-candidate-contract.sh
+++ b/scripts/test-release-candidate-contract.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-rc-contract.XXXXXX")"
+cleanup() {
+  rm -rf "$WORK"
+}
+trap cleanup EXIT HUP INT TERM
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+mkdir -p "$WORK/input"
+printf 'fake dmg' > "$WORK/input/VibeTV-Control-Center.dmg"
+printf 'fake public baseline dmg' > "$WORK/input/public-baseline.dmg"
+printf 'fake firmware' > "$WORK/input/firmware.bin"
+cat > "$WORK/input/virtual-vibetv" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod 755 "$WORK/input/virtual-vibetv"
+mkdir -p "$WORK/input/sparkle.app/Contents/MacOS"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$WORK/input/sparkle.app/Contents/MacOS/sparkle"
+chmod 755 "$WORK/input/sparkle.app/Contents/MacOS/sparkle"
+tar -czf "$WORK/input/sparkle-cli.tar.gz" -C "$WORK/input" sparkle.app
+
+"$ROOT/scripts/release-candidate/create-candidate-bundle.sh" \
+  --dmg "$WORK/input/VibeTV-Control-Center.dmg" \
+  --baseline-dmg "$WORK/input/public-baseline.dmg" \
+  --baseline-version 1.0.43 \
+  --firmware "$WORK/input/firmware.bin" \
+  --virtual-vibetv "$WORK/input/virtual-vibetv" \
+  --sparkle-cli-archive "$WORK/input/sparkle-cli.tar.gz" \
+  --candidate 9.8.7 \
+  --candidate-firmware 9.8.6 \
+  --build 123 \
+  --source-sha abcdef1234567890 \
+  --output "$WORK/bundle" \
+  --allow-unsigned-appcast \
+  > "$WORK/bundle.log"
+
+for required in candidate.json checksums.txt appcast.xml firmware-manifest.json mac-app-release.json \
+  VibeTV-Control-Center.dmg public-baseline.dmg firmware.bin sparkle-cli.tar.gz \
+  virtual-vibetv install-candidate-mac-app.sh; do
+  [[ -f "$WORK/bundle/$required" ]] || fail "bundle missing $required"
+done
+(
+  cd "$WORK/bundle"
+  shasum -a 256 -c checksums.txt >/dev/null
+) || fail "bundle checksums do not verify"
+python3 - "$WORK/bundle/candidate.json" "$WORK/bundle/firmware-manifest.json" <<'PY' || fail "bundle metadata is wrong"
+import json, sys
+candidate = json.load(open(sys.argv[1]))
+firmware = json.load(open(sys.argv[2]))
+assert candidate["candidate"] == "9.8.7"
+assert candidate["candidateFirmware"] == "9.8.6"
+assert candidate["baselineApp"] == "1.0.43"
+assert candidate["private"] is True
+assert firmware["artifacts"][0]["firmwareVersion"] == "9.8.6"
+PY
+
+export VIBETV_RC_FAKE_DRIVER_LOG="$WORK/fake-driver.log"
+"$ROOT/scripts/test-release-candidate.sh" \
+  --from-app 1.0.43 \
+  --legacy-app 1.0.42 \
+  --from-firmware 1.0.36 \
+  --candidate 9.8.7 \
+  --candidate-firmware 9.8.6 \
+  --bundle "$WORK/bundle" \
+  --vm-driver fake \
+  --output "$WORK/run" \
+  > "$WORK/run.log"
+
+python3 - "$WORK/run/result.json" <<'PY' || fail "aggregate result is wrong"
+import json, sys
+result = json.load(open(sys.argv[1]))
+assert result["status"] == "passed"
+assert [item["state"] for item in result["states"]] == ["clean", "legacy", "native"]
+assert all(item["checks"]["snapshotDisposed"] for item in result["states"])
+PY
+[[ "$(grep -c '^clone ' "$WORK/fake-driver.log")" == "3" ]] || fail "expected three VM clones"
+[[ "$(grep -c '^delete ' "$WORK/fake-driver.log")" == "3" ]] || fail "expected three disposed VM clones"
+
+if "$ROOT/scripts/release-candidate/create-candidate-bundle.sh" \
+  --dmg "$WORK/input/VibeTV-Control-Center.dmg" \
+  --baseline-dmg "$WORK/input/public-baseline.dmg" \
+  --baseline-version 1.0.43 \
+  --firmware "$WORK/input/firmware.bin" \
+  --virtual-vibetv "$WORK/input/virtual-vibetv" \
+  --sparkle-cli-archive "$WORK/input/sparkle-cli.tar.gz" \
+  --candidate 9.8.7 \
+  --build 123 \
+  --source-sha abcdef1234567890 \
+  --output "$WORK/should-fail" \
+  > "$WORK/unsigned.log" 2>&1; then
+  fail "real bundle unexpectedly allowed an unsigned appcast"
+fi
+
+workflow="$ROOT/.github/workflows/release-candidate.yml"
+grep -q '^name: CODEX Test VibeTV Release Candidate$' "$workflow" \
+  || fail "candidate workflow name must use the CODEX prefix"
+grep -q 'ref: \${{ github.workflow_sha }}' "$workflow" \
+  || fail "secret-bearing jobs must use trusted workflow source"
+grep -q 'SPARKLE_ED_PRIVATE_KEY_BASE64' "$workflow" \
+  || fail "candidate workflow does not create a signed private appcast"
+grep -q 'build-sparkle-cli.sh' "$workflow" \
+  || fail "candidate workflow does not build Sparkle's official CLI updater"
+grep -q 'extract-candidate-app-archive.sh' "$workflow" \
+  || fail "secret-bearing job does not use the safe candidate app extractor"
+grep -q 'retention-days: 1' "$workflow" \
+  || fail "candidate artifacts are not short-lived"
+grep -q 'runs-on: \[self-hosted, macOS, ARM64, codex-vibetv-rc\]' "$workflow" \
+  || fail "real VM gate is not isolated to the prepared Apple-Silicon runner"
+if grep -Eq 'gh release|git tag|git push origin main|releases/create' "$workflow"; then
+  fail "candidate workflow must not merge, tag, or publish"
+fi
+grep -q 'SPARKLE_SOURCE_SHA256=' "$ROOT/scripts/release-candidate/build-sparkle-cli.sh" \
+  || fail "Sparkle CLI source is not checksum-pinned"
+grep -q 'sparkle.app/Contents/MacOS/sparkle' "$ROOT/scripts/release-candidate/guest-run.sh" \
+  || fail "real guest path does not invoke Sparkle CLI"
+if grep -R -q 'CODEX-vibetv-legacy-1\.0\.41\|LEGACY_APP="1\.0\.41"' \
+  "$ROOT/scripts" "$ROOT/docs/virtual-vibetv.md"; then
+  fail "legacy baseline must not be hard-coded to 1.0.41"
+fi
+
+mkdir -p "$WORK/safe-app/VibeTV Control Center.app/Contents"
+printf '<plist version="1.0"><dict/></plist>\n' \
+  > "$WORK/safe-app/VibeTV Control Center.app/Contents/Info.plist"
+COPYFILE_DISABLE=1 tar -czf "$WORK/safe-app.tar.gz" -C "$WORK/safe-app" "VibeTV Control Center.app"
+"$ROOT/scripts/release-candidate/extract-candidate-app-archive.sh" \
+  --archive "$WORK/safe-app.tar.gz" \
+  --output "$WORK/safe-extracted" >/dev/null \
+  || fail "safe candidate app archive was rejected"
+
+python3 - "$WORK/malicious-app.tar.gz" <<'PY'
+import io, tarfile, sys
+with tarfile.open(sys.argv[1], "w:gz") as archive:
+    payload = b"overwrite"
+    member = tarfile.TarInfo("../../scripts/release-candidate/guest-run.sh")
+    member.size = len(payload)
+    archive.addfile(member, io.BytesIO(payload))
+PY
+if "$ROOT/scripts/release-candidate/extract-candidate-app-archive.sh" \
+  --archive "$WORK/malicious-app.tar.gz" \
+  --output "$WORK/malicious-extracted" >/dev/null 2>&1; then
+  fail "unsafe candidate app archive path was accepted"
+fi
+
+printf 'PASS: release-candidate bundle, VM lifecycle, reports, and disposal contract\n'

--- a/scripts/test-release-candidate.sh
+++ b/scripts/test-release-candidate.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUNDLE=""
+FROM_APP=""
+LEGACY_APP=""
+FROM_FIRMWARE=""
+CANDIDATE=""
+CANDIDATE_FIRMWARE=""
+OUTPUT=""
+STATES="clean,legacy,native"
+DRIVER="tart"
+CLEAN_IMAGE="CODEX-vibetv-clean"
+LEGACY_IMAGE=""
+NATIVE_IMAGE=""
+KEEP_FAILED_VM=0
+SKIP_MAC_UPDATE=0
+SKIP_FIRMWARE_UPDATE=0
+ACTIVE_VM=""
+ACTIVE_DRIVER=""
+ACTIVE_RESULT=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/test-release-candidate.sh \
+    --from-app <current-public-version> \
+    --legacy-app <previous-public-or-migration-floor-version> \
+    --from-firmware <current-public-version> \
+    --candidate <candidate-version> \
+    --bundle <private-candidate-directory> \
+    [--candidate-firmware <version>] [--output <directory>]
+
+Optional VM settings:
+  --vm-driver tart|fake|/path/to/driver
+  --states clean,legacy,native
+  --clean-image <Tart image>
+  --legacy-image <Tart image>
+  --native-image <Tart image>
+  --keep-failed-vm
+  --skip-mac-update
+  --skip-firmware-update
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_value() {
+  [[ -n "${2:-}" ]] || die "$1 needs a value"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle) need_value "$1" "${2:-}"; BUNDLE="$2"; shift 2 ;;
+    --from-app) need_value "$1" "${2:-}"; FROM_APP="${2#v}"; shift 2 ;;
+    --legacy-app) need_value "$1" "${2:-}"; LEGACY_APP="${2#v}"; shift 2 ;;
+    --from-firmware) need_value "$1" "${2:-}"; FROM_FIRMWARE="${2#v}"; shift 2 ;;
+    --candidate) need_value "$1" "${2:-}"; CANDIDATE="${2#v}"; shift 2 ;;
+    --candidate-firmware) need_value "$1" "${2:-}"; CANDIDATE_FIRMWARE="${2#v}"; shift 2 ;;
+    --output) need_value "$1" "${2:-}"; OUTPUT="$2"; shift 2 ;;
+    --states) need_value "$1" "${2:-}"; STATES="$2"; shift 2 ;;
+    --vm-driver) need_value "$1" "${2:-}"; DRIVER="$2"; shift 2 ;;
+    --clean-image) need_value "$1" "${2:-}"; CLEAN_IMAGE="$2"; shift 2 ;;
+    --legacy-image) need_value "$1" "${2:-}"; LEGACY_IMAGE="$2"; shift 2 ;;
+    --native-image) need_value "$1" "${2:-}"; NATIVE_IMAGE="$2"; shift 2 ;;
+    --keep-failed-vm) KEEP_FAILED_VM=1; shift ;;
+    --skip-mac-update) SKIP_MAC_UPDATE=1; shift ;;
+    --skip-firmware-update) SKIP_FIRMWARE_UPDATE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+for version_name in FROM_APP LEGACY_APP FROM_FIRMWARE CANDIDATE; do
+  version="${!version_name}"
+  [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
+    || die "${version_name,,} must be a SemVer release version"
+done
+[[ -n "$CANDIDATE_FIRMWARE" ]] || CANDIDATE_FIRMWARE="$CANDIDATE"
+[[ "$CANDIDATE_FIRMWARE" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
+  || die "candidate firmware must be a SemVer release version"
+[[ -d "$BUNDLE" ]] || die "candidate bundle not found: $BUNDLE"
+for required in candidate.json checksums.txt appcast.xml firmware-manifest.json mac-app-release.json \
+  VibeTV-Control-Center.dmg public-baseline.dmg firmware.bin sparkle-cli.tar.gz \
+  virtual-vibetv install-candidate-mac-app.sh; do
+  [[ -e "$BUNDLE/$required" ]] || die "candidate bundle is missing $required"
+done
+(
+  cd "$BUNDLE"
+  shasum -a 256 -c checksums.txt >/dev/null
+) || die "candidate bundle checksum validation failed"
+bundle_candidate="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["candidate"])' "$BUNDLE/candidate.json")"
+[[ "$bundle_candidate" == "$CANDIDATE" ]] \
+  || die "bundle candidate ${bundle_candidate} does not match --candidate ${CANDIDATE}"
+bundle_firmware="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("candidateFirmware", ""))' "$BUNDLE/candidate.json")"
+[[ "$bundle_firmware" == "$CANDIDATE_FIRMWARE" ]] \
+  || die "bundle firmware ${bundle_firmware} does not match --candidate-firmware ${CANDIDATE_FIRMWARE}"
+bundle_baseline="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("baselineApp", ""))' "$BUNDLE/candidate.json")"
+[[ "$bundle_baseline" == "$FROM_APP" ]] \
+  || die "bundle baseline ${bundle_baseline} does not match --from-app ${FROM_APP}"
+
+case "$DRIVER" in
+  tart|fake) ACTIVE_DRIVER="$ROOT/scripts/release-candidate/drivers/${DRIVER}.sh" ;;
+  *) ACTIVE_DRIVER="$DRIVER" ;;
+esac
+[[ -x "$ACTIVE_DRIVER" ]] || die "VM driver is not executable: $ACTIVE_DRIVER"
+[[ -n "$LEGACY_IMAGE" ]] || LEGACY_IMAGE="CODEX-vibetv-legacy-${LEGACY_APP}"
+[[ -n "$NATIVE_IMAGE" ]] || NATIVE_IMAGE="CODEX-vibetv-native-${FROM_APP}"
+[[ -n "$OUTPUT" ]] || OUTPUT="$ROOT/tmp/release-candidate/${CANDIDATE}-$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$OUTPUT"
+RUN_DIR="$(cd "$OUTPUT" && pwd)"
+SHARE_DIR="$RUN_DIR/shared"
+mkdir -p "$SHARE_DIR/bundle" "$SHARE_DIR/results"
+cp -R "$BUNDLE/." "$SHARE_DIR/bundle/"
+cp "$ROOT/scripts/release-candidate/guest-run.sh" "$SHARE_DIR/guest-run.sh"
+chmod 755 "$SHARE_DIR/guest-run.sh"
+
+export VIBETV_RC_FAKE_SHARE_DIR="$SHARE_DIR"
+printf 'Release candidate %s\n' "$CANDIDATE" > "$RUN_DIR/host.log"
+
+cleanup_active_vm() {
+  local failed="${1:-0}"
+  [[ -n "$ACTIVE_VM" ]] || return 0
+  "$ACTIVE_DRIVER" stop "$ACTIVE_VM" >> "$RUN_DIR/host.log" 2>&1 || true
+  if [[ "$KEEP_FAILED_VM" == "1" && "$failed" != "0" ]]; then
+    printf 'Keeping failed VM: %s\n' "$ACTIVE_VM" | tee -a "$RUN_DIR/host.log"
+    ACTIVE_VM=""
+    return 0
+  fi
+  if "$ACTIVE_DRIVER" delete "$ACTIVE_VM" >> "$RUN_DIR/host.log" 2>&1; then
+    if [[ -f "$ACTIVE_RESULT" ]]; then
+      python3 - "$ACTIVE_RESULT" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+data = json.loads(path.read_text(encoding="utf-8"))
+data.setdefault("checks", {})["snapshotDisposed"] = True
+path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+    fi
+  else
+    printf 'Failed to delete VM: %s\n' "$ACTIVE_VM" | tee -a "$RUN_DIR/host.log"
+    return 1
+  fi
+  ACTIVE_VM=""
+}
+
+on_exit() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  cleanup_active_vm "$status" || status=1
+  exit "$status"
+}
+trap on_exit EXIT HUP INT TERM
+
+"$ACTIVE_DRIVER" check
+IFS=',' read -r -a requested_states <<< "$STATES"
+overall_status=0
+for state in "${requested_states[@]}"; do
+  case "$state" in
+    clean) source_image="$CLEAN_IMAGE" ;;
+    legacy) source_image="$LEGACY_IMAGE" ;;
+    native) source_image="$NATIVE_IMAGE" ;;
+    *) die "unsupported state: $state" ;;
+  esac
+  vm_name="CODEX-rc-${state}-${CANDIDATE//[^0-9A-Za-z]/-}-$$"
+  result_dir="$SHARE_DIR/results/$state"
+  mkdir -p "$result_dir"
+  ACTIVE_VM="$vm_name"
+  ACTIVE_RESULT="$result_dir/result.json"
+  printf 'state=%s source=%s vm=%s\n' "$state" "$source_image" "$vm_name" | tee -a "$RUN_DIR/host.log"
+  "$ACTIVE_DRIVER" clone "$source_image" "$vm_name" >> "$RUN_DIR/host.log" 2>&1
+  "$ACTIVE_DRIVER" run "$vm_name" "$SHARE_DIR" "$RUN_DIR/$state" >> "$RUN_DIR/host.log" 2>&1
+  guest_results="/Volumes/My Shared Files/codex-rc/results/$state"
+  state_status=0
+  guest_args=(
+    --state "$state" \
+    --bundle "/Volumes/My Shared Files/codex-rc/bundle" \
+    --results "$guest_results" \
+    --from-app "$FROM_APP" \
+    --from-firmware "$FROM_FIRMWARE" \
+    --candidate "$CANDIDATE" \
+    --candidate-firmware "$CANDIDATE_FIRMWARE"
+  )
+  [[ "$SKIP_MAC_UPDATE" == "0" ]] || guest_args+=(--skip-mac-update)
+  [[ "$SKIP_FIRMWARE_UPDATE" == "0" ]] || guest_args+=(--skip-firmware-update)
+  if ! "$ACTIVE_DRIVER" exec "$vm_name" \
+    /Volumes/My\ Shared\ Files/codex-rc/guest-run.sh \
+    "${guest_args[@]}" \
+    >> "$RUN_DIR/host.log" 2>&1; then
+    state_status=1
+    overall_status=1
+  fi
+  cleanup_active_vm "$state_status" || overall_status=1
+done
+
+python3 - "$SHARE_DIR/results" "$RUN_DIR" "$CANDIDATE" <<'PY'
+import json, pathlib, sys
+results_root = pathlib.Path(sys.argv[1])
+run_dir = pathlib.Path(sys.argv[2])
+candidate = sys.argv[3]
+states = []
+for path in sorted(results_root.glob("*/result.json")):
+    states.append(json.loads(path.read_text(encoding="utf-8")))
+status = "passed" if states and all(item.get("status") == "passed" for item in states) else "failed"
+payload = {"schemaVersion": 1, "candidate": candidate, "status": status, "states": states}
+(run_dir / "result.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+lines = [f"# VibeTV release candidate {candidate}", "", f"Overall: **{status}**", ""]
+for item in states:
+    lines.append(f"- {item.get('state', 'unknown')}: {item.get('status', 'missing')}")
+(run_dir / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+
+printf 'Machine result: %s\n' "$RUN_DIR/result.json"
+printf 'Human summary: %s\n' "$RUN_DIR/summary.md"
+exit "$overall_status"


### PR DESCRIPTION
Part 2 of 2 for issue #177. **Stacked on #179** (base branch `codex/issue-177-core`) — review/merge #179 first; this PR's diff is only the hardware-gated layer.

## What this adds
The disposable-VM and private-candidate-artifact layers on top of the Virtual VibeTV core. This layer is gated behind a prepared Apple-Silicon runner and a manual workflow; only its fake-driver **contract test** runs in normal CI.

- **`scripts/release-candidate/`** — candidate bundle creation, checksum-pinned Sparkle CLI build, safe candidate-app extraction (path-traversal-rejecting), guest install/run, and Tart + fake VM drivers.
- **`scripts/test-release-candidate.sh`** — single reproducible command running the `clean` / `legacy` / `native` customer states, disposing every clone even on failure.
- **`scripts/test-release-candidate-contract.sh`** (+ `ci.yml` step) — whole-system contract test on every commit using the fake driver: bundle creation, three-state orchestration, result aggregation, clone disposal, and workflow guarantees (short-lived artifacts, no tag/release, trusted secret-bearing jobs).
- **`.github/workflows/release-candidate.yml`** — manual `workflow_dispatch` that builds, signs, and notarizes short-lived (1-day retention) private candidate artifacts and runs the Tart matrix on `[self-hosted, macOS, ARM64, codex-vibetv-rc]`. Publishes no release; changes no production endpoint.
- **`companionapi`** — allow the Mac App installer URL to be overridden to a private candidate source for VM runs only (env-gated; defaults unchanged).
- **`docs/virtual-vibetv.md`** — full three-layer documentation.

## Merge prerequisite
The `run-vm` job requires a prepared Apple-Silicon self-hosted runner labelled `codex-vibetv-rc`. Until that runner exists and a full VM run has been observed green, this PR is intentionally held; the fake-driver contract test still guards the infrastructure in the meantime.

## Guarantees (from #177)
Candidate artifacts are private, short-lived, and separated from production. The flow changes neither `main`, Git tags, public releases, nor production endpoints. Physical hardware remains a separate, explicitly-approved final canary — never written automatically.

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)