### PR TITLE
CODEX: Fix trusted preview DMG signing pin

### DIFF
--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -104,7 +104,8 @@ jobs:
       - name: Checkout signing tools
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: 87bc0355582f76dbb2f89b361c9aa9ffed8b192f
+          # Reviewed main commit that signs Sparkle's nested code inside-out.
+          ref: 24c3855468991f28ef1af2df905b95944d90985c
           persist-credentials: false
 
       - name: Download Mac app

--- a/scripts/test-control-center-release-workflow.sh
+++ b/scripts/test-control-center-release-workflow.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW="${ROOT}/.github/workflows/release.yml"
 CI_WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+PREVIEW_WORKFLOW="${ROOT}/.github/workflows/validate-macos-dmg.yml"
 LOCAL_INSTALLER="${ROOT}/scripts/install-control-center-companion.sh"
 RELEASE_INSTALLER="${ROOT}/scripts/install-control-center-companion-release.sh"
 PUBLIC_INSTALLER="${ROOT}/apps/control-center/public/install-control-center-companion.sh"
@@ -50,6 +51,7 @@ installer_line_number() {
 
 main() {
   [[ -f "$WORKFLOW" ]] || die "release workflow is missing"
+  [[ -f "$PREVIEW_WORKFLOW" ]] || die "macOS preview workflow is missing"
   [[ -f "$LOCAL_INSTALLER" ]] || die "local Control Center installer is missing"
   [[ -f "$RELEASE_INSTALLER" ]] || die "release Control Center installer is missing"
   [[ -f "$PUBLIC_INSTALLER" ]] || die "public Control Center installer is missing"
@@ -238,6 +240,9 @@ main() {
     "signing script must reject Accepted notarization logs that still contain issues"
   assert_contains "$signing_script" "does not match APPLE_TEAM_ID" \
     "signing script must reject a certificate for the wrong Apple team"
+  assert_contains "$(cat "$PREVIEW_WORKFLOW")" \
+    "ref: 24c3855468991f28ef1af2df905b95944d90985c" \
+    "preview signing job must use the reviewed main commit with nested Sparkle signing"
 
   assert_contains "$verify_dmg_plan" "hdiutil verify" \
     "DMG distribution gate must verify the disk image container"


### PR DESCRIPTION
## Summary

- advance the secret-bearing preview signing job to reviewed main commit `24c3855`
- use the existing inside-out Sparkle signing fix without executing feature-branch code with Apple credentials
- add a regression assertion for the trusted signing-tools pin

## Verification

- `./scripts/test-control-center-release-workflow.sh`

## Scope

This PR only updates the trusted signing-tools commit used by the validation-only preview DMG workflow. It does not merge PR #182, tag, release, or deploy anything.