### PR TITLE
CODEX: Keep customer update UI action-only

### DIFF
--- a/apps/control-center/scripts/check-customer-ui-copy.mjs
+++ b/apps/control-center/scripts/check-customer-ui-copy.mjs
@@ -55,6 +55,19 @@ const forbiddenPatterns = [
     pattern: /\b(Installer unavailable|Needs Companion|Protected)\b/i,
     suggestion: "Hide unavailable actions or show a passive status.",
   },
+  {
+    label: "manual update instructions",
+    pattern:
+      /\b(choose Replace|replace the copy|creating a second copy|instead of creating a second copy|keep (?:the|this) current (?:app|Control Center) installed)\b/i,
+    suggestion:
+      "Show one Update action and keep manual replacement details out of customer update UI.",
+  },
+  {
+    label: "non-standard update action",
+    pattern:
+      /\b(Download new Mac App|Install Mac App update|Update now)\b/i,
+    suggestion: "Use the single customer action label Update.",
+  },
 ];
 
 const findings = [];

--- a/apps/control-center/scripts/check-customer-ui-copy.mjs
+++ b/apps/control-center/scripts/check-customer-ui-copy.mjs
@@ -58,9 +58,9 @@ const forbiddenPatterns = [
   {
     label: "manual update instructions",
     pattern:
-      /\b(choose Replace|replace the copy|creating a second copy|instead of creating a second copy|keep (?:the|this) current (?:app|Control Center) installed)\b/i,
+      /\b(open the (?:downloaded )?DMG|drag (?:the )?app into Applications|choose Replace|replace the copy|creating a second copy|instead of creating a second copy|keep (?:the|this) current (?:app|Control Center) installed)\b/i,
     suggestion:
-      "Show one Update action and keep manual replacement details out of customer update UI.",
+      "Show one customer action and keep manual DMG handling out of customer UI.",
   },
   {
     label: "non-standard update action",

--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -1923,7 +1923,7 @@ async function testUpdatesShowCustomerCompanionAction(browser, appUrl) {
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page.getByRole("button", { name: "Updates" }).click();
   const dmgUpdateLink = page.getByRole("link", {
-    name: "Download new Mac App",
+    name: "Update",
   });
   await dmgUpdateLink.waitFor({
     timeout: 10_000,
@@ -1933,8 +1933,11 @@ async function testUpdatesShowCustomerCompanionAction(browser, appUrl) {
       "VibeTV-Control-Center.dmg",
     "Updates should use the verified DMG release asset",
   );
-  await page.getByText("Install the new Mac App.").waitFor({ timeout: 10_000 });
-  await page.getByText(/choose Replace/).waitFor({ timeout: 10_000 });
+  assert(
+    (await page.getByText(/DMG|Applications|choose Replace|second copy/i).count()) ===
+      0,
+    "Updates must not expose manual Mac App installation mechanics",
+  );
   await page.getByText("App version").waitFor({ timeout: 10_000 });
   await page.getByText("Latest version").waitFor({ timeout: 10_000 });
   assert(
@@ -1984,7 +1987,7 @@ async function testNativeMacAppUpdateUsesSparkleAction(browser, appUrl) {
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page.getByRole("button", { name: "Updates" }).click();
   const updateLink = page.getByRole("link", {
-    name: "Install Mac App update",
+    name: "Update",
   });
   await updateLink.waitFor({ timeout: 10_000 });
   assert(
@@ -2002,9 +2005,8 @@ async function testNativeMacAppUpdateUsesSparkleAction(browser, appUrl) {
     "Updates must keep service names, process IDs, and commits out of customer copy",
   );
   assert(
-    (await page.getByRole("link", { name: "Download new Mac App" }).count()) ===
-      0,
-    "Native Sparkle updates must not offer a second DMG download",
+    (await page.getByRole("link", { name: "Update" }).count()) === 1,
+    "Native Sparkle updates must show exactly one Update action",
   );
   assertNoInstallRequests(installRequests);
   await page.close();
@@ -2049,10 +2051,10 @@ async function testLegacyInstallMigratesToDmgAtSameVersion(browser, appUrl) {
     updateAvailable: false,
   });
   await page
-    .getByRole("heading", { name: "Move to the new Mac App" })
+    .getByRole("heading", { name: "Update available" })
     .waitFor({ timeout: 10_000 });
   const overviewDownload = page.getByRole("link", {
-    name: "Download new Mac App",
+    name: "Update",
   });
   await overviewDownload.waitFor({ timeout: 10_000 });
   assert(
@@ -2064,15 +2066,17 @@ async function testLegacyInstallMigratesToDmgAtSameVersion(browser, appUrl) {
 
   await page.getByRole("button", { name: "Updates" }).click();
   await page
-    .getByRole("heading", { name: "Move to the new Mac App" })
+    .getByRole("heading", { name: "Update available" })
     .waitFor({ timeout: 10_000 });
   const updatesDownload = page.getByRole("link", {
-    name: "Download new Mac App",
+    name: "Update",
   });
   await updatesDownload.waitFor({ timeout: 10_000 });
-  await page.getByText("Move to the new Mac App.").waitFor({
-    timeout: 10_000,
-  });
+  assert(
+    (await page.getByText(/DMG|Applications|choose Replace|second copy/i).count()) ===
+      0,
+    "Legacy Updates must not expose manual installation mechanics",
+  );
   await captureMigrationScreenshot(page, "02-legacy-updates.png");
   await updatesDownload.click();
   await waitForCondition(
@@ -2121,14 +2125,14 @@ async function testLegacyMigrationStaysAvailableWhenVibeTVOffline(
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page
-    .getByRole("heading", { name: "Move to the new Mac App" })
+    .getByRole("heading", { name: "Update available" })
     .waitFor({ timeout: 10_000 });
   assert(
     (await page.getByRole("button", { name: "VibeTV is on WiFi" }).count()) ===
       1,
     "Legacy migration must keep the existing VibeTV setup flow available",
   );
-  await page.getByRole("link", { name: "Download new Mac App" }).waitFor({
+  await page.getByRole("link", { name: "Update" }).waitFor({
     timeout: 10_000,
   });
   await captureMigrationScreenshot(page, "03-legacy-offline-setup.png");
@@ -2170,7 +2174,7 @@ async function testLegacyFeatureFallbackMigratesAtSameVersion(browser, appUrl) {
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page
-    .getByRole("heading", { name: "Move to the new Mac App" })
+    .getByRole("heading", { name: "Update available" })
     .waitFor({ timeout: 10_000 });
   assert(
     macAppUpdateRequests.length === 0,
@@ -2205,7 +2209,7 @@ async function testDmgInstallStaysUpToDateAtSameVersion(browser, appUrl) {
     timeout: 10_000,
   });
   assert(
-    (await page.getByRole("heading", { name: "Move to the new Mac App" }).count()) ===
+    (await page.getByRole("heading", { name: "Update available" }).count()) ===
       0,
     "DMG Overview must not show the legacy migration card",
   );
@@ -2214,12 +2218,12 @@ async function testDmgInstallStaysUpToDateAtSameVersion(browser, appUrl) {
     timeout: 10_000,
   });
   assert(
-    (await page.getByRole("link", { name: "Download new Mac App" }).count()) ===
+    (await page.getByRole("link", { name: "Update" }).count()) ===
       0,
     "Current DMG install must not show a migration download",
   );
   assert(
-    (await page.getByRole("link", { name: "Download new Mac App" }).count()) ===
+    (await page.getByRole("link", { name: "Update" }).count()) ===
       0,
     "Current DMG install must not show an update download",
   );
@@ -2315,7 +2319,7 @@ async function testOfflineLegacyMigrationCanRetryFailedRelease(
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page
-    .getByRole("heading", { name: "Move to the new Mac App" })
+    .getByRole("heading", { name: "Update not ready" })
     .waitFor({ timeout: 10_000 });
   const retry = page.getByRole("button", { name: "Check again" });
   await retry.waitFor({ timeout: 10_000 });
@@ -2355,7 +2359,7 @@ async function testUpdatesShowLegacyCompanionReleaseFallback(browser, appUrl) {
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page.getByRole("button", { name: "Updates" }).click();
   await page
-    .getByRole("link", { name: "Download new Mac App" })
+    .getByRole("link", { name: "Update" })
     .waitFor({ timeout: 10_000 });
   const macAppSection = page.locator("section.border-b").filter({
     has: page.getByRole("heading", { name: "Mac App" }),
@@ -2419,14 +2423,15 @@ async function testFirmwareUpdateShowsCustomerProgress(browser, appUrl) {
   const firmwareSection = page.locator("section.border-b").filter({
     has: page.getByRole("heading", { name: "Firmware update" }),
   });
-  await page.getByRole("button", { name: "Update now" }).waitFor({
+  await page.getByRole("button", { name: "Update", exact: true }).waitFor({
     timeout: 10_000,
   });
   assert(
-    (await page.getByRole("button", { name: "Update now" }).count()) === 1,
-    "Updates should show one primary Update now button",
+    (await page.getByRole("button", { name: "Update", exact: true }).count()) ===
+      1,
+    "Updates should show one primary Update button",
   );
-  await page.getByRole("button", { name: "Update now" }).click();
+  await page.getByRole("button", { name: "Update", exact: true }).click();
   await page
     .getByRole("status")
     .filter({ hasText: "Updating VibeTV" })
@@ -2499,7 +2504,7 @@ async function testFirmwareAttentionDoesNotOfferSecondFlash(browser, appUrl) {
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page.getByRole("button", { name: "Updates" }).click();
-  await page.getByRole("button", { name: "Update now" }).click();
+  await page.getByRole("button", { name: "Update", exact: true }).click();
   await page
     .getByText("Firmware current — attention needed")
     .waitFor({ timeout: 10_000 });
@@ -2549,24 +2554,22 @@ async function testUpdatesKeepDmgHiddenWithoutVerifiedAsset(
     updateAvailable: false,
   });
   await page
-    .getByRole("heading", { name: "New Mac App is being prepared" })
+    .getByRole("heading", { name: "Update not ready" })
     .waitFor({ timeout: 10_000 });
-  const overviewUnavailableButton = page.getByRole("button", {
-    name: "New Mac App not ready",
-  });
-  await overviewUnavailableButton.waitFor({ timeout: 10_000 });
   assert(
-    await overviewUnavailableButton.isDisabled(),
-    "Legacy Overview must keep an unavailable DMG disabled",
+    (await page.getByRole("button", { name: "Update", exact: true }).count()) ===
+      0,
+    "Legacy Overview must hide an unavailable update action",
   );
   await page.getByRole("button", { name: "Updates" }).click();
   const unavailableButton = page.getByRole("button", {
-    name: "New Mac App not ready",
+    name: "Update",
+    exact: true,
   });
   await unavailableButton.waitFor({ timeout: 10_000 });
   assert(await unavailableButton.isDisabled(), "Unavailable DMG must stay disabled");
   assert(
-    (await page.getByRole("link", { name: "Download new Mac App" }).count()) ===
+    (await page.getByRole("link", { name: "Update" }).count()) ===
       0,
     "Updates must not show a DMG link without a verified asset",
   );
@@ -2613,16 +2616,13 @@ async function testLegacyMigrationDoesNotBlockFirmwareUpdate(browser, appUrl) {
   await page.getByRole("heading", { name: "Update available" }).waitFor({
     timeout: 10_000,
   });
-  const updateNow = page.getByRole("button", { name: "Update now" });
-  await updateNow.waitFor({ timeout: 10_000 });
+  const update = page.getByRole("button", { name: "Update", exact: true });
+  await update.waitFor({ timeout: 10_000 });
   assert(
-    await updateNow.isEnabled(),
+    await update.isEnabled(),
     "Unavailable DMG migration must not disable a VibeTV firmware update",
   );
-  await page.getByText("New Mac App is not ready yet.").waitFor({
-    timeout: 10_000,
-  });
-  await updateNow.click();
+  await update.click();
   await waitForCondition(
     () => firmwareUpdateRequests.length === 1,
     "Firmware update should start while the migration DMG is unavailable",
@@ -3449,7 +3449,8 @@ async function testDisabledDmgFlagHidesSetupAndUpdateLinks(browser, appUrl) {
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page.getByRole("button", { name: "Updates" }).click();
   const unavailableButton = page.getByRole("button", {
-    name: "New Mac App not ready",
+    name: "Update",
+    exact: true,
   });
   await unavailableButton.waitFor({ timeout: 10_000 });
   assert(await unavailableButton.isDisabled(), "Disabled DMG flag must stay disabled");
@@ -4824,12 +4825,12 @@ async function assertNoDmgDownloadActions(page) {
     "Setup must not show a DMG link without an enabled, verified asset",
   );
   assert(
-    (await page.getByRole("link", { name: "Download new Mac App" }).count()) ===
+    (await page.getByRole("link", { name: "Update" }).count()) ===
       0,
     "Updates must not show a DMG link without an enabled, verified asset",
   );
   assert(
-    (await page.getByRole("link", { name: "Download new Mac App" }).count()) ===
+    (await page.getByRole("link", { name: "Update" }).count()) ===
       0,
     "Legacy migration must not show a DMG link without an enabled, verified asset",
   );

--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -4669,6 +4669,10 @@ async function startVerifiedDmgSetupDownload(
     "Setup should only expose the verified DMG asset",
   );
   assert(
+    (await page.getByText(/open the DMG|Applications/i).count()) === 0,
+    "Setup must not explain manual DMG handling to customers",
+  );
+  assert(
     (await page.getByRole("tab", { name: "Agentic setup" }).count()) === 0,
     "Verified DMG setup must hide the Agentic Terminal installer",
   );

--- a/apps/control-center/src/components/overview-screen.tsx
+++ b/apps/control-center/src/components/overview-screen.tsx
@@ -24,7 +24,6 @@ import {
   type ReadinessTone,
   type UsageSnapshot,
 } from "./control-center-types";
-import { ControlCenterButton } from "./control-center-button";
 import { ControlCenterStatusIcon } from "./control-center-status-icon";
 import { LiveVibeTVPreview } from "./live-vibetv-preview";
 
@@ -157,35 +156,21 @@ function MacAppMigrationCard({ downloadUrl }: { downloadUrl?: string }) {
             className="text-base font-black text-[#1B1B1B]"
             id="mac-app-migration-title"
           >
-            {downloadReady
-              ? "Move to the new Mac App"
-              : "New Mac App is being prepared"}
+            {downloadReady ? "Update available" : "Update not ready"}
           </h3>
-          <p className="mt-1 text-sm leading-6 text-[#444933]">
-            {downloadReady
-              ? "Open the downloaded DMG, drag VibeTV Control Center into Applications, then open it there. Keep the current app installed; your VibeTV settings carry over automatically."
-              : "Your current Control Center keeps working. The download will appear after the signed Mac App is ready."}
-          </p>
         </div>
       </div>
-      <div className="mt-4">
-        {downloadUrl ? (
+      {downloadUrl ? (
+        <div className="mt-4">
           <a
             className="vibetv-button vibetv-button--large vibetv-button--full vibetv-button--primary"
             href={downloadUrl}
           >
             <Download size={20} aria-hidden />
-            <span>Download new Mac App</span>
+            <span>Update</span>
           </a>
-        ) : (
-          <ControlCenterButton
-            disabled
-            fullWidth
-            label="New Mac App not ready"
-            size="large"
-          />
-        )}
-      </div>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/control-center/src/components/setup-screen.tsx
+++ b/apps/control-center/src/components/setup-screen.tsx
@@ -302,12 +302,6 @@ export function SetupScreen({
                 <div className="grid min-w-0 gap-4">
                   {dmgUrl ? (
                     <div className="grid gap-3 border border-[#747A60] bg-[#F9F9F9] p-4">
-                      {hostedMode ? (
-                        <p className="text-sm leading-6 text-[#444933]">
-                          Download VibeTV Control Center, open the DMG, drag the
-                          app into Applications, then open it.
-                        </p>
-                      ) : null}
                       <a
                         className="vibetv-button vibetv-button--large vibetv-button--full vibetv-button--primary"
                         href={dmgUrl}

--- a/apps/control-center/src/components/setup-screen.tsx
+++ b/apps/control-center/src/components/setup-screen.tsx
@@ -99,8 +99,8 @@ export function SetupScreen({
       ? "Download Mac App"
       : "Mac App download not ready"
     : dmgUrl
-      ? "Download new Mac App"
-      : "New Mac App not ready";
+      ? "Update available"
+      : "Update not ready";
   const showControlCenterLauncher =
     !hostedMode &&
     showIntro &&
@@ -112,7 +112,6 @@ export function SetupScreen({
       checkFailed={macAppReleaseCheckFailed}
       checking={busyAction === "firmware-check"}
       downloadUrl={dmgUrl}
-      onDownloadStart={() => setDmgDownloadStarted(true)}
       onRetry={() => void onCheckUpdates?.()}
     />
   ) : null;
@@ -303,11 +302,12 @@ export function SetupScreen({
                 <div className="grid min-w-0 gap-4">
                   {dmgUrl ? (
                     <div className="grid gap-3 border border-[#747A60] bg-[#F9F9F9] p-4">
-                      <p className="text-sm leading-6 text-[#444933]">
-                        {hostedMode
-                          ? "Download VibeTV Control Center, open the DMG, drag the app into Applications, then open it."
-                          : "Download the latest VibeTV Control Center, replace the copy in Applications, then open it again."}
-                      </p>
+                      {hostedMode ? (
+                        <p className="text-sm leading-6 text-[#444933]">
+                          Download VibeTV Control Center, open the DMG, drag the
+                          app into Applications, then open it.
+                        </p>
+                      ) : null}
                       <a
                         className="vibetv-button vibetv-button--large vibetv-button--full vibetv-button--primary"
                         href={dmgUrl}
@@ -317,7 +317,7 @@ export function SetupScreen({
                         <span>
                           {hostedMode
                             ? "Download Mac App"
-                            : "Download new Mac App"}
+                            : "Update"}
                         </span>
                       </a>
                     </div>
@@ -401,13 +401,11 @@ function LegacyMacAppMigrationNotice({
   checkFailed,
   checking,
   downloadUrl,
-  onDownloadStart,
   onRetry,
 }: {
   checkFailed: boolean;
   checking: boolean;
   downloadUrl?: string;
-  onDownloadStart: () => void;
   onRetry: () => void;
 }) {
   return (
@@ -419,25 +417,17 @@ function LegacyMacAppMigrationNotice({
           </ControlCenterStatusIcon>
           <div className="min-w-0">
             <h2 className="text-2xl font-black text-[#1B1B1B]">
-              Move to the new Mac App
+              {downloadUrl ? "Update available" : "Update not ready"}
             </h2>
-            <p className="mt-2 max-w-[620px] text-sm leading-6 text-[#444933]">
-              {downloadUrl
-                ? "Open the DMG, drag VibeTV Control Center into Applications, then open it there. Keep this Control Center installed until the new app opens; your VibeTV settings stay in place."
-                : checkFailed
-                  ? "The signed Mac App check did not finish. Your current Control Center keeps working; check again when you are ready."
-                  : "The signed Mac App is not ready yet. Your current Control Center keeps working, including VibeTV setup and updates."}
-            </p>
           </div>
         </div>
         {downloadUrl ? (
           <a
             className="vibetv-button vibetv-button--large vibetv-button--primary w-full sm:w-auto"
             href={downloadUrl}
-            onClick={onDownloadStart}
           >
             <Download size={18} aria-hidden />
-            <span>Download new Mac App</span>
+            <span>Update</span>
           </a>
         ) : checkFailed ? (
           <PrimaryButton
@@ -449,15 +439,7 @@ function LegacyMacAppMigrationNotice({
             onClick={onRetry}
             size="large"
           />
-        ) : (
-          <PrimaryButton
-            disabled
-            fullWidth
-            icon={<Download size={18} aria-hidden />}
-            label="New Mac App not ready"
-            size="large"
-          />
-        )}
+        ) : null}
       </div>
     </section>
   );

--- a/apps/control-center/src/components/updates-screen.tsx
+++ b/apps/control-center/src/components/updates-screen.tsx
@@ -9,7 +9,7 @@ import {
   ShieldCheck,
   X,
 } from "lucide-react";
-import { useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import {
   availableMacAppDmgDownloadUrl,
   type CompanionReleaseInfo,
@@ -79,7 +79,6 @@ export function UpdatesScreen({
   busyAction,
   updateStatus,
 }: UpdatesScreenProps) {
-  const [macAppDownloadStarted, setMacAppDownloadStarted] = useState(false);
   const installedFirmware =
     firmwareUpdate?.installedFirmware || device?.firmware || "Unknown";
   const canCheckFirmware = Boolean(device?.board && device?.firmware);
@@ -127,9 +126,9 @@ export function UpdatesScreen({
       : checkFailed
         ? "Update check failed"
         : macAppMigrationReady
-          ? "Move to the new Mac App"
+          ? "Update available"
           : requiresMacAppMigration
-            ? "New Mac App is being prepared"
+            ? "Update not ready"
             : anyUpdateAvailable
               ? "Update available"
               : "Up to date";
@@ -208,7 +207,6 @@ export function UpdatesScreen({
             macAppMigrationRequired={requiresMacAppMigration}
             macAppMigrationReady={macAppMigrationReady}
             macAppUpdateAvailable={macAppUpdateAvailable}
-            onDownloadStart={() => setMacAppDownloadStarted(true)}
             onClick={runPrimaryUpdate}
             updateReady={Boolean(
               updateAvailable
@@ -259,16 +257,6 @@ export function UpdatesScreen({
           />
         </dl>
 
-        {requiresMacAppMigration || (macAppUpdateAvailable && !nativeMacUpdateReady) ? (
-          <MacAppDmgUpdateNote
-            downloadReady={macAppDownloadReady}
-            downloadStarted={macAppDownloadStarted}
-            downloadUrl={macAppDownloadUrl}
-            migration={requiresMacAppMigration}
-            onDownloadStart={() => setMacAppDownloadStarted(true)}
-            showDownloadAction={updateAvailable}
-          />
-        ) : null}
       </section>
 
       <section className="border-b border-[#747A60] py-8">
@@ -318,7 +306,6 @@ function PrimaryUpdateAction({
   macAppMigrationRequired,
   macAppMigrationReady,
   macAppUpdateAvailable,
-  onDownloadStart,
   onClick,
   updateReady,
 }: {
@@ -332,12 +319,10 @@ function PrimaryUpdateAction({
   macAppMigrationRequired: boolean;
   macAppMigrationReady: boolean;
   macAppUpdateAvailable: boolean;
-  onDownloadStart: () => void;
   onClick: () => void | Promise<void>;
   updateReady: boolean;
 }) {
   if (
-    !firmwareUpdateAvailable &&
     macAppUpdateAvailable &&
     nativeUpdateUrl &&
     !disabled &&
@@ -349,13 +334,12 @@ function PrimaryUpdateAction({
         href={nativeUpdateUrl}
       >
         <Download size={20} aria-hidden />
-        <span>Install Mac App update</span>
+        <span>Update</span>
       </a>
     );
   }
 
   if (
-    !firmwareUpdateAvailable &&
     (macAppMigrationReady || macAppUpdateAvailable) &&
     downloadUrl &&
     !disabled &&
@@ -365,12 +349,9 @@ function PrimaryUpdateAction({
       <a
         className="vibetv-button vibetv-button--large vibetv-button--primary w-full sm:w-auto sm:min-w-[240px]"
         href={downloadUrl}
-        onClick={onDownloadStart}
       >
         <Download size={20} aria-hidden />
-        <span>
-          Download new Mac App
-        </span>
+        <span>Update</span>
       </a>
     );
   }
@@ -378,17 +359,13 @@ function PrimaryUpdateAction({
   const label = installingFirmware
     ? "Updating VibeTV"
     : firmwareUpdateAvailable
-      ? "Update now"
+      ? "Update"
       : macAppMigrationRequired
         ? macAppCheckFailed
           ? "Check again"
-          : downloadUrl
-            ? "Download new Mac App"
-            : "New Mac App not ready"
+          : "Update"
         : macAppUpdateAvailable
-          ? downloadUrl
-            ? "Download new Mac App"
-            : "New Mac App not ready"
+          ? "Update"
           : checking
             ? "Checking updates"
             : "Check for updates";
@@ -545,71 +522,6 @@ function formatListenerValue(companion: CompanionInfo | null | undefined): strin
     : "Needs attention";
 }
 
-function MacAppDmgUpdateNote({
-  downloadReady,
-  downloadStarted,
-  downloadUrl,
-  migration,
-  onDownloadStart,
-  showDownloadAction,
-}: {
-  downloadReady: boolean;
-  downloadStarted: boolean;
-  downloadUrl?: string;
-  migration: boolean;
-  onDownloadStart: () => void;
-  showDownloadAction: boolean;
-}) {
-  return (
-    <div
-      className="mt-6 border border-[#747A60] bg-[#F9F9F9] p-4 text-sm leading-6 text-[#444933]"
-      role="status"
-    >
-      <div>
-        {downloadReady ? (
-          <>
-            <strong className="font-black text-[#1B1B1B]">
-              {downloadStarted
-                ? "Download started."
-                : migration
-                  ? "Move to the new Mac App."
-                  : "Install the new Mac App."}
-            </strong>{" "}
-            Open the downloaded DMG, drag VibeTV Control Center into
-            Applications, and choose Replace if macOS asks. Then open the app
-            from Applications.
-            {migration
-              ? " Your VibeTV settings stay in place, and the new app takes over only after it confirms its background service is working."
-              : " This replaces the installed app instead of creating a second copy."}
-          </>
-        ) : (
-          <>
-            <strong className="font-black text-[#1B1B1B]">
-              {migration
-                ? "New Mac App is not ready yet."
-                : "New Mac App is not ready yet."}
-            </strong>{" "}
-            Your current Control Center keeps working. No installer will run;
-            check again after the signed Mac App download is available.
-          </>
-        )}
-      </div>
-      {showDownloadAction && downloadUrl ? (
-        <a
-          className="vibetv-button vibetv-button--compact vibetv-button--secondary mt-4 w-full sm:w-auto"
-          href={downloadUrl}
-          onClick={onDownloadStart}
-        >
-          <Download size={16} aria-hidden />
-          <span>
-            Download new Mac App
-          </span>
-        </a>
-      ) : null}
-    </div>
-  );
-}
-
 function companionReleaseLabel({
   macAppRunning,
   migrationReady,
@@ -629,11 +541,11 @@ function companionReleaseLabel({
       ) {
         return "Check failed";
       }
-      return migrationReady ? "New Mac App ready" : "New Mac App waiting";
+      return migrationReady ? "Update available" : "Update not ready";
     }
     if (release?.updateAvailable) {
       return availableMacAppDmgDownloadUrl(release)
-        ? "Download ready"
+        ? "Update available"
         : "Update waiting";
     }
     if (

--- a/docs/control-center-customer-ui-approval.md
+++ b/docs/control-center-customer-ui-approval.md
@@ -1,0 +1,12 @@
+# Control Center Customer UI Approvals
+
+This append-only log is the machine-checked approval marker for customer-facing
+Control Center changes. Every visible UI change needs a new entry that records
+the user's explicit approval and the exact visible result. Technical work,
+issue scope, or release permission never implies UI permission.
+
+## 2026-07-15 — One update action
+
+- User approval: Explicitly approved by the user in the Codex task on 2026-07-15.
+- Approved customer-visible result: App, migration, and firmware update states show one action named `Update`; manual DMG, Applications-folder, replacement, relaunch, and duplicate-copy instructions do not appear in update UI.
+- Approved files: `updates-screen.tsx`, `overview-screen.tsx`, `setup-screen.tsx`, and their customer-flow assertions.

--- a/docs/control-center-customer-ui-approval.md
+++ b/docs/control-center-customer-ui-approval.md
@@ -10,3 +10,9 @@ issue scope, or release permission never implies UI permission.
 - User approval: Explicitly approved by the user in the Codex task on 2026-07-15.
 - Approved customer-visible result: App, migration, and firmware update states show one action named `Update`; manual DMG, Applications-folder, replacement, relaunch, and duplicate-copy instructions do not appear in update UI.
 - Approved files: `updates-screen.tsx`, `overview-screen.tsx`, `setup-screen.tsx`, and their customer-flow assertions.
+
+## 2026-07-15 — Download action without instructions
+
+- User approval: The user explicitly ordered the remaining hosted DMG and Applications instructions to be deleted in the Codex task on 2026-07-15.
+- Approved customer-visible result: The hosted first-install state shows only the `Download Mac App` action and no manual DMG or Applications-folder instructions.
+- Approved files: `setup-screen.tsx`, the customer-copy guard, and the hosted customer-flow assertion.

--- a/docs/control-center-ui-principles.md
+++ b/docs/control-center-ui-principles.md
@@ -14,6 +14,8 @@ This is the customer-facing design standard for VibeTV Control Center. The targe
 - **State gating:** tabs and controls that are not usable in the current setup state stay locked. Overview owns setup recovery.
 - **Visual hierarchy discipline:** no button stacks with equal weight. If multiple actions appear, the design is probably exposing implementation detail.
 - **Low text density:** short labels and short status rows are preferred. If a paragraph is needed, first try to delete it or convert it into a button label/status value.
+- **Approval before visible change:** implementation work never authorizes a visible UI change by itself. Any added, changed, or removed customer-facing copy, control, hierarchy, or state requires explicit user approval recorded in `control-center-customer-ui-approval.md`.
+- **One update action:** whenever an app or firmware update is available, the customer action is exactly `Update`. Do not expose DMG handling, Applications-folder replacement, relaunch mechanics, Sparkle, or duplicate-copy prevention in the customer UI.
 
 ## Setup Flow Rules
 
@@ -36,18 +38,21 @@ This is the customer-facing design standard for VibeTV Control Center. The targe
 
 Before shipping customer-facing UI changes, answer these in order:
 
-1. Can a non-technical customer identify the next step in under 5 seconds?
-2. Is there exactly one primary action for the current state?
-3. Can any visible button fail because another visible setup step should have happened first?
-4. Are there internal implementation words visible to the customer?
-5. Are tabs or controls visible when they cannot be used?
-6. Is any paragraph explaining something that could be solved by hiding, disabling, merging, or automating an action?
-7. Did the change add a new customer decision that the software could make automatically?
-8. Does mobile have the same decision order and no wrapped or crowded action rows?
+1. Is the exact visible result explicitly approved in `control-center-customer-ui-approval.md`?
+2. Can a non-technical customer identify the next step in under 5 seconds?
+3. Is there exactly one primary action for the current state?
+4. Can any visible button fail because another visible setup step should have happened first?
+5. Are there internal implementation words visible to the customer?
+6. Are tabs or controls visible when they cannot be used?
+7. Is any paragraph explaining something that could be solved by hiding, disabling, merging, or automating an action?
+8. Did the change add a new customer decision that the software could make automatically?
+9. Does mobile have the same decision order and no wrapped or crowded action rows?
 
 ## Automated Copy Guard
 
 Run `npm run check:customer-ui-copy` in `apps/control-center` before shipping customer-facing UI changes. It parses customer-facing TSX copy and blocks internal wording such as `Companion`, `Bridge`, local API terms, release/package diagnostics, and technical setup substeps.
+
+The repository gate also blocks every customer-facing UI diff until the same change includes a new approval entry with both `User approval:` and `Approved customer-visible result:`. A general implementation or release approval is not enough; the visible result must be named.
 
 ## Verification Budget
 

--- a/scripts/check-control-center-ui-review-gate.mjs
+++ b/scripts/check-control-center-ui-review-gate.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { readFileSync } from "node:fs";
 
 const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
   encoding: "utf8",
@@ -9,10 +9,12 @@ const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
 }).trim();
 process.chdir(repoRoot);
 
-const REVIEW_FILE = "docs/control-center-ui-review-checkpoint.md";
+const APPROVAL_FILE = "docs/control-center-customer-ui-approval.md";
 const PRINCIPLES_FILE = "docs/control-center-ui-principles.md";
-const DEFAULT_INTERVAL = 5;
-const interval = readInterval();
+const APPROVAL_PREFIXES = [
+  "- User approval:",
+  "- Approved customer-visible result:",
+];
 
 const uiFilePatterns = [
   /^apps\/control-center\/src\/components\//,
@@ -23,69 +25,56 @@ const uiFilePatterns = [
 ];
 
 const analysisRef = analysisHeadRef();
-const reviewCommit = latestReviewCommit(analysisRef);
+const approvalCommit = latestApprovalCommit(analysisRef);
 const workingTreeChangedFiles = changedFilesInWorkingTree();
-const workingTreeReviewMarker =
-  workingTreeChangedFiles.includes(REVIEW_FILE) ||
-  (!reviewCommit && existsSync(REVIEW_FILE));
-const commitsSinceReview = reviewCommit
-  ? workingTreeReviewMarker
-    ? 0
-    : Number(git(["rev-list", "--count", `${reviewCommit}..${analysisRef}`]))
-  : workingTreeReviewMarker
-    ? 0
-  : Number(git(["rev-list", "--count", analysisRef]));
-const committedChangedFiles = workingTreeReviewMarker
-  ? []
-  : changedFilesSince(reviewCommit, analysisRef);
-const changedFiles = unique([...committedChangedFiles, ...workingTreeChangedFiles]);
+const workingTreeApprovalChanged = workingTreeChangedFiles.includes(APPROVAL_FILE);
+const workingTreeApprovalValid = workingTreeApprovalChanged
+  ? diffAddsApprovalEvidence(workingTreeApprovalDiff())
+  : false;
+const committedApprovalValid = approvalCommit
+  ? diffAddsApprovalEvidence(commitDiff(approvalCommit))
+  : false;
+const activeApprovalValid = workingTreeApprovalChanged
+  ? workingTreeApprovalValid
+  : committedApprovalValid;
+const changedFiles = unique([
+  ...changedFilesSince(approvalCommit, analysisRef),
+  ...workingTreeChangedFiles,
+]);
 const uiChangedFiles = changedFiles.filter(isUiFile);
-const projectedCommits =
-  commitsSinceReview + (workingTreeChangedFiles.some(isUiFile) ? 1 : 0);
-const due = projectedCommits >= interval && uiChangedFiles.length > 0;
+const approvalCoversUi = workingTreeApprovalChanged && workingTreeApprovalValid;
+const unapprovedUiFiles = approvalCoversUi ? [] : uiChangedFiles;
+const invalidApprovalMarker =
+  (workingTreeApprovalChanged && !workingTreeApprovalValid) ||
+  (!workingTreeApprovalChanged && Boolean(approvalCommit) && !committedApprovalValid);
+const due = invalidApprovalMarker || unapprovedUiFiles.length > 0;
 
 printSummary({
-  changedFiles,
-  committedChangedFiles,
-  commitsSinceReview,
-  due,
+  activeApprovalValid,
   analysisRef,
-  projectedCommits,
-  reviewCommit,
+  approvalCommit,
+  due,
+  invalidApprovalMarker,
   uiChangedFiles,
+  unapprovedUiFiles,
+  workingTreeApprovalChanged,
   workingTreeChangedFiles,
 });
 
 if (due) {
-  const commitSummary =
-    projectedCommits === commitsSinceReview
-      ? `${commitsSinceReview} commits`
-      : `${commitsSinceReview} committed changes plus current working-tree UI changes`;
+  const reason = invalidApprovalMarker
+    ? `The newest approval marker does not add both required approval lines.`
+    : `Customer-facing UI changed in ${unapprovedUiFiles.length} file(s) without a matching approval entry.`;
   const message = [
-    `Control Center UI review is due: ${commitSummary} since ${REVIEW_FILE}.`,
-    `Customer-facing UI changed in ${uiChangedFiles.length} file(s).`,
-    `Review ${PRINCIPLES_FILE}, simplify the UI, then update ${REVIEW_FILE}.`,
+    reason,
+    `Get explicit approval for the exact visible result, review ${PRINCIPLES_FILE}, then append it to ${APPROVAL_FILE}.`,
   ].join(" ");
   if (process.env["GITHUB_ACTIONS"]) {
-    console.error(`::error title=Control Center UI review due::${message}`);
+    console.error(`::error title=Control Center UI approval required::${message}`);
   } else {
     console.error(`error: ${message}`);
   }
   process.exit(1);
-}
-
-function readInterval() {
-  const raw = process.env["CONTROL_CENTER_UI_REVIEW_INTERVAL"];
-  if (!raw) {
-    return DEFAULT_INTERVAL;
-  }
-  const value = Number(raw);
-  if (!Number.isInteger(value) || value <= 0) {
-    throw new Error(
-      `CONTROL_CENTER_UI_REVIEW_INTERVAL must be a positive integer, got ${raw}`,
-    );
-  }
-  return value;
 }
 
 function analysisHeadRef() {
@@ -99,8 +88,8 @@ function analysisHeadRef() {
   return "HEAD";
 }
 
-function latestReviewCommit(ref) {
-  const result = tryGit(["log", "-n", "1", "--format=%H", ref, "--", REVIEW_FILE]);
+function latestApprovalCommit(ref) {
+  const result = tryGit(["log", "-n", "1", "--format=%H", ref, "--", APPROVAL_FILE]);
   return result || null;
 }
 
@@ -119,48 +108,79 @@ function changedFilesInWorkingTree() {
   ]);
 }
 
+function workingTreeApprovalDiff() {
+  return [
+    tryGit(["diff", "--", APPROVAL_FILE]),
+    tryGit(["diff", "--cached", "--", APPROVAL_FILE]),
+    untrackedFileContents(APPROVAL_FILE),
+  ].join("\n");
+}
+
+function commitDiff(commit) {
+  return tryGit(["show", "--format=", "--unified=0", commit, "--", APPROVAL_FILE]);
+}
+
+function untrackedFileContents(file) {
+  if (!lines(tryGit(["ls-files", "--others", "--exclude-standard", "--", file])).includes(file)) {
+    return "";
+  }
+  try {
+    return readFileSync(file, "utf8")
+      .split("\n")
+      .map((line) => `+${line}`)
+      .join("\n");
+  } catch {
+    return "";
+  }
+}
+
+function diffAddsApprovalEvidence(diff) {
+  const addedLines = lines(diff)
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1).trim());
+  return APPROVAL_PREFIXES.every((prefix) =>
+    addedLines.some((line) => line.startsWith(prefix)),
+  );
+}
+
 function isUiFile(file) {
   return uiFilePatterns.some((pattern) => pattern.test(file));
 }
 
 function printSummary({
-  changedFiles,
-  committedChangedFiles,
-  commitsSinceReview,
-  due,
+  activeApprovalValid,
   analysisRef,
-  projectedCommits,
-  reviewCommit,
+  approvalCommit,
+  due,
+  invalidApprovalMarker,
   uiChangedFiles,
+  unapprovedUiFiles,
+  workingTreeApprovalChanged,
   workingTreeChangedFiles,
 }) {
-  const status = due ? "due" : "ok";
-  console.log(`Control Center UI review gate: ${status}`);
+  console.log(`Control Center UI review gate: ${due ? "due" : "ok"}`);
   if (analysisRef !== "HEAD") {
     console.log(`Review head: ${analysisRef}`);
   }
   console.log(
-    `Review marker: ${reviewCommit || (workingTreeReviewMarker ? "working tree" : "none")}`,
+    `Approval marker: ${workingTreeApprovalChanged ? "working tree" : approvalCommit || "none"}`,
   );
-  console.log(`Commits since marker: ${commitsSinceReview}/${interval}`);
-  if (workingTreeChangedFiles.some(isUiFile)) {
-    console.log(`Projected commits after current UI changes: ${projectedCommits}/${interval}`);
-  }
-  console.log(`Committed files since marker: ${committedChangedFiles.length}`);
+  console.log(`Approval evidence: ${activeApprovalValid ? "valid" : "missing"}`);
   console.log(`Working tree files: ${workingTreeChangedFiles.length}`);
-  console.log(`Changed files since marker: ${changedFiles.length}`);
-  console.log(`UI-impacting files since marker: ${uiChangedFiles.length}`);
-  if (uiChangedFiles.length > 0) {
-    console.log("UI-impacting files:");
-    for (const file of uiChangedFiles.slice(0, 40)) {
+  console.log(`UI-impacting files since approval: ${uiChangedFiles.length}`);
+  console.log(`Unapproved UI files: ${unapprovedUiFiles.length}`);
+  if (invalidApprovalMarker) {
+    console.log("Approval marker is missing required evidence.");
+  }
+  const filesToPrint = due ? unapprovedUiFiles : uiChangedFiles;
+  if (filesToPrint.length > 0) {
+    console.log(due ? "Unapproved UI files:" : "Approved UI files:");
+    for (const file of filesToPrint.slice(0, 40)) {
       console.log(`- ${file}`);
     }
-    if (uiChangedFiles.length > 40) {
-      console.log(`- ... ${uiChangedFiles.length - 40} more`);
+    if (filesToPrint.length > 40) {
+      console.log(`- ... ${filesToPrint.length - 40} more`);
     }
-  }
-  if (!due) {
-    console.log(`Next required review at ${interval} commits with UI changes.`);
   }
 }
 

--- a/scripts/test-control-center-ui-review-gate.sh
+++ b/scripts/test-control-center-ui-review-gate.sh
@@ -25,6 +25,12 @@ assert_contains() {
     || die "expected output to contain: ${needle}"
 }
 
+approval_entry() {
+  local label="$1"
+  printf '\n## %s\n\n- User approval: Explicit test approval.\n- Approved customer-visible result: %s\n' \
+    "$label" "$label"
+}
+
 setup_repo() {
   local repo="$1"
   mkdir -p "$repo"
@@ -33,15 +39,17 @@ setup_repo() {
   git -C "$repo" config user.name "Control Center UI Review Test"
 
   mkdir -p "$repo/docs" "$repo/apps/control-center/src/components"
-  printf '# Control Center UI Review Checkpoint\n\ninitial review\n' \
-    > "$repo/docs/control-center-ui-review-checkpoint.md"
+  printf '# Control Center Customer UI Approvals\n' \
+    > "$repo/docs/control-center-customer-ui-approval.md"
+  approval_entry "Initial UI" \
+    >> "$repo/docs/control-center-customer-ui-approval.md"
   printf '# Control Center UI Principles\n\nKeep it simple.\n' \
     > "$repo/docs/control-center-ui-principles.md"
   printf 'export function Overview() { return "Ready"; }\n' \
     > "$repo/apps/control-center/src/components/overview-screen.tsx"
 
   git -C "$repo" add .
-  git -C "$repo" commit -q -m "Initial UI review checkpoint"
+  git -C "$repo" commit -q -m "Initial approved UI"
 }
 
 commit_file() {
@@ -55,12 +63,20 @@ commit_file() {
   git -C "$repo" commit -q -m "$message"
 }
 
+commit_approval() {
+  local repo="$1"
+  local label="$2"
+  approval_entry "$label" \
+    >> "$repo/docs/control-center-customer-ui-approval.md"
+  git -C "$repo" add docs/control-center-customer-ui-approval.md
+  git -C "$repo" commit -q -m "Approve ${label}"
+}
+
 run_gate() {
   local repo="$1"
   (
     cd "$repo"
-    CONTROL_CENTER_UI_REVIEW_INTERVAL=5 \
-      GITHUB_ACTIONS= \
+    GITHUB_ACTIONS= \
       GITHUB_EVENT_NAME= \
       node "$GATE"
   ) 2>&1
@@ -70,8 +86,7 @@ run_gate_pull_request() {
   local repo="$1"
   (
     cd "$repo"
-    CONTROL_CENTER_UI_REVIEW_INTERVAL=5 \
-      GITHUB_ACTIONS=true \
+    GITHUB_ACTIONS=true \
       GITHUB_EVENT_NAME=pull_request \
       node "$GATE"
   ) 2>&1
@@ -82,7 +97,7 @@ expect_gate_success() {
   local output
   output="$(run_gate "$repo")" || {
     printf '%s\n' "$output" >&2
-    die "expected UI review gate to pass"
+    die "expected UI approval gate to pass"
   }
   assert_contains "$output" "Control Center UI review gate: ok"
 }
@@ -96,10 +111,10 @@ expect_gate_due() {
   set -e
   [[ "$status" -ne 0 ]] || {
     printf '%s\n' "$output" >&2
-    die "expected UI review gate to fail"
+    die "expected UI approval gate to fail"
   }
   assert_contains "$output" "Control Center UI review gate: due"
-  assert_contains "$output" "Control Center UI review is due"
+  assert_contains "$output" "explicit approval"
   assert_contains "$output" "docs/control-center-ui-principles.md"
 }
 
@@ -112,51 +127,50 @@ test_non_ui_commits_do_not_block() {
   expect_gate_success "$repo"
 }
 
-test_control_center_readme_does_not_block() {
-  local repo="${TMP_ROOT}/control-center-readme"
-  setup_repo "$repo"
-  for index in 1 2 3 4 5; do
-    commit_file "$repo" "apps/control-center/README.md" \
-      "Document Control Center setup ${index}"
-  done
-  expect_gate_success "$repo"
-}
-
-test_ui_change_blocks_after_interval() {
+test_ui_change_blocks_immediately() {
   local repo="${TMP_ROOT}/ui-due"
   setup_repo "$repo"
   commit_file "$repo" "apps/control-center/src/components/overview-screen.tsx" \
     "Change customer-facing UI"
-  for index in 1 2 3 4; do
-    commit_file "$repo" "docs/follow-up-${index}.md" "Follow-up non-ui change ${index}"
-  done
   expect_gate_due "$repo"
 }
 
-test_working_tree_ui_change_counts_as_next_commit() {
+test_working_tree_ui_change_blocks_immediately() {
   local repo="${TMP_ROOT}/working-tree"
   setup_repo "$repo"
-  for index in 1 2 3 4; do
-    commit_file "$repo" "docs/follow-up-${index}.md" "Follow-up non-ui change ${index}"
-  done
   printf '\nexport const visibleLabel = "Install";\n' \
     >> "$repo/apps/control-center/src/components/overview-screen.tsx"
   expect_gate_due "$repo"
 }
 
-test_review_marker_resets_gate() {
-  local repo="${TMP_ROOT}/review-reset"
+test_explicit_approval_resets_gate() {
+  local repo="${TMP_ROOT}/approval-reset"
   setup_repo "$repo"
   commit_file "$repo" "apps/control-center/src/components/overview-screen.tsx" \
     "Change customer-facing UI"
-  for index in 1 2 3 4; do
-    commit_file "$repo" "docs/follow-up-${index}.md" "Follow-up non-ui change ${index}"
-  done
   expect_gate_due "$repo"
-
-  commit_file "$repo" "docs/control-center-ui-review-checkpoint.md" \
-    "Record UI review"
+  commit_approval "$repo" "Updated overview"
   expect_gate_success "$repo"
+}
+
+test_working_tree_approval_covers_same_change() {
+  local repo="${TMP_ROOT}/working-tree-approval"
+  setup_repo "$repo"
+  printf '\nexport const visibleLabel = "Update";\n' \
+    >> "$repo/apps/control-center/src/components/overview-screen.tsx"
+  approval_entry "One Update action" \
+    >> "$repo/docs/control-center-customer-ui-approval.md"
+  expect_gate_success "$repo"
+}
+
+test_marker_without_evidence_does_not_reset_gate() {
+  local repo="${TMP_ROOT}/invalid-marker"
+  setup_repo "$repo"
+  commit_file "$repo" "apps/control-center/src/components/overview-screen.tsx" \
+    "Change customer-facing UI"
+  commit_file "$repo" "docs/control-center-customer-ui-approval.md" \
+    "Reviewed by the implementation agent"
+  expect_gate_due "$repo"
 }
 
 test_pull_request_merge_commit_uses_pr_head() {
@@ -168,10 +182,7 @@ test_pull_request_merge_commit_uses_pr_head() {
   git -C "$repo" checkout -q -b feature
   commit_file "$repo" "apps/control-center/src/components/overview-screen.tsx" \
     "Change customer-facing UI"
-  for index in 1 2 3; do
-    commit_file "$repo" "docs/feature-follow-up-${index}.md" \
-      "Feature follow-up non-ui change ${index}"
-  done
+  commit_approval "$repo" "Feature overview"
   local feature_head
   feature_head="$(git -C "$repo" rev-parse HEAD)"
 
@@ -179,28 +190,21 @@ test_pull_request_merge_commit_uses_pr_head() {
   commit_file "$repo" "docs/base-follow-up.md" "Base follow-up non-ui change"
   git -C "$repo" merge -q --no-ff "$feature_head" -m "Merge pull request"
 
-  local output status
-  set +e
-  output="$(run_gate "$repo")"
-  status=$?
-  set -e
-  [[ "$status" -ne 0 ]] || die "expected normal merge-head UI review gate to fail"
-  assert_contains "$output" "Control Center UI review gate: due"
-
+  local output
   output="$(run_gate_pull_request "$repo")" || {
     printf '%s\n' "$output" >&2
-    die "expected pull_request merge-head UI review gate to pass"
+    die "expected pull_request merge-head UI approval gate to pass"
   }
   assert_contains "$output" "Control Center UI review gate: ok"
   assert_contains "$output" "Review head: ${feature_head}"
-  assert_contains "$output" "Commits since marker: 4/5"
 }
 
 test_non_ui_commits_do_not_block
-test_control_center_readme_does_not_block
-test_ui_change_blocks_after_interval
-test_working_tree_ui_change_counts_as_next_commit
-test_review_marker_resets_gate
+test_ui_change_blocks_immediately
+test_working_tree_ui_change_blocks_immediately
+test_explicit_approval_resets_gate
+test_working_tree_approval_covers_same_change
+test_marker_without_evidence_does_not_reset_gate
 test_pull_request_merge_commit_uses_pr_head
 
 printf 'control-center UI review gate tests passed\n'


### PR DESCRIPTION
## Summary
- show exactly one customer action named `Update` for Mac App, migration, and firmware updates
- remove manual DMG, Applications, replacement, relaunch, and duplicate-copy instructions from update UI
- require explicit, recorded user approval for every future customer-visible Control Center change

## Verification
- `npm run test:customer-flows`
- `./scripts/check-control-center-customer-ready-gate.sh --automated-only --skip-live --skip-release`
- `npm run check:customer-ui-copy`
- `npm run lint -- --max-warnings=0`
- `./scripts/test-control-center-ui-review-gate.sh`
- `git diff --check`

No VibeTV hardware write was performed.