### PR TITLE
CODEX Hotfix v1.0.48: bundled CodexBarCLI and automatic provider detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,11 +94,16 @@ jobs:
             "tmp/macos-release/codexbar-display-amd64" \
             "tmp/macos-release/codexbar-display-arm64"
 
+          ./scripts/prepare-bundled-codexbar-cli.sh \
+            --output-dir "tmp/macos-release/codexbar-cli"
+
           ./scripts/build-macos-control-center-app.sh \
             --version "${VERSION}" \
             --build "${GITHUB_RUN_NUMBER:-0}" \
             --universal \
             --companion-binary "tmp/macos-release/codexbar-display" \
+            --codexbar-cli-binary "tmp/macos-release/codexbar-cli/CodexBarCLI" \
+            --codexbar-cli-version-file "tmp/macos-release/codexbar-cli/VERSION" \
             --output "dist/macos/VibeTV Control Center.app"
 
           ./scripts/sign-notarize-macos-control-center.sh \

--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -72,11 +72,16 @@ jobs:
             tmp/macos-preview/codexbar-display-amd64 \
             tmp/macos-preview/codexbar-display-arm64
 
+          ./scripts/prepare-bundled-codexbar-cli.sh \
+            --output-dir tmp/macos-preview/codexbar-cli
+
           ./scripts/build-macos-control-center-app.sh \
             --version "${version}" \
             --build "${GITHUB_RUN_NUMBER}" \
             --universal \
             --companion-binary tmp/macos-preview/codexbar-display \
+            --codexbar-cli-binary tmp/macos-preview/codexbar-cli/CodexBarCLI \
+            --codexbar-cli-version-file tmp/macos-preview/codexbar-cli/VERSION \
             --output "dist/macos/VibeTV Control Center.app"
 
           tar -czf tmp/macos-preview/app.tar.gz \

--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     if: >-
       github.repository == 'DreamyTalesPAN/CodexBar-Display' &&
-      github.ref == 'refs/heads/main' &&
+      github.event_name == 'workflow_dispatch' &&
       github.actor == github.repository_owner
     runs-on: macos-15
     timeout-minutes: 45
@@ -109,8 +109,9 @@ jobs:
       - name: Checkout signing tools
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          # Reviewed main commit that signs Sparkle's nested code inside-out.
-          ref: 24c3855468991f28ef1af2df905b95944d90985c
+          # Reviewed hotfix commit that signs Sparkle and both universal helpers
+          # inside-out. The requested source never supplies signing code.
+          ref: fd95fbdc3a9412b6c85fe9b9bddb750319db48a0
           persist-credentials: false
 
       - name: Download Mac app

--- a/.github/workflows/validate-macos-dmg.yml
+++ b/.github/workflows/validate-macos-dmg.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           # Reviewed hotfix commit that signs Sparkle and both universal helpers
           # inside-out. The requested source never supplies signing code.
-          ref: fd95fbdc3a9412b6c85fe9b9bddb750319db48a0
+          ref: 170a0d0d94e8cf434b6cab1d0380499b94f6b7f2
           persist-credentials: false
 
       - name: Download Mac app

--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -233,6 +233,7 @@ async function main() {
         browser,
         appContext.appUrl,
       );
+      await testProviderDiscoveryNeedsNoSelection(browser, appContext.appUrl);
       await testLocalReachableWithoutFrameStaysInSetup(
         browser,
         appContext.appUrl,
@@ -290,6 +291,7 @@ async function main() {
       browser,
       appContext.appUrl,
     );
+    await testProviderDiscoveryNeedsNoSelection(browser, appContext.appUrl);
     await testLocalWifiVerificationOpensOverview(
       browser,
       appContext.appUrl,
@@ -701,6 +703,56 @@ async function testSetupDoesNotRequestBrowserPermission(browser, appUrl) {
   assert(
     (await page.getByText("Browser permission needed.").count()) === 0,
     "setup should not show browser permission copy",
+  );
+  assertNoInstallRequests(installRequests);
+  await page.close();
+}
+
+async function testProviderDiscoveryNeedsNoSelection(browser, appUrl) {
+  const page = await newCustomerPage(browser, appUrl, { viewport });
+  const installRequests = [];
+  let discoveryRequests = 0;
+  const setupRequired = {
+    state: "setup_required",
+    codexBarVersion: "0.37.2",
+    providers: [],
+    message: "Sign in to your AI tool, then check again.",
+  };
+  await routeCompanionOnline(page, installRequests, undefined, {
+    device: { connected: false },
+    providerStatus: setupRequired,
+    providerStatusSequence: [
+      setupRequired,
+      {
+        state: "ready",
+        codexBarVersion: "0.37.2",
+        providers: ["claude", "codex"],
+        message: "AI tools found.",
+      },
+    ],
+    onProviderDiscover: () => {
+      discoveryRequests += 1;
+    },
+  });
+
+  await page.goto(appUrl, {
+    waitUntil: "domcontentloaded",
+  });
+  await page
+    .getByRole("heading", { name: "Finding your AI tools" })
+    .waitFor({ timeout: 10_000 });
+  await page.getByText("Sign in to your AI tool, then check again.").waitFor();
+  assert(
+    (await page.getByText("Select provider").count()) === 0,
+    "Provider discovery must not ask the customer to select a provider",
+  );
+  await page.getByRole("button", { name: "Check again" }).click();
+  await page
+    .getByRole("button", { name: "VibeTV is on WiFi" })
+    .waitFor({ timeout: 10_000 });
+  assert(
+    discoveryRequests === 1,
+    `Check again must trigger exactly one provider scan, got ${discoveryRequests}`,
   );
   assertNoInstallRequests(installRequests);
   await page.close();
@@ -3938,6 +3990,7 @@ async function routeCompanionOnline(
     device = companionDevice,
     onDiscover,
     onPair,
+    onProviderDiscover,
     onRepair,
     onSelect,
     onSearch,
@@ -3960,6 +4013,13 @@ async function routeCompanionOnline(
     searchDelayMs = 0,
     firstStatusDelayMs = 0,
     statusDeviceSequence,
+    providerStatusSequence,
+    providerStatus = {
+      state: "ready",
+      codexBarVersion: "0.37.2",
+      providers: ["codex"],
+      message: "AI tools found.",
+    },
   } = {},
 ) {
   let currentDevice = device;
@@ -3972,6 +4032,7 @@ async function routeCompanionOnline(
   let macAppUpdateStatusIndex = 0;
   let macAppUpdateStatusFailuresRemaining = macAppUpdateStatusFailures;
   let statusRequestCount = 0;
+  let currentProviderStatus = providerStatus;
   const handler = async (route) => {
     const pathname = companionPath(route);
     onRequest(pathname, route.request().method());
@@ -4383,6 +4444,7 @@ async function routeCompanionOnline(
             companionRuntime,
           ),
           device: currentDevice,
+          provider: providerStatus,
         }),
       });
       return;
@@ -4399,6 +4461,20 @@ async function routeCompanionOnline(
       });
       return;
     }
+    if (pathname === "/v1/providers/discover") {
+      onProviderDiscover?.();
+      currentProviderStatus = {
+        ...currentProviderStatus,
+        state: "scanning",
+        message: "Finding your AI tools.",
+      };
+      await route.fulfill({
+        status: 202,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, provider: currentProviderStatus }),
+      });
+      return;
+    }
     if (pathname === "/v1/status") {
       statusRequestCount += 1;
       if (Array.isArray(statusDeviceSequence) && statusDeviceSequence.length > 0) {
@@ -4409,6 +4485,15 @@ async function routeCompanionOnline(
       }
       if (statusRequestCount === 1 && firstStatusDelayMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, firstStatusDelayMs));
+      }
+      if (
+        Array.isArray(providerStatusSequence) &&
+        providerStatusSequence.length > 0
+      ) {
+        currentProviderStatus =
+          providerStatusSequence[
+            Math.min(statusRequestCount - 1, providerStatusSequence.length - 1)
+          ];
       }
       await route.fulfill({
         status: 200,
@@ -4424,6 +4509,7 @@ async function routeCompanionOnline(
             companionRuntime,
           ),
           device: currentDevice,
+          provider: currentProviderStatus,
         }),
       });
       return;

--- a/apps/control-center/src/components/control-center-app.tsx
+++ b/apps/control-center/src/components/control-center-app.tsx
@@ -34,6 +34,7 @@ import {
   type DeviceInfo,
   type DeviceSearchState,
   type DeviceState,
+  type ProviderStatusInfo,
   type SupportDiagnostics,
   type UsageSnapshot,
 } from "./control-center-types";
@@ -214,6 +215,11 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
     useState<FirmwareUpdateStatus | null>(null);
   const [usage, setUsage] = useState<UsageSnapshot | null>(null);
   const [usageError, setUsageError] = useState<ApiError | null>(null);
+  const [providerStatus, setProviderStatus] = useState<ProviderStatusInfo>({
+    state: "scanning",
+    providers: [],
+    message: "Finding your AI tools.",
+  });
   const [setupPreviewStep, setSetupPreviewStep] = useState<"mac-app" | null>(
     readLocalSetupPreviewStep,
   );
@@ -603,11 +609,15 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
         const payload = await runCompanion<{
           companion?: CompanionInfo;
           device?: DeviceInfo;
+          provider?: ProviderStatusInfo;
         }>("/v1/status", undefined, { preserveLastError: quiet });
         const checkedAt = formatTime();
         const wasMissing = companionStatus === "missing";
         setCompanionStatus("online");
         setCompanionInfo(payload.companion || null);
+        if (payload.provider) {
+          setProviderStatus(payload.provider);
+        }
         setLastError(null);
         setThemeInstallEnabled(
           Boolean(payload.companion?.features?.themeInstallEnabled),
@@ -1544,7 +1554,8 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
     const shouldPollIncompleteSetup =
       companionStatus === "missing" ||
       (companionStatus === "online" &&
-        (!deviceSetupIsUsable(device) ||
+        (providerStatus.state !== "ready" ||
+          !deviceSetupIsUsable(device) ||
           device?.connectionState === "reconnecting"));
     if (hostedSetup || !shouldPollIncompleteSetup) {
       return;
@@ -1558,7 +1569,14 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
     }, 5000);
 
     return () => window.clearInterval(timer);
-  }, [busyAction, checkCompanion, companionStatus, device, hostedSetup]);
+  }, [
+    busyAction,
+    checkCompanion,
+    companionStatus,
+    device,
+    hostedSetup,
+    providerStatus.state,
+  ]);
 
   const deviceBoard = device?.board;
   const deviceFirmware = device?.firmware;
@@ -1886,6 +1904,29 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
     ],
   );
 
+  const discoverProviders = useCallback(async () => {
+    setBusyAction("provider-discovery");
+    try {
+      const payload = await runCompanion<{ provider?: ProviderStatusInfo }>(
+        "/v1/providers/discover",
+        { method: "POST" },
+      );
+      if (payload.provider) {
+        setProviderStatus(payload.provider);
+      }
+      setUsageError(null);
+      setLastError(null);
+    } catch (error) {
+      const normalized = normalizeUsageError(
+        normalizeCaughtError(error, "AI tool check needs attention."),
+      );
+      setUsageError(normalized);
+      setLastError(normalized);
+    } finally {
+      setBusyAction(null);
+    }
+  }, [runCompanion]);
+
   const loadSupportDiagnostics = useCallback(async () => {
     setBusyAction("diagnostics");
     try {
@@ -1997,6 +2038,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
   const setupComplete = Boolean(
     !setupPreviewStep &&
       companionStatus === "online" &&
+      providerStatus.state === "ready" &&
       deviceStartupConnectionIsReady(device),
   );
   const hasSavedActiveDevice = Boolean(device?.deviceId);
@@ -2106,7 +2148,9 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
       requiresMacAppMigration={requiresMacAppMigration}
       showIntro={showIntro}
       setupComplete={setupComplete}
+      providerStatus={providerStatus}
       onCheckCompanion={checkCompanion}
+      onDiscoverProviders={discoverProviders}
       onCheckUpdates={checkUpdates}
       onDeviceTargetChange={handleDeviceTargetChange}
       onSearchDevices={() => {
@@ -2204,6 +2248,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
           deviceState={deviceState}
           firmwareUpdate={effectiveFirmwareUpdate}
           onReloadImage={() => reloadDisplay()}
+          providerStatus={providerStatus}
           requiresMacAppMigration={requiresMacAppMigration}
           usage={usage}
         />
@@ -2213,6 +2258,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
         <UsageScreen
           busyAction={busyAction}
           companionStatus={companionStatus}
+          onDiscoverProviders={discoverProviders}
           onRefresh={() => refreshUsage()}
           usage={usage}
           usageError={usageError}

--- a/apps/control-center/src/components/control-center-types.ts
+++ b/apps/control-center/src/components/control-center-types.ts
@@ -22,6 +22,13 @@ export type ApiError = {
 
 export type CompanionStatus = "unknown" | "online" | "missing";
 
+export type ProviderStatusInfo = {
+  state: "scanning" | "ready" | "setup_required" | "error";
+  codexBarVersion?: string;
+  providers: string[];
+  message: string;
+};
+
 export type CompanionInfo = {
   status?: string;
   version?: string;

--- a/apps/control-center/src/components/overview-screen.tsx
+++ b/apps/control-center/src/components/overview-screen.tsx
@@ -2,6 +2,7 @@
 
 import {
   ArrowUpFromLine,
+  BarChart3,
   Check,
   CircleHelp,
   Download,
@@ -21,6 +22,7 @@ import {
   type CompanionStatus,
   type DeviceInfo,
   type DeviceState,
+  type ProviderStatusInfo,
   type ReadinessTone,
   type UsageSnapshot,
 } from "./control-center-types";
@@ -35,6 +37,7 @@ type OverviewScreenProps = {
   device: DeviceInfo | null;
   firmwareUpdate?: FirmwareUpdateInfo | null;
   usage?: UsageSnapshot | null;
+  providerStatus: ProviderStatusInfo;
   busyAction?: string | null;
   onReloadImage?: () => void;
   requiresMacAppMigration?: boolean;
@@ -49,6 +52,7 @@ export function OverviewScreen({
   device,
   firmwareUpdate,
   usage,
+  providerStatus,
   onReloadImage,
   requiresMacAppMigration = false,
 }: OverviewScreenProps) {
@@ -96,6 +100,12 @@ export function OverviewScreen({
               value={labelForCompanion(companionStatus, companionVersion)}
             />
             <StatusRow
+              icon={<BarChart3 size={18} aria-hidden />}
+              label="AI tools"
+              detail={providerStatus.message}
+              value={labelForProviders(providerStatus)}
+            />
+            <StatusRow
               icon={<Monitor size={18} aria-hidden />}
               label="VibeTV"
               detail={imageStuck ? imageStuckDetail(device) : healthDetail}
@@ -136,6 +146,16 @@ export function OverviewScreen({
       </section>
     </div>
   );
+}
+
+function labelForProviders(provider: ProviderStatusInfo): string {
+  if (provider.state === "ready") {
+    return provider.providers.join(", ") || "Ready";
+  }
+  if (provider.state === "scanning") {
+    return "Finding tools";
+  }
+  return "Sign-in needed";
 }
 
 function MacAppMigrationCard({ downloadUrl }: { downloadUrl?: string }) {

--- a/apps/control-center/src/components/setup-screen.tsx
+++ b/apps/control-center/src/components/setup-screen.tsx
@@ -20,6 +20,7 @@ import type {
   DeviceCandidate,
   DeviceSearchState,
   DeviceState,
+  ProviderStatusInfo,
 } from "./control-center-types";
 import { ControlCenterButton } from "./control-center-button";
 import { DeviceTargetForm } from "./device-target-form";
@@ -34,6 +35,7 @@ type SetupScreenProps = {
   deviceTarget: string;
   lastError?: ApiError | null;
   onCheckCompanion?: () => void | Promise<void>;
+  onDiscoverProviders?: () => void | Promise<void>;
   onCheckUpdates?: () => void | Promise<void>;
   onDeviceTargetChange?: (target: string) => void;
   onSearchDevices?: () => void;
@@ -47,9 +49,10 @@ type SetupScreenProps = {
   requiresMacAppMigration?: boolean;
   showIntro?: boolean;
   setupComplete: boolean;
+  providerStatus: ProviderStatusInfo;
 };
 
-type StepId = "wifi" | "mac-app" | "finish";
+type StepId = "providers" | "wifi" | "mac-app" | "finish";
 type StepState = "active" | "blocked" | "complete" | "pending";
 
 export function SetupScreen({
@@ -61,6 +64,7 @@ export function SetupScreen({
   deviceTarget,
   lastError,
   onCheckCompanion,
+  onDiscoverProviders,
   onCheckUpdates,
   onDeviceTargetChange,
   onSearchDevices,
@@ -74,6 +78,7 @@ export function SetupScreen({
   requiresMacAppMigration = false,
   showIntro = true,
   setupComplete,
+  providerStatus,
 }: SetupScreenProps) {
   const [wifiConfirmedState, setWifiConfirmedState] = useState(false);
   const [dmgDownloadStarted, setDmgDownloadStarted] = useState(false);
@@ -81,6 +86,9 @@ export function SetupScreen({
   const macAppMissing = isCompanionMissingError(lastError);
   const macAppReady = companionStatus === "online";
   const macAppCheckFailed = macAppMissing && macAppConfirmedState;
+  const providersReady = providerStatus.state === "ready";
+  const providersReadyForFlow =
+    providersReady || companionStatus !== "online";
   const forceMacAppStep = previewStep === "mac-app";
   const macAppConfirmed =
     !forceMacAppStep &&
@@ -124,11 +132,17 @@ export function SetupScreen({
     () =>
       hostedMode
         ? "mac-app"
-        : previewStep || (setupComplete || wifiConfirmed ? "finish" : "wifi"),
+        : previewStep ||
+          (!providersReadyForFlow
+            ? "providers"
+            : setupComplete || wifiConfirmed
+              ? "finish"
+              : "wifi"),
     [
       hostedMode,
       previewStep,
       setupComplete,
+      providersReadyForFlow,
       wifiConfirmed,
     ],
   );
@@ -139,6 +153,7 @@ export function SetupScreen({
         forceMacAppStep,
         macAppConfirmed,
         macAppReady,
+        providersReady: providersReadyForFlow,
         setupComplete,
         wifiConfirmed,
       }),
@@ -147,6 +162,7 @@ export function SetupScreen({
       forceMacAppStep,
       macAppConfirmed,
       macAppReady,
+      providersReadyForFlow,
       setupComplete,
       wifiConfirmed,
     ],
@@ -250,10 +266,42 @@ export function SetupScreen({
 
       <section className="py-6">
         <ol className="grid gap-0 border-y border-[#747A60]">
+          {!hostedMode && !forceMacAppStep && companionStatus === "online" ? (
+            <SetupStep
+              icon={
+                providerStatus.state === "scanning" ? (
+                  <Loader2 className="animate-spin" size={22} aria-hidden />
+                ) : (
+                  <RefreshCw size={22} aria-hidden />
+                )
+              }
+              index={1}
+              state={stepStates.providers}
+              title="Finding your AI tools"
+            >
+              {activeStep === "providers" ? (
+                <div className="grid gap-4 text-sm leading-6 text-[#444933]">
+                  <p>{providerStatus.message}</p>
+                  {providerStatus.state !== "scanning" ? (
+                    <PrimaryButton
+                      busy={busyAction === "provider-discovery"}
+                      busyLabel="Checking"
+                      fullWidth
+                      icon={<RefreshCw size={18} aria-hidden />}
+                      label="Check again"
+                      onClick={() => void onDiscoverProviders?.()}
+                      size="large"
+                    />
+                  ) : null}
+                </div>
+              ) : null}
+            </SetupStep>
+          ) : null}
+
           {!hostedMode && !forceMacAppStep ? (
             <SetupStep
               icon={<Wifi size={22} aria-hidden />}
-              index={1}
+              index={2}
               state={stepStates.wifi}
               title="Connect VibeTV to WiFi"
             >
@@ -368,7 +416,7 @@ export function SetupScreen({
           {!hostedMode && !forceMacAppStep ? (
             <SetupStep
               icon={<Monitor size={22} aria-hidden />}
-              index={2}
+              index={3}
               state={stepStates.finish}
               title="Verify VibeTV connection"
             >
@@ -863,6 +911,7 @@ function buildStepStates({
   forceMacAppStep,
   macAppConfirmed,
   macAppReady,
+  providersReady,
   setupComplete,
   wifiConfirmed,
 }: {
@@ -870,16 +919,25 @@ function buildStepStates({
   forceMacAppStep: boolean;
   macAppConfirmed: boolean;
   macAppReady: boolean;
+  providersReady: boolean;
   setupComplete: boolean;
   wifiConfirmed: boolean;
 }): Record<StepId, StepState> {
   return {
+    providers:
+      providersReady || setupComplete
+        ? "complete"
+        : activeStep === "providers"
+          ? "active"
+          : "blocked",
     wifi:
       wifiConfirmed || setupComplete
         ? "complete"
         : activeStep === "wifi"
           ? "active"
-          : "blocked",
+          : providersReady
+            ? "pending"
+            : "blocked",
     "mac-app": forceMacAppStep
       ? "active"
       : macAppConfirmed || macAppReady || setupComplete

--- a/apps/control-center/src/components/usage-screen.tsx
+++ b/apps/control-center/src/components/usage-screen.tsx
@@ -24,6 +24,7 @@ type UsageScreenProps = {
   usage: UsageSnapshot | null;
   usageError?: ApiError | null;
   onRefresh?: () => void;
+  onDiscoverProviders?: () => void;
 };
 
 export function UsageScreen({
@@ -32,8 +33,10 @@ export function UsageScreen({
   usage,
   usageError,
   onRefresh,
+  onDiscoverProviders,
 }: UsageScreenProps) {
   const refreshing = busyAction === "usage";
+  const providerSetupRequired = usageError?.code === "provider_setup_required";
   const providers = filterVisibleProviders(
     usage?.providers || [],
     usage?.currentProvider,
@@ -62,16 +65,26 @@ export function UsageScreen({
           {onRefresh ? (
             <button
               className="inline-flex h-11 items-center justify-center gap-2 border border-[#747A60] bg-[#F9F9F9] px-4 text-sm font-semibold text-[#1B1B1B] transition hover:bg-[#EEEEEE] disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={refreshing}
-              onClick={onRefresh}
+              disabled={refreshing || busyAction === "provider-discovery"}
+              onClick={
+                providerSetupRequired && onDiscoverProviders
+                  ? onDiscoverProviders
+                  : onRefresh
+              }
               type="button"
             >
-              {refreshing ? (
+              {refreshing || busyAction === "provider-discovery" ? (
                 <RefreshCw className="animate-spin" size={18} aria-hidden />
               ) : (
                 <RefreshCw size={18} aria-hidden />
               )}
-              <span>{refreshing ? "Refreshing" : "Refresh"}</span>
+              <span>
+                {refreshing || busyAction === "provider-discovery"
+                  ? "Checking"
+                  : providerSetupRequired
+                    ? "Check again"
+                    : "Refresh"}
+              </span>
             </button>
           ) : null}
         </div>

--- a/companion/internal/codexbar/codexbar.go
+++ b/companion/internal/codexbar/codexbar.go
@@ -35,13 +35,21 @@ var (
 var runUsageCommandFn = runUsageCommand
 var runCostCommandFn = runUsageCommand
 var runVersionCommandFn = runUsageCommand
+var runConfigCommandFn = runUsageCommand
+var executablePathFn = os.Executable
+var fetchAllProvidersFn = FetchAllProviders
 var readFileFn = os.ReadFile
 
 const (
 	minSharedFallbackTimeBudget = 4 * time.Second
 	minSupportedVersionString   = "0.23"
+	minConfigVersionString      = "0.27"
 	versionCheckTimeout         = 2 * time.Second
+	discoveryCommandTimeout     = 45 * time.Second
+	configCommandTimeout        = 5 * time.Second
 )
+
+var providerIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,63}$`)
 
 const usageModeEnvVar = "CODEXBAR_DISPLAY_USAGE_MODE"
 
@@ -111,6 +119,13 @@ func FindBinary() (string, error) {
 		return "", fmt.Errorf("CODEXBAR_BIN is not executable: %s", env)
 	}
 
+	if executable, err := executablePathFn(); err == nil && strings.TrimSpace(executable) != "" {
+		bundled := filepath.Join(filepath.Dir(executable), "CodexBarCLI")
+		if isExecutable(bundled) {
+			return bundled, nil
+		}
+	}
+
 	if p, err := exec.LookPath("codexbar"); err == nil && p != "" {
 		return p, nil
 	}
@@ -136,21 +151,130 @@ func FindBinary() (string, error) {
 	return "", errors.New("could not find CodexBar CLI binary")
 }
 
+// DiscoverAndEnableProviders asks the pinned CodexBar CLI to probe every
+// registered provider once. Only providers that return a valid usage payload
+// are enabled, then the normal enabled-provider fetch verifies the result.
+func DiscoverAndEnableProviders(ctx context.Context) ([]ParsedFrame, error) {
+	bin, err := FindBinary()
+	if err != nil {
+		return nil, wrapFetchError(FetchErrorBinary, err)
+	}
+	if err := checkMinimumVersion(ctx, bin, minConfigVersionString); err != nil {
+		return nil, wrapFetchError(FetchErrorVersion, err)
+	}
+
+	out, commandErr := runUsageCommandFn(
+		ctx,
+		discoveryCommandTimeout,
+		bin,
+		"usage",
+		"--provider",
+		"all",
+		"--json",
+		"--web-timeout",
+		"8",
+	)
+	discovered, parseErr := parseAllProviders(out)
+	if len(discovered) == 0 {
+		if commandErr != nil {
+			return nil, wrapFetchError(FetchErrorCommand, fmt.Errorf("discover codexbar providers: %w", commandErr))
+		}
+		if parseErr != nil {
+			if errors.Is(parseErr, ErrUnexpectedProviderShape) && payloadContainsOnlyProviderErrors(out) {
+				return nil, wrapFetchError(FetchErrorNoProviders, ErrNoProviders)
+			}
+			return nil, wrapFetchError(classifyParseError(parseErr), parseErr)
+		}
+		return nil, wrapFetchError(FetchErrorNoProviders, ErrNoProviders)
+	}
+
+	providerIDs := make([]string, 0, len(discovered))
+	seen := make(map[string]struct{}, len(discovered))
+	for _, parsed := range discovered {
+		provider := strings.TrimSpace(strings.ToLower(parsed.Provider))
+		if provider == "" {
+			provider = strings.TrimSpace(strings.ToLower(parsed.Frame.Provider))
+		}
+		if !providerIDPattern.MatchString(provider) {
+			continue
+		}
+		if _, ok := seen[provider]; ok {
+			continue
+		}
+		seen[provider] = struct{}{}
+		providerIDs = append(providerIDs, provider)
+	}
+	sort.Strings(providerIDs)
+
+	enabled := 0
+	var enableErrors []string
+	for _, provider := range providerIDs {
+		if _, err := runConfigCommandFn(
+			ctx,
+			configCommandTimeout,
+			bin,
+			"config",
+			"enable",
+			"--provider",
+			provider,
+			"--format",
+			"json",
+		); err != nil {
+			enableErrors = append(enableErrors, provider)
+			continue
+		}
+		enabled++
+	}
+	if enabled == 0 {
+		if len(enableErrors) > 0 {
+			return nil, wrapFetchError(FetchErrorCommand, fmt.Errorf("could not enable discovered providers: %s", strings.Join(enableErrors, ", ")))
+		}
+		return nil, wrapFetchError(FetchErrorNoProviders, ErrNoProviders)
+	}
+
+	verified, err := fetchAllProvidersFn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(verified) == 0 {
+		return nil, wrapFetchError(FetchErrorNoProviders, ErrNoProviders)
+	}
+	return verified, nil
+}
+
+func payloadContainsOnlyProviderErrors(raw []byte) bool {
+	providers, err := extractProvidersFromRawJSON(raw)
+	if err != nil || len(providers) == 0 {
+		return false
+	}
+	for _, providerAny := range providers {
+		payload, ok := providerAny.(map[string]any)
+		if !ok || !providerPayloadHasError(payload) {
+			return false
+		}
+	}
+	return true
+}
+
 func MinimumSupportedVersion() string {
 	return minSupportedVersionString
 }
 
 func CheckMinimumVersion(ctx context.Context, bin string) error {
+	return checkMinimumVersion(ctx, bin, minSupportedVersionString)
+}
+
+func checkMinimumVersion(ctx context.Context, bin, minimumVersion string) error {
 	version, err := installedVersion(ctx, bin)
 	if err != nil {
 		return err
 	}
-	minimum, err := parseLooseVersion(minSupportedVersionString)
+	minimum, err := parseLooseVersion(minimumVersion)
 	if err != nil {
 		return err
 	}
 	if version.Compare(minimum) < 0 {
-		return fmt.Errorf("CodexBar %s is too old; need >= %s", version.String(), minSupportedVersionString)
+		return fmt.Errorf("CodexBar %s is too old; need >= %s", version.String(), minimumVersion)
 	}
 	return nil
 }

--- a/companion/internal/codexbar/codexbar_test.go
+++ b/companion/internal/codexbar/codexbar_test.go
@@ -14,6 +14,116 @@ import (
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
 )
 
+func TestFindBinaryPrefersBundledCLI(t *testing.T) {
+	t.Setenv("CODEXBAR_BIN", "")
+	tmp := t.TempDir()
+	appExecutable := filepath.Join(tmp, "VibeTV Control Center")
+	bundled := filepath.Join(tmp, "CodexBarCLI")
+	if err := os.WriteFile(appExecutable, []byte("app"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bundled, []byte("cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	originalExecutablePath := executablePathFn
+	executablePathFn = func() (string, error) { return appExecutable, nil }
+	t.Cleanup(func() { executablePathFn = originalExecutablePath })
+
+	got, err := FindBinary()
+	if err != nil {
+		t.Fatalf("FindBinary failed: %v", err)
+	}
+	if got != bundled {
+		t.Fatalf("expected bundled CLI %q, got %q", bundled, got)
+	}
+}
+
+func TestDiscoverAndEnableProvidersKeepsSuccessfulProviders(t *testing.T) {
+	t.Setenv("CODEXBAR_BIN", executableTestFile(t))
+	originalUsage := runUsageCommandFn
+	originalVersion := runVersionCommandFn
+	originalConfig := runConfigCommandFn
+	originalFetch := fetchAllProvidersFn
+	t.Cleanup(func() {
+		runUsageCommandFn = originalUsage
+		runVersionCommandFn = originalVersion
+		runConfigCommandFn = originalConfig
+		fetchAllProvidersFn = originalFetch
+	})
+
+	runVersionCommandFn = func(context.Context, time.Duration, string, ...string) ([]byte, error) {
+		return []byte("CodexBar 0.37.2\n"), nil
+	}
+	var discoveryArgs []string
+	runUsageCommandFn = func(_ context.Context, _ time.Duration, _ string, args ...string) ([]byte, error) {
+		discoveryArgs = append([]string(nil), args...)
+		return []byte(`[
+			{"provider":"codex","usage":{"primary":{"usedPercent":12}}},
+			{"provider":"claude","usage":{"primary":{"usedPercent":34}}},
+			{"provider":"cursor","error":{"message":"not signed in"}}
+		]`), nil
+	}
+	var enabled []string
+	runConfigCommandFn = func(_ context.Context, _ time.Duration, _ string, args ...string) ([]byte, error) {
+		for i, arg := range args {
+			if arg == "--provider" && i+1 < len(args) {
+				enabled = append(enabled, args[i+1])
+				if args[i+1] == "claude" {
+					return nil, errors.New("claude config failed")
+				}
+			}
+		}
+		return []byte(`{"ok":true}`), nil
+	}
+	fetchAllProvidersFn = func(context.Context) ([]ParsedFrame, error) {
+		return []ParsedFrame{testParsedFrame("codex", 12, 20, 0)}, nil
+	}
+
+	got, err := DiscoverAndEnableProviders(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverAndEnableProviders failed: %v", err)
+	}
+	if len(got) != 1 || got[0].Provider != "codex" {
+		t.Fatalf("unexpected verified providers: %+v", got)
+	}
+	if strings.Join(discoveryArgs, " ") != "usage --provider all --json --web-timeout 8" {
+		t.Fatalf("unexpected discovery args: %v", discoveryArgs)
+	}
+	if strings.Join(enabled, ",") != "claude,codex" {
+		t.Fatalf("expected all usable providers to be considered in sorted order, got %v", enabled)
+	}
+}
+
+func TestDiscoverAndEnableProvidersRequiresUsableProvider(t *testing.T) {
+	t.Setenv("CODEXBAR_BIN", executableTestFile(t))
+	originalUsage := runUsageCommandFn
+	originalVersion := runVersionCommandFn
+	t.Cleanup(func() {
+		runUsageCommandFn = originalUsage
+		runVersionCommandFn = originalVersion
+	})
+	runVersionCommandFn = func(context.Context, time.Duration, string, ...string) ([]byte, error) {
+		return []byte("CodexBar 0.37.2\n"), nil
+	}
+	runUsageCommandFn = func(context.Context, time.Duration, string, ...string) ([]byte, error) {
+		return []byte(`[{"provider":"cursor","error":{"message":"not signed in"}}]`), nil
+	}
+
+	_, err := DiscoverAndEnableProviders(context.Background())
+	if err == nil || FetchErrorKindOf(err) != FetchErrorNoProviders {
+		t.Fatalf("expected no-providers error, got %v", err)
+	}
+}
+
+func executableTestFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "codexbar")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 func TestParseUsageJSONReturnsFirstProvider(t *testing.T) {
 	raw := []byte(`[
 		{"provider":"codex","usage":{"primary":{"usedPercent":1}}},

--- a/companion/internal/companionapi/provider_discovery.go
+++ b/companion/internal/companionapi/provider_discovery.go
@@ -1,0 +1,252 @@
+package companionapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/codexbar"
+)
+
+const (
+	providerDiscoverySchema  = 1
+	providerStateScanning    = "scanning"
+	providerStateReady       = "ready"
+	providerStateSetup       = "setup_required"
+	providerStateError       = "error"
+	providerDiscoveryTimeout = 70 * time.Second
+)
+
+type providerStatusInfo struct {
+	State           string   `json:"state"`
+	CodexBarVersion string   `json:"codexBarVersion,omitempty"`
+	Providers       []string `json:"providers"`
+	Message         string   `json:"message"`
+}
+
+type providerDiscoveryMarker struct {
+	SchemaVersion   int      `json:"schemaVersion"`
+	CodexBarVersion string   `json:"codexBarVersion"`
+	Providers       []string `json:"providers"`
+	CompletedAt     string   `json:"completedAt"`
+}
+
+func installedCodexBarVersion(ctx context.Context) (string, error) {
+	bin, err := codexbar.FindBinary()
+	if err != nil {
+		return "", err
+	}
+	return codexbar.InstalledVersion(ctx, bin)
+}
+
+func (s *Server) providerStatusSnapshot() providerStatusInfo {
+	s.providerMu.RLock()
+	defer s.providerMu.RUnlock()
+	status := s.providerStatus
+	status.Providers = append([]string(nil), status.Providers...)
+	return status
+}
+
+func (s *Server) setProviderStatus(status providerStatusInfo) {
+	status.Providers = normalizedProviderIDs(status.Providers)
+	s.providerMu.Lock()
+	s.providerStatus = status
+	s.providerMu.Unlock()
+}
+
+func (s *Server) startProviderDiscovery(force bool) bool {
+	s.providerMu.Lock()
+	if s.providerDiscoveryBusy {
+		s.providerMu.Unlock()
+		return false
+	}
+	s.providerDiscoveryBusy = true
+	s.providerStatus.State = providerStateScanning
+	s.providerStatus.Message = "Finding your AI tools."
+	s.providerMu.Unlock()
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), providerDiscoveryTimeout)
+		defer cancel()
+		s.runProviderDiscovery(ctx, force)
+		s.providerMu.Lock()
+		s.providerDiscoveryBusy = false
+		s.providerMu.Unlock()
+	}()
+	return true
+}
+
+func (s *Server) runProviderDiscovery(ctx context.Context, force bool) {
+	version, err := s.providerVersion(ctx)
+	if err != nil {
+		s.setProviderStatus(providerStatusInfo{
+			State:     providerStateError,
+			Providers: []string{},
+			Message:   "VibeTV could not check your AI tools.",
+		})
+		return
+	}
+
+	if !force {
+		if marker, ok := s.loadProviderDiscoveryMarker(); ok &&
+			marker.SchemaVersion == providerDiscoverySchema &&
+			marker.CodexBarVersion == version {
+			if parsed, fetchErr := s.fetchUsage(ctx); fetchErr == nil && len(parsed) > 0 {
+				s.setProviderStatus(providerReadyStatus(version, parsed))
+				return
+			}
+		}
+	}
+
+	parsed, err := s.discoverProviders(ctx)
+	if err != nil || len(parsed) == 0 {
+		state := providerStateError
+		message := "VibeTV could not check your AI tools."
+		if err == nil || errors.Is(err, codexbar.ErrNoProviders) ||
+			codexbar.FetchErrorKindOf(err) == codexbar.FetchErrorNoProviders ||
+			codexbar.FetchErrorKindOf(err) == codexbar.FetchErrorCommand {
+			state = providerStateSetup
+			message = "Sign in to your AI tool, then check again."
+		}
+		s.setProviderStatus(providerStatusInfo{
+			State:           state,
+			CodexBarVersion: version,
+			Providers:       []string{},
+			Message:         message,
+		})
+		return
+	}
+
+	status := providerReadyStatus(version, parsed)
+	if err := s.saveProviderDiscoveryMarker(providerDiscoveryMarker{
+		SchemaVersion:   providerDiscoverySchema,
+		CodexBarVersion: version,
+		Providers:       status.Providers,
+		CompletedAt:     s.currentTime().UTC().Format(time.RFC3339Nano),
+	}); err != nil {
+		s.setProviderStatus(providerStatusInfo{
+			State:           providerStateError,
+			CodexBarVersion: version,
+			Providers:       status.Providers,
+			Message:         "Your AI tools were found, but setup could not be saved.",
+		})
+		return
+	}
+	s.setProviderStatus(status)
+}
+
+func providerReadyStatus(version string, parsed []codexbar.ParsedFrame) providerStatusInfo {
+	return providerStatusInfo{
+		State:           providerStateReady,
+		CodexBarVersion: version,
+		Providers:       parsedProviderIDs(parsed),
+		Message:         "AI tools found.",
+	}
+}
+
+func parsedProviderIDs(parsed []codexbar.ParsedFrame) []string {
+	providers := make([]string, 0, len(parsed))
+	for _, item := range parsed {
+		provider := strings.TrimSpace(strings.ToLower(item.Provider))
+		if provider == "" {
+			provider = strings.TrimSpace(strings.ToLower(item.Frame.Provider))
+		}
+		if provider != "" {
+			providers = append(providers, provider)
+		}
+	}
+	return normalizedProviderIDs(providers)
+}
+
+func normalizedProviderIDs(providers []string) []string {
+	seen := make(map[string]struct{}, len(providers))
+	result := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		provider = strings.TrimSpace(strings.ToLower(provider))
+		if provider == "" {
+			continue
+		}
+		if _, ok := seen[provider]; ok {
+			continue
+		}
+		seen[provider] = struct{}{}
+		result = append(result, provider)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func (s *Server) handleProviderDiscover(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	s.startProviderDiscovery(true)
+	writeJSON(w, http.StatusAccepted, struct {
+		OK       bool               `json:"ok"`
+		Provider providerStatusInfo `json:"provider"`
+	}{
+		OK:       true,
+		Provider: s.providerStatusSnapshot(),
+	})
+}
+
+func (s *Server) providerDiscoveryMarkerPath() string {
+	return filepath.Join(s.home, "Library", "Application Support", "codexbar-display", "provider-discovery.json")
+}
+
+func (s *Server) loadProviderDiscoveryMarker() (providerDiscoveryMarker, bool) {
+	var marker providerDiscoveryMarker
+	data, err := os.ReadFile(s.providerDiscoveryMarkerPath())
+	if err != nil || json.Unmarshal(data, &marker) != nil {
+		return providerDiscoveryMarker{}, false
+	}
+	marker.Providers = normalizedProviderIDs(marker.Providers)
+	if marker.SchemaVersion <= 0 || strings.TrimSpace(marker.CodexBarVersion) == "" || len(marker.Providers) == 0 {
+		return providerDiscoveryMarker{}, false
+	}
+	return marker, true
+}
+
+func (s *Server) saveProviderDiscoveryMarker(marker providerDiscoveryMarker) error {
+	path := s.providerDiscoveryMarkerPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create provider discovery directory: %w", err)
+	}
+	data, err := json.MarshalIndent(marker, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode provider discovery marker: %w", err)
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".provider-discovery-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create provider discovery marker: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("protect provider discovery marker: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write provider discovery marker: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync provider discovery marker: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close provider discovery marker: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace provider discovery marker: %w", err)
+	}
+	return nil
+}

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -180,6 +180,11 @@ type Server struct {
 	installationMode       string
 	loadUsage              func(time.Time) (daemon.PersistedUsage, bool)
 	fetchUsage             func(context.Context) ([]codexbar.ParsedFrame, error)
+	discoverProviders      func(context.Context) ([]codexbar.ParsedFrame, error)
+	providerVersion        func(context.Context) (string, error)
+	providerMu             sync.RWMutex
+	providerStatus         providerStatusInfo
+	providerDiscoveryBusy  bool
 	updateFirmware         func(context.Context, string, runtimeconfig.Config, firmwareUpdateRequest, io.Writer) error
 	updateMacApp           func(context.Context, string, string, macAppUpdateRequest, io.Writer) error
 	fetchMacAppRelease     func(context.Context) (githubRelease, error)
@@ -346,9 +351,10 @@ type themeSpecHealth struct {
 }
 
 type statusResponse struct {
-	OK        bool       `json:"ok"`
-	Companion companion  `json:"companion"`
-	Device    deviceInfo `json:"device"`
+	OK        bool               `json:"ok"`
+	Companion companion          `json:"companion"`
+	Device    deviceInfo         `json:"device"`
+	Provider  providerStatusInfo `json:"provider"`
 }
 
 type deviceActionResponse struct {
@@ -765,16 +771,23 @@ func New(opts Options) (*Server, error) {
 		installationMode:      macAppInstallationMode(),
 		loadUsage:             daemon.LoadPersistedUsage,
 		fetchUsage:            codexbar.FetchAllProviders,
-		updateFirmware:        runFirmwareUpdateCommand,
-		updateMacApp:          runMacAppUpdateCommand,
-		fetchMacAppRelease:    fetchLatestMacAppRelease,
-		installJobs:           make(map[string]*themeInstallJob),
-		updateJobs:            make(map[string]*firmwareUpdateJob),
-		macAppUpdateJobs:      make(map[string]*macAppUpdateJob),
+		discoverProviders:     codexbar.DiscoverAndEnableProviders,
+		providerVersion:       installedCodexBarVersion,
+		providerStatus: providerStatusInfo{
+			State:   providerStateScanning,
+			Message: "Finding your AI tools.",
+		},
+		updateFirmware:     runFirmwareUpdateCommand,
+		updateMacApp:       runMacAppUpdateCommand,
+		fetchMacAppRelease: fetchLatestMacAppRelease,
+		installJobs:        make(map[string]*themeInstallJob),
+		updateJobs:         make(map[string]*firmwareUpdateJob),
+		macAppUpdateJobs:   make(map[string]*macAppUpdateJob),
 	}, nil
 }
 
 func (s *Server) ListenAndServe(ctx context.Context) error {
+	s.startProviderDiscovery(false)
 	server := &http.Server{
 		Addr:              s.addr,
 		Handler:           s.Handler(),
@@ -807,6 +820,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/v1/status", s.handleStatus)
 	mux.HandleFunc("/v1/runtime-health", s.handleRuntimeHealth)
 	mux.HandleFunc("/v1/usage", s.handleUsage)
+	mux.HandleFunc("/v1/providers/discover", s.handleProviderDiscover)
 	mux.HandleFunc("/v1/display-frame/latest", s.handleDisplayFrameLatest)
 	mux.HandleFunc("/v1/diagnostics", s.handleDiagnostics)
 	mux.HandleFunc("/v1/device/discover", s.handleDeviceDiscover)
@@ -1024,6 +1038,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		OK:        true,
 		Companion: s.companionInfo(r.Context()),
 		Device:    device,
+		Provider:  s.providerStatusSnapshot(),
 	})
 }
 
@@ -1224,7 +1239,7 @@ func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 			writeUsage(persisted)
 			return
 		}
-		writeUsage(emptyUsageResponse(now, "codexbar-display"))
+		writeProviderSetupRequired(w)
 		return
 	}
 
@@ -1236,13 +1251,8 @@ func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 			writeUsage(persisted)
 			return
 		}
-		writeError(
-			w,
-			http.StatusServiceUnavailable,
-			"usage_unavailable",
-			"Usage is not ready.",
-			"Open CodexBar and the Mac App, then try again.",
-		)
+		s.startProviderDiscovery(false)
+		writeProviderSetupRequired(w)
 		return
 	}
 	resp := usageResponseFromParsed(now, providers)
@@ -1250,7 +1260,32 @@ func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 		writeUsage(persisted)
 		return
 	}
+	if len(resp.Providers) == 0 {
+		s.startProviderDiscovery(false)
+		writeProviderSetupRequired(w)
+		return
+	}
+	status := s.providerStatusSnapshot()
+	if status.State != providerStateReady || len(status.Providers) == 0 {
+		version := status.CodexBarVersion
+		if version == "" && s.providerVersion != nil {
+			if detectedVersion, versionErr := s.providerVersion(r.Context()); versionErr == nil {
+				version = detectedVersion
+			}
+		}
+		s.setProviderStatus(providerReadyStatus(version, providers))
+	}
 	writeUsage(resp)
+}
+
+func writeProviderSetupRequired(w http.ResponseWriter) {
+	writeError(
+		w,
+		http.StatusServiceUnavailable,
+		"provider_setup_required",
+		"No AI tool usage is available yet.",
+		"Sign in to your AI tool, then choose Check again.",
+	)
 }
 
 func (s *Server) handleDisplayFrameLatest(w http.ResponseWriter, r *http.Request) {
@@ -1354,6 +1389,19 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 			NextAction: "Unset VIBETV_DISABLE_WIFI_THEME_INSTALL, then restart the Mac App.",
 		})
 	}
+	provider := s.providerStatusSnapshot()
+	providerCheck := diagnosticCheck{
+		Name:   "provider_usage",
+		Status: "pass",
+		Detail: strings.Join(provider.Providers, ", "),
+	}
+	if provider.State != providerStateReady || len(provider.Providers) == 0 {
+		providerCheck.Status = "attention"
+		providerCheck.Detail = provider.Message
+		providerCheck.ErrorCode = "provider_setup_required"
+		providerCheck.NextAction = "Sign in to your AI tool, then choose Check again."
+	}
+	checks = append(checks, providerCheck)
 
 	device := deviceInfo{
 		Target:    publicTarget(cfg.DeviceTarget),
@@ -6199,6 +6247,11 @@ func lastDisplayStreamErrorRecordAfter(path string, boundary time.Time) (time.Ti
 				code = "display_stream_timeout"
 			}
 			lower := strings.ToLower(line)
+			if strings.Contains(lower, "runtime/no-providers") ||
+				strings.Contains(lower, "select-provider") {
+				detail = "No AI tool usage is available yet."
+				code = "provider_setup_required"
+			}
 			if strings.Contains(lower, "status=401") ||
 				strings.Contains(lower, "pairing token required") ||
 				strings.Contains(lower, "unauthorized") {

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -61,6 +61,145 @@ func TestStatusWorksWithoutDevice(t *testing.T) {
 	}
 }
 
+func TestStatusReportsProviderReadiness(t *testing.T) {
+	server := newTestServer(t, runtimeconfig.Config{})
+	server.setProviderStatus(providerStatusInfo{
+		State:           providerStateReady,
+		CodexBarVersion: "0.37.2",
+		Providers:       []string{"codex", "claude"},
+		Message:         "AI tools found.",
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/status", nil)
+	server.Handler().ServeHTTP(rec, req)
+
+	var got statusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Provider.State != providerStateReady || got.Provider.CodexBarVersion != "0.37.2" {
+		t.Fatalf("unexpected provider status: %+v", got.Provider)
+	}
+	if strings.Join(got.Provider.Providers, ",") != "claude,codex" {
+		t.Fatalf("expected normalized providers, got %v", got.Provider.Providers)
+	}
+}
+
+func TestProviderDiscoveryMarksReadyAndPersistsSchemaMarker(t *testing.T) {
+	server := newTestServer(t, runtimeconfig.Config{})
+	server.providerVersion = func(context.Context) (string, error) { return "0.37.2", nil }
+	server.discoverProviders = func(context.Context) ([]codexbar.ParsedFrame, error) {
+		return []codexbar.ParsedFrame{
+			{Provider: "codex", Frame: protocol.Frame{Provider: "codex"}},
+			{Provider: "claude", Frame: protocol.Frame{Provider: "claude"}},
+		}, nil
+	}
+	server.runProviderDiscovery(context.Background(), true)
+
+	status := server.providerStatusSnapshot()
+	if status.State != providerStateReady || strings.Join(status.Providers, ",") != "claude,codex" {
+		t.Fatalf("unexpected provider readiness: %+v", status)
+	}
+	marker, ok := server.loadProviderDiscoveryMarker()
+	if !ok || marker.SchemaVersion != 1 || marker.CodexBarVersion != "0.37.2" {
+		t.Fatalf("unexpected provider marker: %+v ok=%v", marker, ok)
+	}
+	info, err := os.Stat(server.providerDiscoveryMarkerPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected marker permissions 0600, got %o", info.Mode().Perm())
+	}
+}
+
+func TestProviderDiscoveryReusesMarkerOnlyWhileUsageStillWorks(t *testing.T) {
+	server := newTestServer(t, runtimeconfig.Config{})
+	server.providerVersion = func(context.Context) (string, error) { return "0.37.2", nil }
+	if err := server.saveProviderDiscoveryMarker(providerDiscoveryMarker{
+		SchemaVersion:   1,
+		CodexBarVersion: "0.37.2",
+		Providers:       []string{"codex"},
+		CompletedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	server.fetchUsage = func(context.Context) ([]codexbar.ParsedFrame, error) {
+		return nil, nil
+	}
+	discoveryCalls := 0
+	server.discoverProviders = func(context.Context) ([]codexbar.ParsedFrame, error) {
+		discoveryCalls++
+		return []codexbar.ParsedFrame{{Provider: "claude", Frame: protocol.Frame{Provider: "claude"}}}, nil
+	}
+
+	server.runProviderDiscovery(context.Background(), false)
+	status := server.providerStatusSnapshot()
+	if discoveryCalls != 1 || status.State != providerStateReady || strings.Join(status.Providers, ",") != "claude" {
+		t.Fatalf("zero live providers must trigger a new scan: calls=%d status=%+v", discoveryCalls, status)
+	}
+}
+
+func TestProviderDiscoveryRerunsWhenBundledVersionChanges(t *testing.T) {
+	server := newTestServer(t, runtimeconfig.Config{})
+	server.providerVersion = func(context.Context) (string, error) { return "0.37.2", nil }
+	if err := server.saveProviderDiscoveryMarker(providerDiscoveryMarker{
+		SchemaVersion:   1,
+		CodexBarVersion: "0.36.0",
+		Providers:       []string{"codex"},
+		CompletedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	server.fetchUsage = func(context.Context) ([]codexbar.ParsedFrame, error) {
+		t.Fatal("version change must bypass the old marker")
+		return nil, nil
+	}
+	discoveryCalls := 0
+	server.discoverProviders = func(context.Context) ([]codexbar.ParsedFrame, error) {
+		discoveryCalls++
+		return []codexbar.ParsedFrame{{Provider: "codex", Frame: protocol.Frame{Provider: "codex"}}}, nil
+	}
+	server.runProviderDiscovery(context.Background(), false)
+	if discoveryCalls != 1 || server.providerStatusSnapshot().State != providerStateReady {
+		t.Fatalf("bundled version change did not rerun discovery")
+	}
+}
+
+func TestProviderDiscoveryHidesRawAPIFailure(t *testing.T) {
+	server := newTestServer(t, runtimeconfig.Config{})
+	server.providerVersion = func(context.Context) (string, error) { return "0.37.2", nil }
+	server.discoverProviders = func(context.Context) ([]codexbar.ParsedFrame, error) {
+		return nil, errors.New("secret upstream API response")
+	}
+	server.runProviderDiscovery(context.Background(), true)
+	status := server.providerStatusSnapshot()
+	if status.State != providerStateError || strings.Contains(status.Message, "secret") {
+		t.Fatalf("unexpected provider API error status: %+v", status)
+	}
+}
+
+func TestProviderDiscoveryRetryEndpointStartsAutomaticScan(t *testing.T) {
+	server := newTestServer(t, runtimeconfig.Config{})
+	started := make(chan struct{}, 1)
+	server.providerVersion = func(context.Context) (string, error) { return "0.37.2", nil }
+	server.discoverProviders = func(context.Context) ([]codexbar.ParsedFrame, error) {
+		started <- struct{}{}
+		return nil, codexbar.ErrNoProviders
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/providers/discover", nil)
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("provider discovery did not start")
+	}
+}
+
 func TestRuntimeHealthDoesNotProbeDeviceOrRelease(t *testing.T) {
 	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatalf("runtime health must not contact VibeTV, got %s", r.URL.Path)
@@ -1602,6 +1741,21 @@ func TestLastDisplayStreamErrorParsesLatestCycleError(t *testing.T) {
 	}
 }
 
+func TestLastDisplayStreamErrorMapsMissingProvidersToSetup(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "daemon.out.log")
+	if err := os.WriteFile(
+		logPath,
+		[]byte(`2026-07-17T10:00:00Z cycle error: code=runtime/no-providers op=select-provider retry=3s err="no providers"`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	_, detail, code, ok := lastDisplayStreamErrorRecordAfter(logPath, time.Time{})
+	if !ok || code != "provider_setup_required" || detail != "No AI tool usage is available yet." {
+		t.Fatalf("unexpected provider stream error: ok=%v code=%q detail=%q", ok, code, detail)
+	}
+}
+
 func TestDisplayFrameLatestReturnsNotFoundWithoutLastGoodFrame(t *testing.T) {
 	t.Setenv(displayStreamOutLogEnv, filepath.Join(t.TempDir(), "missing.log"))
 	server := newTestServer(t, runtimeconfig.Config{})
@@ -1815,8 +1969,24 @@ func TestUsageUnavailableReturnsCustomerSafeError(t *testing.T) {
 	if err := json.Unmarshal([]byte(body), &got); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if got.OK || got.Error.Code != "usage_unavailable" {
+	if got.OK || got.Error.Code != "provider_setup_required" {
 		t.Fatalf("unexpected error response: %+v", got)
+	}
+}
+
+func TestUsageWithZeroProvidersRequiresProviderSetup(t *testing.T) {
+	server := newTestServer(t, runtimeconfig.Config{})
+	server.loadUsage = func(time.Time) (daemon.PersistedUsage, bool) {
+		return daemon.PersistedUsage{}, false
+	}
+	server.fetchUsage = func(context.Context) ([]codexbar.ParsedFrame, error) {
+		return nil, nil
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/usage", nil)
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable || !strings.Contains(rec.Body.String(), `"code":"provider_setup_required"`) {
+		t.Fatalf("expected provider setup response, got %d body=%s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -5874,6 +6044,12 @@ func newTestServer(t *testing.T, cfg runtimeconfig.Config) *Server {
 	}
 	server.fetchMacAppRelease = func(context.Context) (githubRelease, error) {
 		return githubRelease{TagName: "v1.0.0"}, nil
+	}
+	server.providerVersion = func(context.Context) (string, error) {
+		return "0.37.2", nil
+	}
+	server.discoverProviders = func(context.Context) ([]codexbar.ParsedFrame, error) {
+		return nil, codexbar.ErrNoProviders
 	}
 	server.subnetTargets = func() []string {
 		return nil

--- a/docs/control-center-customer-ui-approval.md
+++ b/docs/control-center-customer-ui-approval.md
@@ -46,3 +46,9 @@ issue scope, or release permission never implies UI permission.
 - User approval: After the critical pre-release review, the user explicitly ordered all identified retry-safety and real-runtime-path fixes except the separately numbered reproducible-build and staged-rollout items in the Codex task on 2026-07-16.
 - Approved customer-visible result: When a firmware upload may have started but did not finish safely, the failed update state shows the instruction to disconnect VibeTV from power for 10 seconds and wait for the picture after reconnecting. It does not show `Try again` in that state; creating a support report remains available.
 - Approved files: `control-center-app.tsx`, `updates-screen.tsx`, and the customer-flow assertion in `test-customer-flows.mjs`.
+
+## 2026-07-17 — Automatic AI-tool discovery without provider selection
+
+- User approval: The user explicitly approved the KISS hotfix plan in the Codex task on 2026-07-17 and required automatic detection with no provider choice.
+- Approved customer-visible result: During automatic detection, Setup shows `Finding your AI tools`. When no usable AI tool is available, it asks the customer to sign in to their existing AI tool and offers only `Check again`. It never asks the customer to select a provider, never recommends firmware repair or `Fix connection` for this cause, and Overview shows the automatically detected AI tools.
+- Approved files: `control-center-app.tsx`, `control-center-types.ts`, `overview-screen.tsx`, `setup-screen.tsx`, `usage-screen.tsx`, and their customer-flow assertions in `test-customer-flows.mjs`.

--- a/scripts/build-macos-control-center-app.sh
+++ b/scripts/build-macos-control-center-app.sh
@@ -262,7 +262,8 @@ EOF
 copy_codexbar_cli() {
   local helpers_dir="$1"
   local notices_dir="$2"
-  mkdir -p "$helpers_dir" "$notices_dir"
+  local metadata_dir="$3"
+  mkdir -p "$helpers_dir" "$notices_dir" "$metadata_dir"
 
   if [[ "$DRY_RUN" == "1" ]]; then
     cat > "${helpers_dir}/${CODEXBAR_CLI_NAME}" <<'EOF'
@@ -270,7 +271,7 @@ copy_codexbar_cli() {
 printf 'CodexBar 0.37.2\n'
 EOF
     chmod 755 "${helpers_dir}/${CODEXBAR_CLI_NAME}"
-    printf '0.37.2\n' > "${helpers_dir}/VERSION"
+    printf '0.37.2\n' > "${metadata_dir}/VERSION"
   else
     [[ -f "$CODEXBAR_CLI_BINARY" ]] \
       || die "real app builds need --codexbar-cli-binary path/to/${CODEXBAR_CLI_NAME}"
@@ -278,7 +279,7 @@ EOF
       || die "real app builds need --codexbar-cli-version-file path/to/VERSION"
     cp "$CODEXBAR_CLI_BINARY" "${helpers_dir}/${CODEXBAR_CLI_NAME}"
     chmod 755 "${helpers_dir}/${CODEXBAR_CLI_NAME}"
-    cp "$CODEXBAR_CLI_VERSION_FILE" "${helpers_dir}/VERSION"
+    cp "$CODEXBAR_CLI_VERSION_FILE" "${metadata_dir}/VERSION"
   fi
 
   [[ -f "$CODEXBAR_LICENSE" ]] || die "CodexBar license file not found: ${CODEXBAR_LICENSE}"
@@ -394,6 +395,7 @@ main() {
   local frameworks_dir="${contents}/Frameworks"
   local resources_dir="${contents}/Resources"
   local notices_dir="${resources_dir}/ThirdPartyNotices"
+  local codexbar_metadata_dir="${resources_dir}/CodexBar"
   local launch_agents_dir="${contents}/Library/LaunchAgents"
 
   rm -rf "$APP_DIR"
@@ -406,7 +408,7 @@ main() {
   copy_app_icon "$resources_dir"
   copy_control_center_static "${resources_dir}/control-center"
   copy_companion_binary "$helpers_dir"
-  copy_codexbar_cli "$helpers_dir" "$notices_dir"
+  copy_codexbar_cli "$helpers_dir" "$notices_dir" "$codexbar_metadata_dir"
   copy_runtime_agent_plist "${launch_agents_dir}/${RUNTIME_AGENT_PLIST_NAME}"
   cp "${ROOT}/macos/VibeTVControlCenter/VibeTVControlCenter.entitlements" "${resources_dir}/VibeTVControlCenter.entitlements"
 

--- a/scripts/build-macos-control-center-app.sh
+++ b/scripts/build-macos-control-center-app.sh
@@ -7,6 +7,7 @@ APP_NAME="VibeTV Control Center"
 BUNDLE_ID="shop.vibetv.control-center"
 EXECUTABLE_NAME="VibeTVControlCenter"
 COMPANION_NAME="codexbar-display"
+CODEXBAR_CLI_NAME="CodexBarCLI"
 ICON_FILE_NAME="VibeTVControlCenter.icns"
 RUNTIME_AGENT_PLIST_NAME="shop.vibetv.control-center.runtime.plist"
 APP_ICON="${ROOT}/macos/VibeTVControlCenter/${ICON_FILE_NAME}"
@@ -20,6 +21,9 @@ BUILD="${BUILD:-0}"
 APP_DIR="${ROOT}/dist/macos/${APP_NAME}.app"
 CONTROL_CENTER_STATIC="${ROOT}/apps/control-center/out-local"
 COMPANION_BINARY=""
+CODEXBAR_CLI_BINARY=""
+CODEXBAR_CLI_VERSION_FILE=""
+CODEXBAR_LICENSE="${ROOT}/third_party/CodexBar-LICENSE.txt"
 DRY_RUN=0
 UNIVERSAL=0
 LOCAL_PREVIEW=0
@@ -27,7 +31,7 @@ LOCAL_PREVIEW=0
 usage() {
   cat <<EOF
 Usage:
-  build-macos-control-center-app.sh [--version x.y.z] [--build n] [--output path.app] [--control-center-static dir] [--companion-binary path] [--app-icon path.icns] [--sparkle-feed-url url] [--sparkle-public-key key] [--universal] [--local-preview] [--dry-run]
+  build-macos-control-center-app.sh [--version x.y.z] [--build n] [--output path.app] [--control-center-static dir] [--companion-binary path] [--codexbar-cli-binary path] [--codexbar-cli-version-file path] [--app-icon path.icns] [--sparkle-feed-url url] [--sparkle-public-key key] [--universal] [--local-preview] [--dry-run]
 
 Builds the prepared macOS .app bundle for ${APP_NAME}.
 
@@ -73,6 +77,16 @@ while [[ $# -gt 0 ]]; do
     --companion-binary)
       need_value "$1" "${2:-}"
       COMPANION_BINARY="$2"
+      shift 2
+      ;;
+    --codexbar-cli-binary)
+      need_value "$1" "${2:-}"
+      CODEXBAR_CLI_BINARY="$2"
+      shift 2
+      ;;
+    --codexbar-cli-version-file)
+      need_value "$1" "${2:-}"
+      CODEXBAR_CLI_VERSION_FILE="$2"
       shift 2
       ;;
     --app-icon)
@@ -245,6 +259,32 @@ EOF
   die "real app builds need --companion-binary path/to/${COMPANION_NAME}"
 }
 
+copy_codexbar_cli() {
+  local helpers_dir="$1"
+  local notices_dir="$2"
+  mkdir -p "$helpers_dir" "$notices_dir"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    cat > "${helpers_dir}/${CODEXBAR_CLI_NAME}" <<'EOF'
+#!/usr/bin/env bash
+printf 'CodexBar 0.37.2\n'
+EOF
+    chmod 755 "${helpers_dir}/${CODEXBAR_CLI_NAME}"
+    printf '0.37.2\n' > "${helpers_dir}/VERSION"
+  else
+    [[ -f "$CODEXBAR_CLI_BINARY" ]] \
+      || die "real app builds need --codexbar-cli-binary path/to/${CODEXBAR_CLI_NAME}"
+    [[ -f "$CODEXBAR_CLI_VERSION_FILE" ]] \
+      || die "real app builds need --codexbar-cli-version-file path/to/VERSION"
+    cp "$CODEXBAR_CLI_BINARY" "${helpers_dir}/${CODEXBAR_CLI_NAME}"
+    chmod 755 "${helpers_dir}/${CODEXBAR_CLI_NAME}"
+    cp "$CODEXBAR_CLI_VERSION_FILE" "${helpers_dir}/VERSION"
+  fi
+
+  [[ -f "$CODEXBAR_LICENSE" ]] || die "CodexBar license file not found: ${CODEXBAR_LICENSE}"
+  cp "$CODEXBAR_LICENSE" "${notices_dir}/CodexBar-LICENSE.txt"
+}
+
 copy_runtime_agent_plist() {
   local target="$1"
   [[ -f "$RUNTIME_AGENT_PLIST" ]] || die "runtime LaunchAgent plist not found: ${RUNTIME_AGENT_PLIST}"
@@ -353,10 +393,11 @@ main() {
   local helpers_dir="${contents}/Helpers"
   local frameworks_dir="${contents}/Frameworks"
   local resources_dir="${contents}/Resources"
+  local notices_dir="${resources_dir}/ThirdPartyNotices"
   local launch_agents_dir="${contents}/Library/LaunchAgents"
 
   rm -rf "$APP_DIR"
-  mkdir -p "$macos_dir" "$helpers_dir" "$frameworks_dir" "$resources_dir" "$launch_agents_dir"
+  mkdir -p "$macos_dir" "$helpers_dir" "$frameworks_dir" "$resources_dir" "$notices_dir" "$launch_agents_dir"
 
   prepare_sparkle
   write_info_plist "${contents}/Info.plist"
@@ -365,6 +406,7 @@ main() {
   copy_app_icon "$resources_dir"
   copy_control_center_static "${resources_dir}/control-center"
   copy_companion_binary "$helpers_dir"
+  copy_codexbar_cli "$helpers_dir" "$notices_dir"
   copy_runtime_agent_plist "${launch_agents_dir}/${RUNTIME_AGENT_PLIST_NAME}"
   cp "${ROOT}/macos/VibeTVControlCenter/VibeTVControlCenter.entitlements" "${resources_dir}/VibeTVControlCenter.entitlements"
 

--- a/scripts/prepare-bundled-codexbar-cli.sh
+++ b/scripts/prepare-bundled-codexbar-cli.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CODEXBAR_VERSION="0.37.2"
+CODEXBAR_TAG="v${CODEXBAR_VERSION}"
+CODEXBAR_RELEASE_BASE="https://github.com/steipete/CodexBar/releases/download/${CODEXBAR_TAG}"
+ARM64_ARCHIVE="CodexBarCLI-${CODEXBAR_TAG}-macos-arm64.tar.gz"
+X86_64_ARCHIVE="CodexBarCLI-${CODEXBAR_TAG}-macos-x86_64.tar.gz"
+ARM64_SHA256="282acfc4b99aafe9d3b7b093f2ee6abbda3e2725b8512217f10c41784cba59df"
+X86_64_SHA256="da24ab1bd9ec5ba51026bb2d97d9634b642e0fc9c6a5f2198854c20fb76ca34a"
+OUTPUT_DIR=""
+WORK_DIR=""
+
+usage() {
+  cat <<EOF
+Usage:
+  prepare-bundled-codexbar-cli.sh --output-dir path
+
+Downloads the pinned CodexBarCLI ${CODEXBAR_VERSION} macOS release binaries,
+verifies their SHA-256 digests, and creates one universal binary for the VibeTV
+Control Center app bundle.
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      [[ -n "${2:-}" ]] || die "--output-dir needs a value"
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$OUTPUT_DIR" ]] || die "--output-dir is required"
+for command in curl file lipo shasum tar; do
+  command -v "$command" >/dev/null 2>&1 || die "required command is unavailable: $command"
+done
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-codexbar-cli.XXXXXX")"
+trap cleanup EXIT
+mkdir -p "$WORK_DIR/arm64" "$WORK_DIR/x86_64" "$OUTPUT_DIR"
+
+curl -fsSL --retry 3 \
+  "${CODEXBAR_RELEASE_BASE}/${ARM64_ARCHIVE}" \
+  -o "$WORK_DIR/$ARM64_ARCHIVE"
+curl -fsSL --retry 3 \
+  "${CODEXBAR_RELEASE_BASE}/${X86_64_ARCHIVE}" \
+  -o "$WORK_DIR/$X86_64_ARCHIVE"
+
+printf '%s  %s\n' "$ARM64_SHA256" "$WORK_DIR/$ARM64_ARCHIVE" | shasum -a 256 -c -
+printf '%s  %s\n' "$X86_64_SHA256" "$WORK_DIR/$X86_64_ARCHIVE" | shasum -a 256 -c -
+
+tar -xzf "$WORK_DIR/$ARM64_ARCHIVE" -C "$WORK_DIR/arm64"
+tar -xzf "$WORK_DIR/$X86_64_ARCHIVE" -C "$WORK_DIR/x86_64"
+
+for arch in arm64 x86_64; do
+  binary="$WORK_DIR/$arch/CodexBarCLI"
+  version_file="$WORK_DIR/$arch/VERSION"
+  [[ -x "$binary" ]] || die "${arch} archive does not contain an executable CodexBarCLI"
+  [[ -f "$version_file" ]] || die "${arch} archive does not contain VERSION"
+  [[ "$(tr -d '[:space:]' < "$version_file")" == "$CODEXBAR_VERSION" ]] \
+    || die "${arch} VERSION does not match ${CODEXBAR_VERSION}"
+done
+
+lipo -create \
+  -output "$OUTPUT_DIR/CodexBarCLI" \
+  "$WORK_DIR/arm64/CodexBarCLI" \
+  "$WORK_DIR/x86_64/CodexBarCLI"
+chmod 755 "$OUTPUT_DIR/CodexBarCLI"
+printf '%s\n' "$CODEXBAR_VERSION" > "$OUTPUT_DIR/VERSION"
+
+lipo "$OUTPUT_DIR/CodexBarCLI" -verify_arch arm64 x86_64
+version_output="$("$OUTPUT_DIR/CodexBarCLI" --version)"
+[[ "$version_output" == *"${CODEXBAR_VERSION}"* ]] \
+  || die "universal CodexBarCLI reported unexpected version: ${version_output}"
+
+printf 'prepared bundled CodexBarCLI %s: %s\n' \
+  "$CODEXBAR_VERSION" "$OUTPUT_DIR/CodexBarCLI"

--- a/scripts/sign-notarize-macos-control-center.sh
+++ b/scripts/sign-notarize-macos-control-center.sh
@@ -169,6 +169,7 @@ require_real_inputs() {
   [[ "$(uname -s)" == "Darwin" ]] || die "real signing and notarization require macOS"
   command -v security >/dev/null 2>&1 || die "security is required"
   command -v codesign >/dev/null 2>&1 || die "codesign is required"
+  command -v lipo >/dev/null 2>&1 || die "lipo is required"
   command -v plutil >/dev/null 2>&1 || die "plutil is required"
   command -v xcrun >/dev/null 2>&1 || die "xcrun is required"
   command -v spctl >/dev/null 2>&1 || die "spctl is required"
@@ -203,6 +204,9 @@ dry-run: planned real-mode commands:
   curl https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
   security create-keychain / security import Developer ID Application certificate
   codesign --force --options runtime --timestamp --sign <identity> "${APP_DIR}/Contents/Helpers/codexbar-display"
+  codesign --force --options runtime --timestamp --sign <identity> "${APP_DIR}/Contents/Helpers/CodexBarCLI"
+  lipo "${APP_DIR}/Contents/Helpers/codexbar-display" -verify_arch arm64 x86_64
+  lipo "${APP_DIR}/Contents/Helpers/CodexBarCLI" -verify_arch arm64 x86_64
   codesign --force --options runtime --timestamp --entitlements macos/VibeTVControlCenter/VibeTVControlCenter.entitlements --sign <identity> "${APP_DIR}"
   codesign --verify --deep --strict --verbose=2 "${APP_DIR}"
   syspolicy_check notary-submission "${APP_DIR}" (when available)
@@ -310,6 +314,7 @@ run_notary_submission_preflight() {
 sign_app_bundle() {
   local identity="$1"
   local companion_binary="${APP_DIR}/Contents/Helpers/codexbar-display"
+  local codexbar_cli="${APP_DIR}/Contents/Helpers/CodexBarCLI"
   local sparkle_framework="${APP_DIR}/Contents/Frameworks/Sparkle.framework"
   local authority signature_details signed_team_id
 
@@ -338,15 +343,18 @@ sign_app_bundle() {
     codesign --verify --deep --strict --verbose=2 "$sparkle_framework"
   fi
 
-  if [[ -x "$companion_binary" ]]; then
+  for helper in "$companion_binary" "$codexbar_cli"; do
+    [[ -x "$helper" ]] || die "required app helper is missing or not executable: ${helper}"
+    lipo "$helper" -verify_arch arm64 x86_64 \
+      || die "required app helper is not universal arm64/x86_64: ${helper}"
     codesign \
       --force \
       --options runtime \
       --timestamp \
       --sign "$identity" \
-      "$companion_binary"
-    codesign --verify --strict --verbose=2 "$companion_binary"
-  fi
+      "$helper"
+    codesign --verify --strict --verbose=2 "$helper"
+  done
 
   codesign \
     --force \

--- a/scripts/test-control-center-release-workflow.sh
+++ b/scripts/test-control-center-release-workflow.sh
@@ -10,6 +10,7 @@ RELEASE_INSTALLER="${ROOT}/scripts/install-control-center-companion-release.sh"
 PUBLIC_INSTALLER="${ROOT}/apps/control-center/public/install-control-center-companion.sh"
 SIGNING_SCRIPT="${ROOT}/scripts/sign-notarize-macos-control-center.sh"
 VERIFY_DMG_SCRIPT="${ROOT}/scripts/verify-macos-control-center-dmg.sh"
+PREPARE_CODEXBAR_SCRIPT="${ROOT}/scripts/prepare-bundled-codexbar-cli.sh"
 
 die() {
   printf 'error: %s\n' "$*" >&2
@@ -57,6 +58,7 @@ main() {
   [[ -f "$PUBLIC_INSTALLER" ]] || die "public Control Center installer is missing"
   [[ -x "$SIGNING_SCRIPT" ]] || die "macOS signing/notarization script is missing or not executable"
   [[ -x "$VERIFY_DMG_SCRIPT" ]] || die "macOS DMG verification script is missing or not executable"
+  [[ -x "$PREPARE_CODEXBAR_SCRIPT" ]] || die "bundled CodexBarCLI preparation script is missing or not executable"
   cmp -s "$RELEASE_INSTALLER" "$PUBLIC_INSTALLER" \
     || die "public Control Center installer must match the release installer"
 
@@ -74,6 +76,15 @@ main() {
   signing_script="$(cat "$SIGNING_SCRIPT")"
   verify_dmg_plan="$("$VERIFY_DMG_SCRIPT" --dry-run --dmg "/tmp/VibeTV-Control-Center.dmg")"
   macos_job="$(job_block "build-macos-dmg")"
+
+  assert_contains "$(cat "$PREPARE_CODEXBAR_SCRIPT")" \
+    "282acfc4b99aafe9d3b7b093f2ee6abbda3e2725b8512217f10c41784cba59df" \
+    "bundled arm64 CodexBarCLI must use the reviewed 0.37.2 SHA-256"
+  assert_contains "$(cat "$PREPARE_CODEXBAR_SCRIPT")" \
+    "da24ab1bd9ec5ba51026bb2d97d9634b642e0fc9c6a5f2198854c20fb76ca34a" \
+    "bundled x86_64 CodexBarCLI must use the reviewed 0.37.2 SHA-256"
+  assert_contains "$(cat "$PREPARE_CODEXBAR_SCRIPT")" "lipo -create" \
+    "bundled CodexBarCLI must be assembled as a universal binary"
 
   assert_not_contains "$workflow" "workflow_dispatch:" \
     "public release workflow must not expose the validation-only trigger"
@@ -121,6 +132,12 @@ main() {
     "macOS DMG job must build both Darwin companion architectures"
   assert_contains "$macos_job" "lipo -create" \
     "macOS DMG job must combine the bundled companion binary into a universal binary"
+  assert_contains "$macos_job" "prepare-bundled-codexbar-cli.sh" \
+    "macOS DMG job must prepare the pinned universal CodexBarCLI"
+  assert_contains "$macos_job" "--codexbar-cli-binary" \
+    "macOS DMG job must bundle CodexBarCLI inside the Mac App"
+  assert_contains "$macos_job" "--codexbar-cli-version-file" \
+    "macOS DMG job must bundle the pinned CodexBarCLI VERSION file"
   assert_contains "$macos_job" "build-macos-control-center-app.sh" \
     "macOS DMG job must build the real app bundle"
   assert_contains "$macos_job" "--universal" \
@@ -248,6 +265,10 @@ main() {
     "DMG distribution gate must verify the disk image container"
   assert_contains "$verify_dmg_plan" "codesign --verify --strict" \
     "DMG distribution gate must verify the DMG signature"
+  assert_contains "$verify_dmg_plan" "CodexBarCLI\" -verify_arch arm64 x86_64" \
+    "DMG distribution gate must verify the bundled CodexBarCLI architectures"
+  assert_contains "$verify_dmg_plan" "VERSION is 0.37.2" \
+    "DMG distribution gate must verify the pinned CodexBarCLI version"
   assert_contains "$verify_dmg_plan" "xcrun stapler validate" \
     "DMG distribution gate must validate the stapled notarization ticket"
   assert_contains "$verify_dmg_plan" "spctl --assess --type open" \

--- a/scripts/test-control-center-release-workflow.sh
+++ b/scripts/test-control-center-release-workflow.sh
@@ -258,8 +258,11 @@ main() {
   assert_contains "$signing_script" "does not match APPLE_TEAM_ID" \
     "signing script must reject a certificate for the wrong Apple team"
   assert_contains "$(cat "$PREVIEW_WORKFLOW")" \
-    "ref: 24c3855468991f28ef1af2df905b95944d90985c" \
-    "preview signing job must use the reviewed main commit with nested Sparkle signing"
+    "ref: fd95fbdc3a9412b6c85fe9b9bddb750319db48a0" \
+    "preview signing job must use the reviewed hotfix commit with both helper signatures"
+  assert_contains "$(cat "$PREVIEW_WORKFLOW")" \
+    "github.actor == github.repository_owner" \
+    "preview workflow must remain restricted to the repository owner"
 
   assert_contains "$verify_dmg_plan" "hdiutil verify" \
     "DMG distribution gate must verify the disk image container"

--- a/scripts/test-control-center-release-workflow.sh
+++ b/scripts/test-control-center-release-workflow.sh
@@ -258,7 +258,7 @@ main() {
   assert_contains "$signing_script" "does not match APPLE_TEAM_ID" \
     "signing script must reject a certificate for the wrong Apple team"
   assert_contains "$(cat "$PREVIEW_WORKFLOW")" \
-    "ref: fd95fbdc3a9412b6c85fe9b9bddb750319db48a0" \
+    "ref: 170a0d0d94e8cf434b6cab1d0380499b94f6b7f2" \
     "preview signing job must use the reviewed hotfix commit with both helper signatures"
   assert_contains "$(cat "$PREVIEW_WORKFLOW")" \
     "github.actor == github.repository_owner" \

--- a/scripts/test-macos-control-center-app-bundle.sh
+++ b/scripts/test-macos-control-center-app-bundle.sh
@@ -433,6 +433,12 @@ main() {
     || die "Control Center resource folder is missing"
   [[ -x "${app}/Contents/Helpers/codexbar-display" ]] \
     || die "bundled Companion helper is missing or not executable"
+  [[ -x "${app}/Contents/Helpers/CodexBarCLI" ]] \
+    || die "bundled CodexBarCLI helper is missing or not executable"
+  assert_file "${app}/Contents/Helpers/VERSION"
+  [[ "$(tr -d '[:space:]' < "${app}/Contents/Helpers/VERSION")" == "0.37.2" ]] \
+    || die "bundled CodexBarCLI VERSION must be pinned to 0.37.2"
+  assert_file "${app}/Contents/Resources/ThirdPartyNotices/CodexBar-LICENSE.txt"
   [[ ! -e "${app}/Contents/Resources/companion" ]] \
     || die "Mach-O helpers must not be stored in the Resources directory"
   assert_file "${app}/Contents/Resources/VibeTVControlCenter.icns"
@@ -887,6 +893,10 @@ PY
     "signing dry-run must show hardened-runtime codesign"
   assert_contains "$sign_output" "${app}/Contents/Helpers/codexbar-display" \
     "signing dry-run must sign the helper from the standard code directory"
+  assert_contains "$sign_output" "${app}/Contents/Helpers/CodexBarCLI" \
+    "signing dry-run must sign the bundled CodexBarCLI helper"
+  assert_contains "$sign_output" "-verify_arch arm64 x86_64" \
+    "signing dry-run must verify both helper architectures"
   if [[ "$sign_output" == *"Contents/Resources/companion"* ]]; then
     die "signing dry-run must not treat Resources as a Mach-O code directory"
   fi

--- a/scripts/test-macos-control-center-app-bundle.sh
+++ b/scripts/test-macos-control-center-app-bundle.sh
@@ -435,9 +435,11 @@ main() {
     || die "bundled Companion helper is missing or not executable"
   [[ -x "${app}/Contents/Helpers/CodexBarCLI" ]] \
     || die "bundled CodexBarCLI helper is missing or not executable"
-  assert_file "${app}/Contents/Helpers/VERSION"
-  [[ "$(tr -d '[:space:]' < "${app}/Contents/Helpers/VERSION")" == "0.37.2" ]] \
+  assert_file "${app}/Contents/Resources/CodexBar/VERSION"
+  [[ "$(tr -d '[:space:]' < "${app}/Contents/Resources/CodexBar/VERSION")" == "0.37.2" ]] \
     || die "bundled CodexBarCLI VERSION must be pinned to 0.37.2"
+  [[ ! -e "${app}/Contents/Helpers/VERSION" ]] \
+    || die "data files must not be placed in the code-only Contents/Helpers directory"
   assert_file "${app}/Contents/Resources/ThirdPartyNotices/CodexBar-LICENSE.txt"
   [[ ! -e "${app}/Contents/Resources/companion" ]] \
     || die "Mach-O helpers must not be stored in the Resources directory"

--- a/scripts/verify-macos-control-center-dmg.sh
+++ b/scripts/verify-macos-control-center-dmg.sh
@@ -270,7 +270,7 @@ MOUNTED_APP="${MOUNT_DIR}/${APP_NAME}.app"
 
 COMPANION_HELPER="${MOUNTED_APP}/Contents/Helpers/codexbar-display"
 CODEXBAR_HELPER="${MOUNTED_APP}/Contents/Helpers/CodexBarCLI"
-CODEXBAR_VERSION="${MOUNTED_APP}/Contents/Helpers/VERSION"
+CODEXBAR_VERSION="${MOUNTED_APP}/Contents/Resources/CodexBar/VERSION"
 CODEXBAR_LICENSE="${MOUNTED_APP}/Contents/Resources/ThirdPartyNotices/CodexBar-LICENSE.txt"
 for helper in "$COMPANION_HELPER" "$CODEXBAR_HELPER"; do
   [[ -x "$helper" ]] || die "DMG is missing executable helper: ${helper}"

--- a/scripts/verify-macos-control-center-dmg.sh
+++ b/scripts/verify-macos-control-center-dmg.sh
@@ -227,6 +227,9 @@ dry-run: planned distribution verification for ${DMG_PATH}:
   spctl --assess --type open --context context:primary-signature --verbose=4 "${DMG_PATH}"
   hdiutil attach -readonly -nobrowse -noautoopen "${DMG_PATH}"
   codesign --verify --deep --strict --verbose=2 "<mount>/${APP_NAME}.app"
+  lipo "<mount>/${APP_NAME}.app/Contents/Helpers/codexbar-display" -verify_arch arm64 x86_64
+  lipo "<mount>/${APP_NAME}.app/Contents/Helpers/CodexBarCLI" -verify_arch arm64 x86_64
+  verify bundled CodexBarCLI VERSION is 0.37.2 and MIT license is present
   syspolicy_check distribution "<mount>/${APP_NAME}.app" (allow only the exact outer-DMG ticket diagnostic)
   spctl --assess --type execute --verbose=4 "<mount>/${APP_NAME}.app"
 EOF
@@ -235,7 +238,7 @@ fi
 
 [[ "$(uname -s)" == "Darwin" ]] || die "DMG distribution verification requires macOS"
 [[ -f "$DMG_PATH" ]] || die "DMG not found: ${DMG_PATH}"
-for command in codesign hdiutil spctl xcrun; do
+for command in codesign hdiutil lipo spctl xcrun; do
   command -v "$command" >/dev/null 2>&1 || die "${command} is required"
 done
 
@@ -264,6 +267,21 @@ MOUNTED_APP="${MOUNT_DIR}/${APP_NAME}.app"
 [[ -L "${MOUNT_DIR}/Applications" ]] || die "DMG is missing the Applications symlink"
 [[ "$(readlink "${MOUNT_DIR}/Applications")" == "/Applications" ]] \
   || die "DMG Applications symlink does not point to /Applications"
+
+COMPANION_HELPER="${MOUNTED_APP}/Contents/Helpers/codexbar-display"
+CODEXBAR_HELPER="${MOUNTED_APP}/Contents/Helpers/CodexBarCLI"
+CODEXBAR_VERSION="${MOUNTED_APP}/Contents/Helpers/VERSION"
+CODEXBAR_LICENSE="${MOUNTED_APP}/Contents/Resources/ThirdPartyNotices/CodexBar-LICENSE.txt"
+for helper in "$COMPANION_HELPER" "$CODEXBAR_HELPER"; do
+  [[ -x "$helper" ]] || die "DMG is missing executable helper: ${helper}"
+  lipo "$helper" -verify_arch arm64 x86_64 \
+    || die "DMG helper is not universal arm64/x86_64: ${helper}"
+  codesign --verify --strict --verbose=2 "$helper"
+done
+[[ -f "$CODEXBAR_VERSION" ]] || die "DMG is missing bundled CodexBarCLI VERSION"
+[[ "$(tr -d '[:space:]' < "$CODEXBAR_VERSION")" == "0.37.2" ]] \
+  || die "DMG bundled CodexBarCLI VERSION is not 0.37.2"
+[[ -s "$CODEXBAR_LICENSE" ]] || die "DMG is missing CodexBar MIT license notice"
 
 codesign --verify --deep --strict --verbose=2 "$MOUNTED_APP"
 verify_mounted_app_gatekeeper

--- a/third_party/CodexBar-LICENSE.txt
+++ b/third_party/CodexBar-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Peter Steinberger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- bundle pinned universal CodexBarCLI 0.37.2 with verified SHA-256 checksums, signing, version metadata, and MIT notice
- automatically discover and enable every provider that returns usable usage data; no provider selection UI
- expose provider readiness via status, retry, usage errors, diagnostics, Overview, and Setup
- add unit, race, customer-flow, bundle, signing, and release-contract coverage

## Verification
- `go vet ./...`
- `go test ./...`
- `go test -race ./internal/codexbar ./internal/companionapi`
- `npm run lint`
- `npm run build`
- `npm run test:customer-flows`
- `npm run check:customer-ui-copy`
- `npm run check:ui-review`
- `./scripts/test-macos-control-center-app-bundle.sh`
- `./scripts/test-control-center-release-workflow.sh`

## Preview status
The first signed-preview attempt correctly signed both helpers, then exposed an Apple bundle-layout error because `VERSION` was inside code-only `Contents/Helpers`. This PR moves it to `Contents/Resources/CodexBar/VERSION` and pins the corrected signer. Per user instruction, no further preview run or clean-machine test was started.

No merge, tag, release, or hardware write was performed.