### PR TITLE
CODEX: Validate VibeTV pairing before RAW OTA

### DIFF
--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -1330,6 +1330,31 @@ type firmwareDeviceHTTPError struct {
 	Body       string
 }
 
+type redactedFirmwareDeviceTokenError struct {
+	err   error
+	token string
+}
+
+func (e *redactedFirmwareDeviceTokenError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	message := e.err.Error()
+	for _, secret := range []string{e.token, url.QueryEscape(e.token), url.PathEscape(e.token)} {
+		if secret != "" {
+			message = strings.ReplaceAll(message, secret, "[REDACTED]")
+		}
+	}
+	return message
+}
+
+func (e *redactedFirmwareDeviceTokenError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
 func (e *firmwareDeviceHTTPError) Error() string {
 	if e == nil {
 		return ""
@@ -1351,6 +1376,9 @@ func fetchDeviceHelloHTTPWithToken(ctx context.Context, base, token string) (pro
 	}
 	resp, err := releaseHTTPClient.Do(req)
 	if err != nil {
+		if token != "" {
+			err = &redactedFirmwareDeviceTokenError{err: err, token: token}
+		}
 		return protocol.DeviceHello{}, err
 	}
 	defer resp.Body.Close()

--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -567,10 +567,10 @@ func runInstallUpdate(args []string) (retErr error) {
 		HelloVerified:     true,
 	})
 
-	deviceToken, err := ensureFirmwareUpdateDeviceToken(ctx, home, base, false)
+	deviceToken, err := ensureFirmwareUpdateDeviceToken(ctx, home, base, deviceID)
 	if err != nil {
 		return &commandError{
-			Op:   "pair-device",
+			Op:   "device-auth-preflight",
 			Code: errcode.UpgradeFlashFirmware,
 			Err:  err,
 			Hint: "keep VibeTV powered and on the same WiFi, then retry",
@@ -593,39 +593,22 @@ func runInstallUpdate(args []string) (retErr error) {
 		uploadErr,
 	)
 	if uploadErr != nil {
-		if firmwareOTAAuthError(uploadErr) {
-			refreshedToken, pairErr := ensureFirmwareUpdateDeviceToken(ctx, home, base, true)
-			if pairErr == nil {
-				uploadErr = uploadFirmwareOTAFn(ctx, base, imagePath, refreshedToken)
-				uploadErr = recoverInterruptedFirmwareUpload(
-					ctx,
-					base,
-					targetVersion,
-					deviceID,
-					uploadErr,
-				)
-			} else {
-				uploadErr = fmt.Errorf("%w; repair pairing failed: %v", uploadErr, pairErr)
-			}
+		hint := "keep VibeTV powered and on the same WiFi, then retry"
+		if errors.Is(uploadErr, errFirmwareUploadRestartRequired) {
+			hint = "disconnect VibeTV from power for 10 seconds, reconnect it, wait until the picture returns, then retry once"
+			emitFirmwareUpdateEvent(firmwareUpdateEvent{
+				Stage:       "uploading",
+				RetryPolicy: "power_cycle",
+				Firmware:    targetVersion,
+				Target:      base,
+				DeviceID:    deviceID,
+			})
 		}
-		if uploadErr != nil {
-			hint := "keep VibeTV powered and on the same WiFi, then retry"
-			if errors.Is(uploadErr, errFirmwareUploadRestartRequired) {
-				hint = "disconnect VibeTV from power for 10 seconds, reconnect it, wait until the picture returns, then retry once"
-				emitFirmwareUpdateEvent(firmwareUpdateEvent{
-					Stage:       "uploading",
-					RetryPolicy: "power_cycle",
-					Firmware:    targetVersion,
-					Target:      base,
-					DeviceID:    deviceID,
-				})
-			}
-			return &commandError{
-				Op:   "ota-upload",
-				Code: errcode.UpgradeFlashFirmware,
-				Err:  uploadErr,
-				Hint: hint,
-			}
+		return &commandError{
+			Op:   "ota-upload",
+			Code: errcode.UpgradeFlashFirmware,
+			Err:  uploadErr,
+			Hint: hint,
 		}
 	}
 	emitFirmwareUpdateEvent(firmwareUpdateEvent{
@@ -670,7 +653,7 @@ func runInstallUpdate(args []string) (retErr error) {
 	})
 	if verifiedBase != base {
 		base = verifiedBase
-		if _, err := ensureFirmwareUpdateDeviceToken(ctx, home, base, false); err != nil {
+		if _, err := ensureFirmwareUpdateDeviceToken(ctx, home, base, deviceID); err != nil {
 			fmt.Printf("warning: firmware updated, but saving the rediscovered VibeTV address failed: %v\n", err)
 		}
 	}
@@ -678,42 +661,63 @@ func runInstallUpdate(args []string) (retErr error) {
 	return nil
 }
 
-func ensureFirmwareUpdateDeviceToken(ctx context.Context, home, base string, forcePair bool) (string, error) {
+func ensureFirmwareUpdateDeviceToken(ctx context.Context, home, base, expectedDeviceID string) (string, error) {
+	base = strings.TrimSpace(base)
+	expectedDeviceID = strings.TrimSpace(expectedDeviceID)
+	if expectedDeviceID == "" {
+		return "", errors.New("VibeTV /hello response did not include deviceId")
+	}
+
 	cfg, err := runtimeconfig.Load(home)
 	if err != nil {
 		return "", err
 	}
 
-	changed := false
-	if shouldStoreFirmwareUpdateTarget(cfg.DeviceTarget, base) {
-		cfg.DeviceTarget = strings.TrimSpace(base)
-		changed = true
+	token := ""
+	if known, ok := cfg.KnownDevice(expectedDeviceID); ok {
+		token = strings.TrimSpace(known.DeviceToken)
 	}
-
-	token := strings.TrimSpace(cfg.DeviceToken)
-	if token == "" || forcePair {
+	if token == "" {
+		token = strings.TrimSpace(cfg.DeviceToken)
+	}
+	paired := false
+	if token == "" {
 		token, err = pairFirmwareUpdateDevice(ctx, base)
 		if err != nil {
 			return "", err
 		}
-		cfg.DeviceToken = token
-		changed = true
+		paired = true
 	}
 
-	if changed {
-		if err := runtimeconfig.Save(home, cfg); err != nil {
-			return "", err
+	authenticatedHello, err := fetchDeviceHelloHTTPWithToken(ctx, base, token)
+	if err != nil && firmwareOTAAuthError(err) && !paired {
+		token, err = pairFirmwareUpdateDevice(ctx, base)
+		if err != nil {
+			return "", fmt.Errorf("repair VibeTV pairing: %w", err)
 		}
+		authenticatedHello, err = fetchDeviceHelloHTTPWithToken(ctx, base, token)
+	}
+	if err != nil {
+		return "", fmt.Errorf("authenticate VibeTV /hello: %w", err)
+	}
+	actualDeviceID := strings.TrimSpace(authenticatedHello.DeviceID)
+	if !strings.EqualFold(actualDeviceID, expectedDeviceID) {
+		return "", fmt.Errorf(
+			"authenticated VibeTV identity changed before OTA: expected=%q got=%q",
+			expectedDeviceID,
+			actualDeviceID,
+		)
+	}
+
+	cfg.SetActiveDevice(runtimeconfig.KnownDevice{
+		DeviceID:    expectedDeviceID,
+		Target:      base,
+		DeviceToken: token,
+	})
+	if err := runtimeconfig.Save(home, cfg); err != nil {
+		return "", err
 	}
 	return token, nil
-}
-
-func shouldStoreFirmwareUpdateTarget(current, next string) bool {
-	next = strings.TrimSpace(next)
-	if next == "" || strings.TrimSpace(current) == next {
-		return false
-	}
-	return true
 }
 
 func waitForHTTPFirmwareVersionWithDiscovery(ctx context.Context, home, base, version, deviceID string, timeout time.Duration) (string, error) {
@@ -824,9 +828,15 @@ func firmwareOTAAuthError(err error) bool {
 	if err == nil {
 		return false
 	}
+	var httpErr *firmwareDeviceHTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden
+	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "401") ||
+		strings.Contains(msg, "403") ||
 		strings.Contains(msg, "unauthorized") ||
+		strings.Contains(msg, "forbidden") ||
 		strings.Contains(msg, "pairing token required")
 }
 
@@ -1310,11 +1320,35 @@ func normalizeHTTPBaseURL(raw string) (string, error) {
 }
 
 func fetchDeviceHelloHTTP(ctx context.Context, base string) (protocol.DeviceHello, error) {
+	return fetchDeviceHelloHTTPWithToken(ctx, base, "")
+}
+
+type firmwareDeviceHTTPError struct {
+	Operation  string
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e *firmwareDeviceHTTPError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s returned %s body=%q", e.Operation, e.Status, e.Body)
+}
+
+func fetchDeviceHelloHTTPWithToken(ctx context.Context, base, token string) (protocol.DeviceHello, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(base, "/")+"/hello", nil)
 	if err != nil {
 		return protocol.DeviceHello{}, err
 	}
 	req.Header.Set("User-Agent", "codexbar-display-update")
+	if token = strings.TrimSpace(token); token != "" {
+		applyFirmwareUpdateToken(req, token)
+		query := req.URL.Query()
+		query.Set("token", token)
+		req.URL.RawQuery = query.Encode()
+	}
 	resp, err := releaseHTTPClient.Do(req)
 	if err != nil {
 		return protocol.DeviceHello{}, err
@@ -1322,7 +1356,12 @@ func fetchDeviceHelloHTTP(ctx context.Context, base string) (protocol.DeviceHell
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return protocol.DeviceHello{}, fmt.Errorf("GET /hello returned %s body=%q", resp.Status, strings.TrimSpace(string(body)))
+		return protocol.DeviceHello{}, &firmwareDeviceHTTPError{
+			Operation:  "GET /hello",
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       strings.TrimSpace(string(body)),
+		}
 	}
 	var hello protocol.DeviceHello
 	if err := json.NewDecoder(resp.Body).Decode(&hello); err != nil {

--- a/companion/cmd/codexbar-display/release_commands_test.go
+++ b/companion/cmd/codexbar-display/release_commands_test.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1002,6 +1003,37 @@ func TestEnsureFirmwareUpdateDeviceTokenStoresValidatedIdentityTuple(t *testing.
 	known, ok := cfg.KnownDevice("device-new")
 	if !ok || known.Target != server.URL || known.DeviceToken != "pair-token" {
 		t.Fatalf("expected validated known-device tuple, got %+v", cfg.KnownDevices)
+	}
+}
+
+func TestFetchDeviceHelloHTTPWithTokenRedactsTokenFromTransportError(t *testing.T) {
+	previousHTTPClient := releaseHTTPClient
+	t.Cleanup(func() {
+		releaseHTTPClient = previousHTTPClient
+	})
+
+	token := "pair token/with+symbols"
+	transportErr := errors.New("connection refused")
+	releaseHTTPClient = releaseHTTPDoerFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, &url.Error{
+			Op:  "Get",
+			URL: req.URL.String(),
+			Err: transportErr,
+		}
+	})
+
+	_, err := fetchDeviceHelloHTTPWithToken(context.Background(), "http://192.0.2.10", token)
+	if err == nil {
+		t.Fatal("expected authenticated hello transport error")
+	}
+	if strings.Contains(err.Error(), token) || strings.Contains(err.Error(), url.QueryEscape(token)) {
+		t.Fatalf("authenticated hello error leaked pairing token: %v", err)
+	}
+	if !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("expected pairing token placeholder, got: %v", err)
+	}
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("expected original transport error to remain unwrap-compatible, got: %v", err)
 	}
 }
 
@@ -2022,6 +2054,12 @@ func repoRoot(t *testing.T) string {
 
 type fakeReleaseHTTPClient struct {
 	responses map[string]string
+}
+
+type releaseHTTPDoerFunc func(*http.Request) (*http.Response, error)
+
+func (fn releaseHTTPDoerFunc) Do(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }
 
 func (f fakeReleaseHTTPClient) Do(req *http.Request) (*http.Response, error) {

--- a/companion/cmd/codexbar-display/release_commands_test.go
+++ b/companion/cmd/codexbar-display/release_commands_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -9,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -70,6 +72,74 @@ func TestRawFirmwareBodyWriterWaitsForBodyBlockAcks(t *testing.T) {
 	}
 	if ackCalls != 2 {
 		t.Fatalf("expected two body-block acks, got %d", ackCalls)
+	}
+}
+
+func TestUploadFirmwareOTARawEarlyUnauthorizedSocketCloseIsUnsafe(t *testing.T) {
+	previousDial := firmwareRawDialContextFn
+	t.Cleanup(func() {
+		firmwareRawDialContextFn = previousDial
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverDone <- acceptErr
+			return
+		}
+		defer conn.Close()
+		reader := bufio.NewReader(conn)
+		for {
+			line, readErr := reader.ReadString('\n')
+			if readErr != nil {
+				serverDone <- readErr
+				return
+			}
+			if line == "\r\n" {
+				break
+			}
+		}
+		if _, writeErr := io.WriteString(
+			conn,
+			"HTTP/1.1 401 Unauthorized\r\nContent-Length: 22\r\nConnection: close\r\n\r\npairing token required",
+		); writeErr != nil {
+			serverDone <- writeErr
+			return
+		}
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
+			_ = tcpConn.SetLinger(0)
+		}
+		serverDone <- nil
+	}()
+
+	firmwareRawDialContextFn = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		var dialer net.Dialer
+		return dialer.DialContext(ctx, "tcp", listener.Addr().String())
+	}
+	imagePath := filepath.Join(t.TempDir(), "firmware.bin")
+	if err := os.WriteFile(imagePath, bytes.Repeat([]byte{0xa5}, 512*1024), 0o600); err != nil {
+		t.Fatalf("write firmware fixture: %v", err)
+	}
+
+	err = uploadFirmwareOTARaw(context.Background(), "http://127.0.0.1", imagePath, "stale-token")
+	if err == nil {
+		t.Fatal("expected early unauthorized socket close to fail")
+	}
+	if !errors.Is(err, errFirmwareUploadMayHaveWritten) {
+		t.Fatalf("expected unsafe upload classification, got %v", err)
+	}
+	if !firmwareUploadConnectionInterrupted(err) {
+		t.Fatalf("expected interrupted upload classification, got %v", err)
+	}
+	if serverErr := <-serverDone; serverErr != nil {
+		t.Fatalf("early unauthorized server: %v", serverErr)
 	}
 }
 
@@ -574,7 +644,7 @@ func TestRunInstallUpdateDownloadsVerifiesAndUploadsOTA(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/hello":
-			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"` + firmwareVersion + `","features":["theme"],"maxFrameBytes":1024}`))
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-a","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"` + firmwareVersion + `","features":["theme"],"maxFrameBytes":1024}`))
 		case "/manifest.json":
 			_, _ = w.Write([]byte(`{
   "schemaVersion": 1,
@@ -644,7 +714,7 @@ func TestRunInstallUpdateDownloadsVerifiesAndUploadsOTA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load runtime config: %v", err)
 	}
-	if cfg.DeviceTarget != server.URL || cfg.DeviceToken != "pair-token" {
+	if cfg.DeviceTarget != server.URL || cfg.DeviceID != "device-a" || cfg.DeviceToken != "pair-token" {
 		t.Fatalf("expected paired runtime config, got %+v", cfg)
 	}
 	for _, want := range []string{
@@ -779,7 +849,7 @@ func TestRunInstallUpdateRediscoverAfterFirmwareRebootIPChange(t *testing.T) {
 	newServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/hello":
-			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.1","features":["theme"],"maxFrameBytes":1024}`))
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-a","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.1","features":["theme"],"maxFrameBytes":1024}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -793,7 +863,7 @@ func TestRunInstallUpdateRediscoverAfterFirmwareRebootIPChange(t *testing.T) {
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}
-			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.0","features":["theme"],"maxFrameBytes":1024}`))
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-a","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.0","features":["theme"],"maxFrameBytes":1024}`))
 		case "/manifest.json":
 			_, _ = w.Write([]byte(`{
   "schemaVersion": 1,
@@ -817,6 +887,7 @@ func TestRunInstallUpdateRediscoverAfterFirmwareRebootIPChange(t *testing.T) {
 	oldServerURL = oldServer.URL
 	if err := runtimeconfig.Save(home, runtimeconfig.Config{
 		DeviceTarget: oldServer.URL,
+		DeviceID:     "device-a",
 		DeviceToken:  "pair-token",
 	}); err != nil {
 		t.Fatalf("save runtime config: %v", err)
@@ -843,6 +914,7 @@ func TestRunInstallUpdateRediscoverAfterFirmwareRebootIPChange(t *testing.T) {
 			Target: newServer.URL,
 			Hello: protocol.DeviceHello{
 				Kind:            "hello",
+				DeviceID:        "device-a",
 				ProtocolVersion: 2,
 				Board:           "esp8266-smalltv-st7789",
 				Firmware:        "1.0.1",
@@ -876,18 +948,40 @@ func TestRunInstallUpdateRediscoverAfterFirmwareRebootIPChange(t *testing.T) {
 	}
 }
 
-func TestEnsureFirmwareUpdateDeviceTokenStoresNewConcreteTarget(t *testing.T) {
+func TestEnsureFirmwareUpdateDeviceTokenStoresValidatedIdentityTuple(t *testing.T) {
+	previousHTTPClient := releaseHTTPClient
+	t.Cleanup(func() {
+		releaseHTTPClient = previousHTTPClient
+	})
+
 	home := t.TempDir()
 	savedTarget := "http://192.168.178.72"
 	if err := runtimeconfig.Save(home, runtimeconfig.Config{
 		DeviceTarget: savedTarget,
+		DeviceID:     "device-old",
 		DeviceToken:  "pair-token",
 	}); err != nil {
 		t.Fatalf("save runtime config: %v", err)
 	}
 
-	newTarget := "http://192.168.178.99"
-	token, err := ensureFirmwareUpdateDeviceToken(context.Background(), home, newTarget, false)
+	authenticatedHelloCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/hello" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if got := r.Header.Get("X-VibeTV-Token"); got != "pair-token" {
+			t.Errorf("expected authenticated hello token, got %q", got)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		authenticatedHelloCalls++
+		_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-new","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.1"}`))
+	}))
+	defer server.Close()
+	releaseHTTPClient = server.Client()
+
+	token, err := ensureFirmwareUpdateDeviceToken(context.Background(), home, server.URL, "device-new")
 	if err != nil {
 		t.Fatalf("ensure token: %v", err)
 	}
@@ -899,8 +993,53 @@ func TestEnsureFirmwareUpdateDeviceTokenStoresNewConcreteTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load runtime config: %v", err)
 	}
-	if cfg.DeviceTarget != newTarget {
-		t.Fatalf("expected new concrete target %q, got %q", newTarget, cfg.DeviceTarget)
+	if authenticatedHelloCalls != 1 {
+		t.Fatalf("expected one authenticated hello, got %d", authenticatedHelloCalls)
+	}
+	if cfg.DeviceTarget != server.URL || cfg.DeviceID != "device-new" || cfg.DeviceToken != "pair-token" {
+		t.Fatalf("expected validated active identity tuple, got %+v", cfg)
+	}
+	known, ok := cfg.KnownDevice("device-new")
+	if !ok || known.Target != server.URL || known.DeviceToken != "pair-token" {
+		t.Fatalf("expected validated known-device tuple, got %+v", cfg.KnownDevices)
+	}
+}
+
+func TestEnsureFirmwareUpdateDeviceTokenPairsOnlyOnceWhenFreshTokenIsRejected(t *testing.T) {
+	previousHTTPClient := releaseHTTPClient
+	t.Cleanup(func() {
+		releaseHTTPClient = previousHTTPClient
+	})
+
+	home := t.TempDir()
+	pairCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/pair":
+			pairCalls++
+			_, _ = w.Write([]byte(`{"ok":true,"token":"rejected-token"}`))
+		case "/hello":
+			http.Error(w, "pairing token required", http.StatusUnauthorized)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	releaseHTTPClient = server.Client()
+
+	_, err := ensureFirmwareUpdateDeviceToken(context.Background(), home, server.URL, "device-a")
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Fatalf("expected rejected fresh token error, got %v", err)
+	}
+	if pairCalls != 1 {
+		t.Fatalf("expected exactly one pairing attempt, got %d", pairCalls)
+	}
+	cfg, loadErr := runtimeconfig.Load(home)
+	if loadErr != nil {
+		t.Fatalf("load runtime config: %v", loadErr)
+	}
+	if cfg.DeviceTarget != "" || cfg.DeviceID != "" || cfg.DeviceToken != "" {
+		t.Fatalf("rejected fresh token must not persist an identity, got %+v", cfg)
 	}
 }
 
@@ -924,7 +1063,7 @@ func TestRunInstallUpdateUsesStoredDeviceTokenForOTA(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/hello":
-			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"` + firmwareVersion + `","features":["theme"],"maxFrameBytes":1024}`))
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-a","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"` + firmwareVersion + `","features":["theme"],"maxFrameBytes":1024}`))
 		case "/manifest.json":
 			_, _ = w.Write([]byte(`{
   "schemaVersion": 1,
@@ -1128,7 +1267,7 @@ func TestFirmwareUploadConnectionInterruptedRequiresRecoveryForUnsafeErrors(t *t
 	}
 }
 
-func TestRunInstallUpdateRepairsStaleDeviceTokenOnUnauthorizedOTA(t *testing.T) {
+func TestRunInstallUpdateRepairsStaleDeviceTokenBeforeOTA(t *testing.T) {
 	previousHTTPClient := releaseHTTPClient
 	previousUpload := uploadFirmwareOTAFn
 	t.Cleanup(func() {
@@ -1138,7 +1277,11 @@ func TestRunInstallUpdateRepairsStaleDeviceTokenOnUnauthorizedOTA(t *testing.T) 
 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	if err := runtimeconfig.Save(home, runtimeconfig.Config{DeviceToken: "stale-token"}); err != nil {
+	if err := runtimeconfig.Save(home, runtimeconfig.Config{
+		DeviceTarget: "http://192.0.2.50",
+		DeviceID:     "device-old",
+		DeviceToken:  "stale-token",
+	}); err != nil {
 		t.Fatalf("save runtime config: %v", err)
 	}
 
@@ -1151,7 +1294,19 @@ func TestRunInstallUpdateRepairsStaleDeviceTokenOnUnauthorizedOTA(t *testing.T) 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/hello":
-			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"` + firmwareVersion + `","features":["theme"],"maxFrameBytes":1024}`))
+			token := r.Header.Get("X-VibeTV-Token")
+			if token == "" {
+				token = r.URL.Query().Get("token")
+			}
+			if token == "stale-token" {
+				http.Error(w, "pairing token required", http.StatusUnauthorized)
+				return
+			}
+			if token != "" && token != "fresh-token" {
+				http.Error(w, "unexpected token", http.StatusForbidden)
+				return
+			}
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-a","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"` + firmwareVersion + `","features":["theme"],"maxFrameBytes":1024}`))
 		case "/manifest.json":
 			_, _ = w.Write([]byte(`{
   "schemaVersion": 1,
@@ -1181,9 +1336,6 @@ func TestRunInstallUpdateRepairsStaleDeviceTokenOnUnauthorizedOTA(t *testing.T) 
 	var uploadTokens []string
 	uploadFirmwareOTAFn = func(_ context.Context, _ string, _ string, token string) error {
 		uploadTokens = append(uploadTokens, token)
-		if token == "stale-token" {
-			return errors.New(`POST /update/firmware.raw returned 401 Unauthorized body="pairing token required"`)
-		}
 		if token != "fresh-token" {
 			t.Fatalf("unexpected upload token %q", token)
 		}
@@ -1197,15 +1349,104 @@ func TestRunInstallUpdateRepairsStaleDeviceTokenOnUnauthorizedOTA(t *testing.T) 
 	if pairCalls != 1 {
 		t.Fatalf("expected one repair pairing call, got %d", pairCalls)
 	}
-	if strings.Join(uploadTokens, ",") != "stale-token,fresh-token" {
+	if strings.Join(uploadTokens, ",") != "fresh-token" {
 		t.Fatalf("unexpected upload token sequence %v", uploadTokens)
 	}
 	cfg, err := runtimeconfig.Load(home)
 	if err != nil {
 		t.Fatalf("load runtime config: %v", err)
 	}
-	if cfg.DeviceToken != "fresh-token" || cfg.DeviceTarget != server.URL {
+	if cfg.DeviceToken != "fresh-token" || cfg.DeviceTarget != server.URL || cfg.DeviceID != "device-a" {
 		t.Fatalf("expected repaired runtime config, got %+v", cfg)
+	}
+	known, ok := cfg.KnownDevice("device-a")
+	if !ok || known.Target != server.URL || known.DeviceToken != "fresh-token" {
+		t.Fatalf("expected repaired identity tuple in known devices, got %+v", cfg.KnownDevices)
+	}
+}
+
+func TestRunInstallUpdateStopsBeforeOTAOnNonAuthPreflightError(t *testing.T) {
+	previousHTTPClient := releaseHTTPClient
+	previousUpload := uploadFirmwareOTAFn
+	t.Cleanup(func() {
+		releaseHTTPClient = previousHTTPClient
+		uploadFirmwareOTAFn = previousUpload
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	initial := runtimeconfig.Config{
+		DeviceTarget: "http://192.0.2.60",
+		DeviceID:     "device-old",
+		DeviceToken:  "saved-token",
+	}
+	if err := runtimeconfig.Save(home, initial); err != nil {
+		t.Fatalf("save runtime config: %v", err)
+	}
+
+	imageBody := "firmware image"
+	imageSHA := sha256String(imageBody)
+	serverURL := ""
+	pairCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			if r.Header.Get("X-VibeTV-Token") != "" || r.URL.Query().Get("token") != "" {
+				http.Error(w, "temporary hello failure", http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-a","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.0"}`))
+		case "/manifest.json":
+			_, _ = w.Write([]byte(`{
+  "schemaVersion": 1,
+  "release": "v1.0.1",
+  "artifacts": [{
+    "firmwareEnv": "esp8266_smalltv_st7789",
+    "board": "esp8266-smalltv-st7789",
+    "firmwareVersion": "1.0.1",
+    "asset": "firmware.bin",
+    "firmwareUrl": "` + serverURL + `/firmware.bin",
+    "sha256": "` + imageSHA + `"
+  }]
+}`))
+		case "/firmware.bin":
+			_, _ = w.Write([]byte(imageBody))
+		case "/api/pair":
+			pairCalls++
+			_, _ = w.Write([]byte(`{"ok":true,"token":"fresh-token"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+	releaseHTTPClient = server.Client()
+
+	uploadCalls := 0
+	uploadFirmwareOTAFn = func(context.Context, string, string, string) error {
+		uploadCalls++
+		return nil
+	}
+	err := runInstallUpdate([]string{
+		"--target", server.URL,
+		"--manifest-url", server.URL + "/manifest.json",
+		"--skip-launchagent-pause",
+	})
+	if err == nil || !strings.Contains(err.Error(), "GET /hello returned 500") {
+		t.Fatalf("expected non-authenticated preflight failure, got %v", err)
+	}
+	if pairCalls != 0 {
+		t.Fatalf("non-auth preflight error must not repair pairing, got %d calls", pairCalls)
+	}
+	if uploadCalls != 0 {
+		t.Fatalf("non-auth preflight error must not open OTA, got %d uploads", uploadCalls)
+	}
+	cfg, loadErr := runtimeconfig.Load(home)
+	if loadErr != nil {
+		t.Fatalf("load runtime config: %v", loadErr)
+	}
+	if cfg.DeviceTarget != initial.DeviceTarget || cfg.DeviceID != initial.DeviceID || cfg.DeviceToken != initial.DeviceToken {
+		t.Fatalf("failed preflight must not replace saved identity, got %+v", cfg)
 	}
 }
 
@@ -1235,7 +1476,7 @@ func TestRunInstallUpdatePausesLaunchAgentDuringOTAAndRestarts(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/hello":
-			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"` + firmwareVersion + `","features":["theme"],"maxFrameBytes":1024}`))
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-a","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"` + firmwareVersion + `","features":["theme"],"maxFrameBytes":1024}`))
 		case "/manifest.json":
 			_, _ = w.Write([]byte(`{
   "schemaVersion": 1,
@@ -1319,7 +1560,7 @@ func TestRunInstallUpdateCanSkipLaunchAgentPauseForLocalAPI(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/hello":
-			_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"` + firmwareVersion + `","features":["theme"],"maxFrameBytes":1024}`))
+			_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-a","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"` + firmwareVersion + `","features":["theme"],"maxFrameBytes":1024}`))
 		case "/manifest.json":
 			_, _ = w.Write([]byte(`{
   "schemaVersion": 1,
@@ -1396,7 +1637,7 @@ func TestRunInstallUpdateRequiresLiveManifestConfirmation(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.0","features":["theme"],"maxFrameBytes":1024}`))
+		_, _ = w.Write([]byte(`{"kind":"hello","deviceId":"device-a","protocolVersion":2,"supportedProtocolVersions":[2,1],"preferredProtocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.0","features":["theme"],"maxFrameBytes":1024}`))
 	}))
 	defer server.Close()
 	releaseHTTPClient = server.Client()

--- a/docs/firmware-ota-contract.md
+++ b/docs/firmware-ota-contract.md
@@ -7,6 +7,12 @@ handlers.
 ## Safety invariants
 
 - Pin the device URL and `deviceId` before downloading or uploading firmware.
+- Treat device URL, `deviceId`, and pairing token as one identity tuple. When a
+  target changes, update all three together; never reuse an unverified token
+  from the previous target.
+- Validate the selected token with an authenticated `GET /hello` against the
+  pinned device before opening the RAW OTA connection. A `401`/`403` must repair
+  pairing and repeat identity validation before any firmware body is sent.
 - Validate the selected manifest artifact and SHA-256 before opening the OTA
   connection.
 - Pause the display stream for the complete upload. The Control Center uses its
@@ -45,8 +51,8 @@ HTTP `404`. A timeout is not proof that no firmware bytes reached the device.
 ## Failure and retry state machine
 
 1. A connection refusal before RAW is available may fall back to multipart.
-2. An authentication rejection may repair pairing because the firmware handler
-   rejects it before `Update.begin()`.
+2. An authentication rejection during the mandatory preflight repairs pairing
+   and repeats authenticated identity validation before opening RAW OTA.
 3. A broken pipe, reset, EOF, or other interrupted RAW upload first waits for
    the target version to return. This covers a successful flash whose response
    was lost.
@@ -54,6 +60,13 @@ HTTP `404`. A timeout is not proof that no firmware bytes reached the device.
    disconnect power for 10 seconds and retry only after the picture returns.
 5. Never switch to multipart or automatically resend in the same boot after an
    interrupted RAW upload.
+
+The firmware validates OTA authentication immediately after reading the request
+headers and closes the connection before `Update.begin()` when the token is
+wrong. A sender that reads the HTTP response only after writing the complete
+body can therefore surface the early `401` merely as `EPIPE`/`broken pipe`.
+This is why authenticated `/hello` is a required preflight rather than an
+upload-error recovery optimization.
 
 ## Firmware receiver requirements from 1.0.37 onward
 

--- a/docs/firmware-provisioning.md
+++ b/docs/firmware-provisioning.md
@@ -2,6 +2,11 @@
 
 This runbook describes the repeatable OTA provisioning flow for Vibe TV devices with the GeekMagic factory firmware already installed.
 
+> **Stop if `GET /hello` succeeds.** A device that returns VibeTV JSON from
+> `http://<ip>/hello` is no longer a GeekMagic factory device. Do not send that
+> device to this runbook's `/update` endpoint. Use `codexbar-display
+> install-update` as documented in `docs/operator-runbook.md` instead.
+
 The first OTA pass uses the GeekMagic updater at `http://<ip>/update` with multipart field `firmware`. After that, CodexBar Display firmware is expected to expose:
 
 - `GET /health`
@@ -13,6 +18,24 @@ The first OTA pass uses the GeekMagic updater at `http://<ip>/update` with multi
 - `POST /frame` for smoke frames
 
 The tooling does not store WiFi passwords or other secrets.
+
+## Choose the updater before writing
+
+Run these read-only probes before selecting a flash command:
+
+```bash
+curl -sS -o /tmp/vibetv-hello.json -w 'hello=%{http_code}\n' \
+  http://<device-ip>/hello
+curl -sS -o /dev/null -w 'factory-update=%{http_code}\n' \
+  http://<device-ip>/update
+```
+
+- `GET /hello -> 200` with VibeTV JSON: use `codexbar-display install-update`.
+  Never use the GeekMagic `/update` path for this device.
+- `GET /hello -> 404` and `GET /update -> 200`: the GeekMagic factory
+  provisioning flow in this document is the correct path.
+- Any other combination: stop and identify the running firmware before sending
+  an upload. Do not try update endpoints until one works.
 
 ## Build an OTA Package
 

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -72,6 +72,50 @@ codexbar-display install-update \
   --confirm-live-update
 ```
 
+Before an operator-triggered OTA, prove that the target, stored `deviceId`, and
+pairing token all describe the same VibeTV. This is especially important after
+changing `--target`, moving between test devices, or running a development
+Companion:
+
+1. Keep only the normal Companion on `127.0.0.1:47832`; stop any development
+   Companion on `127.0.0.1:47833`.
+2. Read `GET http://<device-ip>/hello` and compare its `deviceId` with
+   `deviceId` in
+   `~/Library/Application Support/codexbar-display/config.json`.
+3. Validate the stored token without printing it:
+
+```bash
+VIBETV_CONFIG="$HOME/Library/Application Support/codexbar-display/config.json"
+VIBETV_TOKEN="$(jq -r '.deviceToken // empty' "$VIBETV_CONFIG")"
+curl -fsS -o /dev/null \
+  -H "X-VibeTV-Token: ${VIBETV_TOKEN}" \
+  http://<device-ip>/hello
+unset VIBETV_TOKEN
+```
+
+An HTTP `401`/`403`, an empty token, or a different `deviceId` means the stored
+pairing belongs to another device. With explicit approval for this device,
+repair it before OTA:
+
+```bash
+curl -fsS --max-time 90 \
+  -X POST http://127.0.0.1:47832/v1/device/repair \
+  -H 'Content-Type: application/json' \
+  --data '{"target":"http://<device-ip>","forcePair":true}'
+```
+
+Repeat the authenticated `/hello` check and start `install-update` only after it
+returns `200` with the expected `deviceId`.
+
+The RAW updater can report only `broken pipe` when firmware rejects a stale
+token immediately after the request headers. That message does not prove that
+firmware bytes were accepted. Still treat it as a potentially interrupted OTA:
+do not retry in the same boot, disconnect power for 10 seconds, repair pairing,
+validate authenticated `/hello`, and then retry once.
+
+Do not use `scripts/vibetv-provision.sh` or `POST /update` when `/hello` already
+identifies a VibeTV runtime. Those are GeekMagic factory-provisioning paths.
+
 ### USB recovery flash path
 
 Use only when a device is physically attached with a working data-capable USB serial connection and WiFi OTA is not available. This path flashes release firmware, not a local source build:

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -72,10 +72,15 @@ codexbar-display install-update \
   --confirm-live-update
 ```
 
-Before an operator-triggered OTA, prove that the target, stored `deviceId`, and
-pairing token all describe the same VibeTV. This is especially important after
-changing `--target`, moving between test devices, or running a development
-Companion:
+`install-update` automatically proves that the target, `deviceId`, and pairing
+token all describe the same VibeTV before it opens an OTA connection. It first
+pins tokenless `/hello`, validates the stored token with authenticated `/hello`,
+repairs a `401`/`403` once, repeats identity validation, and only then persists
+the complete identity tuple and starts the upload.
+
+The following read-only checks are useful when diagnosing an older build or a
+preflight failure, especially after changing `--target`, moving between test
+devices, or running a development Companion:
 
 1. Keep only the normal Companion on `127.0.0.1:47832`; stop any development
    Companion on `127.0.0.1:47833`.
@@ -94,8 +99,9 @@ unset VIBETV_TOKEN
 ```
 
 An HTTP `401`/`403`, an empty token, or a different `deviceId` means the stored
-pairing belongs to another device. With explicit approval for this device,
-repair it before OTA:
+pairing cannot be trusted for that target. The current `install-update` command
+repairs an authentication rejection before OTA. For manual recovery, with
+explicit approval for this device, use:
 
 ```bash
 curl -fsS --max-time 90 \
@@ -104,14 +110,15 @@ curl -fsS --max-time 90 \
   --data '{"target":"http://<device-ip>","forcePair":true}'
 ```
 
-Repeat the authenticated `/hello` check and start `install-update` only after it
-returns `200` with the expected `deviceId`.
+Repeat the authenticated `/hello` check after manual recovery. Do not bypass an
+`install-update` preflight failure.
 
-The RAW updater can report only `broken pipe` when firmware rejects a stale
-token immediately after the request headers. That message does not prove that
-firmware bytes were accepted. Still treat it as a potentially interrupted OTA:
-do not retry in the same boot, disconnect power for 10 seconds, repair pairing,
-validate authenticated `/hello`, and then retry once.
+Older updaters can report only `broken pipe` when firmware rejects a stale token
+immediately after the request headers. The current preflight prevents that stale
+token from reaching RAW OTA. Any `broken pipe` after RAW has opened must still
+be treated as a potentially interrupted OTA: do not retry in the same boot,
+disconnect power for 10 seconds, and then let `install-update` repeat the full
+preflight before retrying once.
 
 Do not use `scripts/vibetv-provision.sh` or `POST /update` when `/hello` already
 identifies a VibeTV runtime. Those are GeekMagic factory-provisioning paths.


### PR DESCRIPTION
## Summary

- validate the selected VibeTV pairing token with authenticated GET /hello before RAW OTA
- repair 401/403 pairing once, revalidate the pinned deviceId, and save target/deviceId/token as one identity tuple
- preserve the no-retry rule after firmware bytes may have been sent
- document updater selection and safe OTA preflight

## Root cause

install-update trusted any non-empty stored token after a target change. The selected VibeTV could reject RAW OTA immediately after the headers, while the sender surfaced only broken pipe after beginning the body write.

## User impact

Switching between VibeTV devices now repairs stale pairing before firmware bytes are sent. Non-authentication preflight failures stop without opening OTA.

## Validation

- go test -count=1 -p 1 ./...
- go test ./cmd/codexbar-display
- new early-401 real socket regression repeated 20 times
- no hardware writes performed

Closes #195