### PR TITLE
CODEX: Use SemVer prerelease precedence in all update checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,3 +409,17 @@ jobs:
             dist/macos/*.dmg
             dist/macos/appcast.xml
             dist/checksums-*.txt
+
+  verify-release-canary:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build-and-release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify prerelease installs are offered the final release
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: ./scripts/verify-release-canary.sh --version "${VERSION#v}"

--- a/apps/control-center/src/app/api/companion/latest/route.test.ts
+++ b/apps/control-center/src/app/api/companion/latest/route.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+
+let releaseUrlCounter = 0;
+
+function stubRelease(tagName: string) {
+  // A unique release URL per test bypasses the module-level release cache.
+  releaseUrlCounter += 1;
+  vi.stubEnv(
+    "CONTROL_CENTER_COMPANION_RELEASE_API_URL",
+    `http://localhost/release-${releaseUrlCounter}`,
+  );
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      new Response(JSON.stringify({ tag_name: tagName }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
+}
+
+function companionRequest(version: string): Request {
+  const url = new URL("http://localhost/api/companion/latest");
+  url.searchParams.set("version", version);
+  return new Request(url);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("GET /api/companion/latest", () => {
+  it("offers the final release to an installed RC", async () => {
+    stubRelease("v1.0.44");
+
+    const response = await GET(companionRequest("1.0.44-rc.16"));
+    const body = await response.json();
+    expect(body.updateAvailable).toBe(true);
+    expect(body.latestVersion).toBe("1.0.44");
+    expect(body.message).toBe("Mac App update is available.");
+  });
+
+  it("keeps the exact final release current", async () => {
+    stubRelease("v1.0.44");
+
+    const response = await GET(companionRequest("1.0.44"));
+    const body = await response.json();
+    expect(body.updateAvailable).toBe(false);
+    expect(body.message).toBe("Mac App is up to date.");
+  });
+
+  it("orders prerelease identifiers numerically", async () => {
+    stubRelease("v1.0.44-rc.16");
+
+    const response = await GET(companionRequest("1.0.44-rc.2"));
+    const body = await response.json();
+    expect(body.updateAvailable).toBe(true);
+  });
+
+  it("fails visibly for a malformed installed version", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await GET(companionRequest("banana"));
+    const body = await response.json();
+    expect(body.status).toBe("check_failed");
+    expect(body.updateAvailable).toBe(false);
+    expect(body.message).toContain("banana");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fails the check when the release tag is not a valid version", async () => {
+    stubRelease("nightly-build");
+
+    const response = await GET(companionRequest("1.0.44"));
+    const body = await response.json();
+    expect(body.status).toBe("check_failed");
+    expect(body.updateAvailable).toBe(false);
+  });
+});

--- a/apps/control-center/src/app/api/companion/latest/route.test.ts
+++ b/apps/control-center/src/app/api/companion/latest/route.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-describe("GET /api/companion/latest", () => {
+describe("Mac App update check route", () => {
   it("offers the final release to an installed RC", async () => {
     stubRelease("v1.0.44");
 

--- a/apps/control-center/src/app/api/companion/latest/route.ts
+++ b/apps/control-center/src/app/api/companion/latest/route.ts
@@ -1,4 +1,9 @@
 import type { CompanionReleaseInfo } from "@/lib/companion-release";
+import {
+  compareSemVer,
+  parseSemVer,
+  type ParsedSemVer,
+} from "@/lib/semver";
 
 export const dynamic = "force-dynamic";
 
@@ -43,7 +48,21 @@ export async function GET(request: Request) {
     url.searchParams.get("version")?.trim() || "",
   );
   const checkedAt = new Date().toISOString();
+  const installedParsed = installedVersion
+    ? parseSemVer(installedVersion)
+    : null;
+  if (installedVersion && !installedParsed) {
+    return publicJson({
+      checkedAt,
+      status: "check_failed",
+      installedVersion,
+      updateAvailable: false,
+      message: `Installed Mac App version "${installedVersion}" is not a valid version.`,
+      dmgDownloadStatus: "check_failed",
+    } satisfies CompanionReleaseInfo);
+  }
   const previewRelease = previewMacAppRelease(
+    installedParsed,
     installedVersion,
     checkedAt,
   );
@@ -55,11 +74,12 @@ export async function GET(request: Request) {
     const release = await fetchLatestRelease();
     const releaseTag = release.tag_name?.trim() || "";
     const latestVersion = normalizeVersion(releaseTag);
+    const latestParsed = latestVersion ? parseSemVer(latestVersion) : null;
     const dmgDownloadEnabled = macAppDmgDownloadEnabled();
     const dmgAsset = dmgDownloadEnabled
       ? verifiedDmgAsset(release, releaseTag)
       : null;
-    if (!latestVersion) {
+    if (!latestVersion || !latestParsed) {
       return publicJson({
         checkedAt,
         status: "check_failed",
@@ -72,7 +92,7 @@ export async function GET(request: Request) {
     }
 
     const updateAvailable = Boolean(
-      installedVersion && compareSemver(latestVersion, installedVersion) > 0,
+      installedParsed && compareSemVer(latestParsed, installedParsed) > 0,
     );
 
     return publicJson({
@@ -105,6 +125,7 @@ export async function GET(request: Request) {
 }
 
 function previewMacAppRelease(
+  installedParsed: ParsedSemVer | null,
   installedVersion: string,
   checkedAt: string,
 ): CompanionReleaseInfo | null {
@@ -114,15 +135,16 @@ function previewMacAppRelease(
   const latestVersion = exactSemver(
     process.env[PREVIEW_MAC_APP_VERSION] || "",
   );
+  const latestParsed = latestVersion ? parseSemVer(latestVersion) : null;
   const dmgDownloadUrl = verifiedPreviewDmgUrl(
     process.env[PREVIEW_MAC_APP_DMG_URL] || "",
   );
-  if (!latestVersion || !dmgDownloadUrl) {
+  if (!latestVersion || !latestParsed || !dmgDownloadUrl) {
     return null;
   }
 
   const updateAvailable = Boolean(
-    installedVersion && compareSemver(latestVersion, installedVersion) > 0,
+    installedParsed && compareSemVer(latestParsed, installedParsed) > 0,
   );
   return {
     checkedAt,
@@ -305,26 +327,6 @@ function tokenFingerprint(token: string): string {
     hash = Math.imul(hash, 0x01000193);
   }
   return `auth-${(hash >>> 0).toString(16)}`;
-}
-
-function compareSemver(left: string, right: string): number {
-  const leftParts = parseSemver(left);
-  const rightParts = parseSemver(right);
-  for (let index = 0; index < 3; index += 1) {
-    const diff = leftParts[index] - rightParts[index];
-    if (diff !== 0) {
-      return diff;
-    }
-  }
-  return 0;
-}
-
-function parseSemver(version: string): [number, number, number] {
-  const match = version.trim().replace(/^v/i, "").match(/^(\d+)\.(\d+)\.(\d+)/);
-  if (!match) {
-    return [0, 0, 0];
-  }
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
 function normalizeVersion(version: string): string {

--- a/apps/control-center/src/app/api/firmware/latest/route.test.ts
+++ b/apps/control-center/src/app/api/firmware/latest/route.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("GET /api/firmware/latest", () => {
+describe("firmware update check route", () => {
   it("offers the final release to an installed RC", async () => {
     stubManifest({
       release: "v1.0.36",

--- a/apps/control-center/src/app/api/firmware/latest/route.test.ts
+++ b/apps/control-center/src/app/api/firmware/latest/route.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+
+function stubManifest(manifest: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      new Response(JSON.stringify(manifest), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
+}
+
+function firmwareRequest(board: string, firmware: string): Request {
+  const url = new URL("http://localhost/api/firmware/latest");
+  url.searchParams.set("board", board);
+  url.searchParams.set("firmware", firmware);
+  return new Request(url);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("GET /api/firmware/latest", () => {
+  it("offers the final release to an installed RC", async () => {
+    stubManifest({
+      release: "v1.0.36",
+      artifacts: [
+        { board: "esp8266_smalltv_st7789", firmwareVersion: "1.0.36" },
+      ],
+    });
+
+    const response = await GET(
+      firmwareRequest("esp8266_smalltv_st7789", "1.0.36-rc.2"),
+    );
+    const body = await response.json();
+    expect(body.updateAvailable).toBe(true);
+    expect(body.status).toBe("update_available");
+    expect(body.latestFirmware).toBe("1.0.36");
+  });
+
+  it("keeps the exact final release current", async () => {
+    stubManifest({
+      release: "v1.0.36",
+      artifacts: [
+        { board: "esp8266_smalltv_st7789", firmwareVersion: "1.0.36" },
+      ],
+    });
+
+    const response = await GET(
+      firmwareRequest("esp8266_smalltv_st7789", "1.0.36"),
+    );
+    const body = await response.json();
+    expect(body.updateAvailable).toBe(false);
+    expect(body.status).toBe("current");
+  });
+
+  it("fails visibly for a malformed installed version", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await GET(
+      firmwareRequest("esp8266_smalltv_st7789", "banana"),
+    );
+    const body = await response.json();
+    expect(body.updateAvailable).toBe(false);
+    expect(body.status).toBe("check_failed");
+    expect(body.message).toContain("banana");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips malformed manifest versions and sorts by SemVer precedence", async () => {
+    stubManifest({
+      release: "v1.0.37",
+      artifacts: [
+        { board: "esp8266_smalltv_st7789", firmwareVersion: "broken" },
+        { board: "esp8266_smalltv_st7789", firmwareVersion: "1.0.37-rc.1" },
+        { board: "esp8266_smalltv_st7789", firmwareVersion: "1.0.37" },
+        { board: "other_board", firmwareVersion: "9.9.9" },
+      ],
+    });
+
+    const response = await GET(
+      firmwareRequest("esp8266_smalltv_st7789", "1.0.36"),
+    );
+    const body = await response.json();
+    expect(body.latestFirmware).toBe("1.0.37");
+    expect(body.updateAvailable).toBe(true);
+  });
+});

--- a/apps/control-center/src/app/api/firmware/latest/route.ts
+++ b/apps/control-center/src/app/api/firmware/latest/route.ts
@@ -1,4 +1,5 @@
 import type { FirmwareUpdateInfo } from "@/lib/firmware";
+import { compareSemVer, parseSemVer, type ParsedSemVer } from "@/lib/semver";
 
 export const dynamic = "force-dynamic";
 
@@ -33,6 +34,17 @@ export async function GET(request: Request) {
     } satisfies FirmwareUpdateInfo);
   }
 
+  const installedParsed = parseSemVer(installedFirmware);
+  if (!installedParsed) {
+    return Response.json({
+      checkedAt,
+      installedFirmware,
+      updateAvailable: false,
+      status: "check_failed",
+      message: `Installed firmware version "${installedFirmware}" is not a valid version.`,
+    } satisfies FirmwareUpdateInfo);
+  }
+
   try {
     const manifest = await fetchFirmwareManifest();
     const artifact = selectLatestArtifactForBoard(manifest, board);
@@ -48,8 +60,19 @@ export async function GET(request: Request) {
       } satisfies FirmwareUpdateInfo);
     }
 
-    const comparison = compareSemver(artifact.firmwareVersion, installedFirmware);
-    const updateAvailable = comparison > 0;
+    const latestParsed = parseSemVer(artifact.firmwareVersion);
+    if (!latestParsed) {
+      return Response.json({
+        checkedAt,
+        installedFirmware,
+        release: manifest.release,
+        updateAvailable: false,
+        status: "check_failed",
+        message: `Published firmware version "${artifact.firmwareVersion}" is not a valid version.`,
+      } satisfies FirmwareUpdateInfo);
+    }
+
+    const updateAvailable = compareSemVer(latestParsed, installedParsed) > 0;
 
     return Response.json({
       checkedAt,
@@ -94,31 +117,22 @@ function selectLatestArtifactForBoard(
   board: string,
 ): FirmwareArtifact | undefined {
   const normalizedBoard = normalize(board);
-  return (manifest.artifacts || [])
-    .filter((artifact) => normalize(artifact.board) === normalizedBoard)
-    .sort((a, b) =>
-      compareSemver(b.firmwareVersion || "0.0.0", a.firmwareVersion || "0.0.0"),
-    )[0];
-}
-
-function compareSemver(left: string, right: string): number {
-  const leftParts = parseSemver(left);
-  const rightParts = parseSemver(right);
-  for (let index = 0; index < 3; index += 1) {
-    const diff = leftParts[index] - rightParts[index];
-    if (diff !== 0) {
-      return diff;
+  let latestArtifact: FirmwareArtifact | undefined;
+  let latestParsed: ParsedSemVer | undefined;
+  for (const artifact of manifest.artifacts || []) {
+    if (normalize(artifact.board) !== normalizedBoard) {
+      continue;
+    }
+    const parsed = parseSemVer(artifact.firmwareVersion || "");
+    if (!parsed) {
+      continue;
+    }
+    if (!latestParsed || compareSemVer(parsed, latestParsed) > 0) {
+      latestParsed = parsed;
+      latestArtifact = artifact;
     }
   }
-  return 0;
-}
-
-function parseSemver(version: string): [number, number, number] {
-  const match = version.trim().replace(/^v/i, "").match(/^(\d+)\.(\d+)\.(\d+)/);
-  if (!match) {
-    return [0, 0, 0];
-  }
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
+  return latestArtifact;
 }
 
 function normalize(value?: string): string {

--- a/apps/control-center/src/components/theme-library-screen.tsx
+++ b/apps/control-center/src/components/theme-library-screen.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
+import { compareSemVer, parseSemVer } from "@/lib/semver";
 import { isRemoteThemePackUrl } from "@/lib/theme-pack-url";
 import {
   createBlankThemeSpec,
@@ -1330,7 +1331,12 @@ function themeFirmwareBlocker(
   if (!required) {
     return null;
   }
-  if (!device.firmware) {
+  const requiredParsed = parseSemVer(required);
+  if (!requiredParsed) {
+    return null;
+  }
+  const deviceParsed = device.firmware ? parseSemVer(device.firmware) : null;
+  if (!deviceParsed) {
     return {
       reason: "Check VibeTV first.",
       readinessTitle: "Check VibeTV first",
@@ -1338,7 +1344,7 @@ function themeFirmwareBlocker(
       readinessIcon: <RefreshCw size={22} aria-hidden />,
     };
   }
-  if (compareVersions(device.firmware, required) >= 0) {
+  if (compareSemVer(deviceParsed, requiredParsed) >= 0) {
     return null;
   }
   return {
@@ -1354,27 +1360,6 @@ function normalizeBoard(value: string): string {
     .trim()
     .toLowerCase()
     .replace(/[_\s]+/g, "-");
-}
-
-function compareVersions(left: string, right: string): number {
-  const leftParts = parseVersion(left);
-  const rightParts = parseVersion(right);
-  const maxLength = Math.max(leftParts.length, rightParts.length, 3);
-  for (let index = 0; index < maxLength; index += 1) {
-    const diff = (leftParts[index] || 0) - (rightParts[index] || 0);
-    if (diff !== 0) {
-      return diff;
-    }
-  }
-  return 0;
-}
-
-function parseVersion(value: string): number[] {
-  const matches = value.match(/\d+/g);
-  if (!matches?.length) {
-    return [0, 0, 0];
-  }
-  return matches.map((part) => Number(part));
 }
 
 function ThemePreview({

--- a/apps/control-center/src/lib/semver.test.ts
+++ b/apps/control-center/src/lib/semver.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareSemVer,
+  compareSemVerStrings,
+  parseSemVer,
+} from "./semver";
+
+describe("parseSemVer", () => {
+  it("parses a plain release version", () => {
+    expect(parseSemVer("1.0.44")).toEqual({
+      major: 1,
+      minor: 0,
+      patch: 44,
+      prerelease: [],
+    });
+  });
+
+  it("parses a leading v and prerelease identifiers", () => {
+    expect(parseSemVer("v1.0.44-rc.16")).toEqual({
+      major: 1,
+      minor: 0,
+      patch: 44,
+      prerelease: ["rc", "16"],
+    });
+  });
+
+  it("ignores build metadata", () => {
+    expect(parseSemVer("1.0.44+build.7")).toEqual({
+      major: 1,
+      minor: 0,
+      patch: 44,
+      prerelease: [],
+    });
+    expect(parseSemVer("1.0.44-rc.1+build.7")?.prerelease).toEqual([
+      "rc",
+      "1",
+    ]);
+  });
+
+  it("rejects malformed versions instead of degrading to 0.0.0", () => {
+    for (const raw of [
+      "",
+      "  ",
+      "1.0",
+      "1.0.44.5",
+      "banana",
+      "1.0.44-",
+      "1.0.44-rc..1",
+      "1.0.44-rc.1!",
+    ]) {
+      expect(parseSemVer(raw)).toBeNull();
+    }
+  });
+});
+
+describe("compareSemVer precedence", () => {
+  const cases: Array<[string, string, number]> = [
+    ["1.0.44-rc.16", "1.0.44", -1],
+    ["1.0.36-rc.2", "1.0.36", -1],
+    ["1.0.44-beta.3", "1.0.44-rc.1", -1],
+    ["1.0.44-rc.2", "1.0.44-rc.10", -1],
+    ["1.0.44-alpha", "1.0.44-alpha.1", -1],
+    ["1.0.44-1", "1.0.44-alpha", -1],
+    ["1.0.44", "1.0.44", 0],
+    ["1.0.44+build7", "1.0.44", 0],
+    ["v1.0.44", "1.0.44", 0],
+    ["1.0.44", "1.0.44-rc.16", 1],
+    ["1.0.45-rc.1", "1.0.44", 1],
+    ["1.1.0", "1.0.99", 1],
+  ];
+
+  it.each(cases)("compare(%s, %s) = %d", (left, right, want) => {
+    const leftParsed = parseSemVer(left);
+    const rightParsed = parseSemVer(right);
+    expect(leftParsed).not.toBeNull();
+    expect(rightParsed).not.toBeNull();
+    expect(compareSemVer(leftParsed!, rightParsed!)).toBe(want);
+  });
+});
+
+describe("compareSemVerStrings", () => {
+  it("returns null when either side is malformed", () => {
+    expect(compareSemVerStrings("banana", "1.0.44")).toBeNull();
+    expect(compareSemVerStrings("1.0.44", "")).toBeNull();
+  });
+
+  it("offers the final release to an installed RC", () => {
+    expect(compareSemVerStrings("1.0.44", "1.0.44-rc.16")).toBe(1);
+  });
+});

--- a/apps/control-center/src/lib/semver.ts
+++ b/apps/control-center/src/lib/semver.ts
@@ -1,0 +1,118 @@
+export type ParsedSemVer = {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+};
+
+const IDENTIFIER_PATTERN = /^[0-9A-Za-z-]+$/;
+const CORE_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/;
+const NUMERIC_PATTERN = /^\d+$/;
+
+export function parseSemVer(raw: string): ParsedSemVer | null {
+  let version = raw.trim().replace(/^v/i, "");
+  if (!version) {
+    return null;
+  }
+
+  const plusIndex = version.indexOf("+");
+  if (plusIndex >= 0) {
+    version = version.slice(0, plusIndex);
+  }
+
+  let core = version;
+  let prerelease: string[] = [];
+  const dashIndex = version.indexOf("-");
+  if (dashIndex >= 0) {
+    core = version.slice(0, dashIndex);
+    const pre = version.slice(dashIndex + 1);
+    if (!pre) {
+      return null;
+    }
+    prerelease = pre.split(".");
+    if (prerelease.some((identifier) => !IDENTIFIER_PATTERN.test(identifier))) {
+      return null;
+    }
+  }
+
+  const match = core.match(CORE_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease,
+  };
+}
+
+export function compareSemVer(left: ParsedSemVer, right: ParsedSemVer): number {
+  if (left.major !== right.major) {
+    return left.major < right.major ? -1 : 1;
+  }
+  if (left.minor !== right.minor) {
+    return left.minor < right.minor ? -1 : 1;
+  }
+  if (left.patch !== right.patch) {
+    return left.patch < right.patch ? -1 : 1;
+  }
+  return comparePrerelease(left.prerelease, right.prerelease);
+}
+
+export function compareSemVerStrings(
+  left: string,
+  right: string,
+): number | null {
+  const leftParsed = parseSemVer(left);
+  const rightParsed = parseSemVer(right);
+  if (!leftParsed || !rightParsed) {
+    return null;
+  }
+  return compareSemVer(leftParsed, rightParsed);
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+  if (left.length === 0 && right.length === 0) {
+    return 0;
+  }
+  if (left.length === 0) {
+    return 1;
+  }
+  if (right.length === 0) {
+    return -1;
+  }
+
+  const limit = Math.min(left.length, right.length);
+  for (let index = 0; index < limit; index += 1) {
+    const diff = comparePrereleaseIdentifier(left[index], right[index]);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+
+  if (left.length === right.length) {
+    return 0;
+  }
+  return left.length < right.length ? -1 : 1;
+}
+
+function comparePrereleaseIdentifier(left: string, right: string): number {
+  const leftNumeric = NUMERIC_PATTERN.test(left);
+  const rightNumeric = NUMERIC_PATTERN.test(right);
+  if (leftNumeric && rightNumeric) {
+    const diff = Number(left) - Number(right);
+    return diff === 0 ? 0 : diff < 0 ? -1 : 1;
+  }
+  if (leftNumeric) {
+    return -1;
+  }
+  if (rightNumeric) {
+    return 1;
+  }
+  if (left === right) {
+    return 0;
+  }
+  return left < right ? -1 : 1;
+}

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -1803,41 +1803,12 @@ func normalizeMacAppReleaseVersion(raw string) string {
 }
 
 func compareMacAppReleaseVersions(left, right string) int {
-	leftParts, leftOK := parseMacAppReleaseVersion(left)
-	rightParts, rightOK := parseMacAppReleaseVersion(right)
-	if !leftOK || !rightOK {
+	leftVersion, leftErr := versioning.ParseSemVer(normalizeMacAppReleaseVersion(left))
+	rightVersion, rightErr := versioning.ParseSemVer(normalizeMacAppReleaseVersion(right))
+	if leftErr != nil || rightErr != nil {
 		return 0
 	}
-	for i := 0; i < 3; i++ {
-		if leftParts[i] > rightParts[i] {
-			return 1
-		}
-		if leftParts[i] < rightParts[i] {
-			return -1
-		}
-	}
-	return 0
-}
-
-func parseMacAppReleaseVersion(version string) ([3]int, bool) {
-	var parts [3]int
-	normalized := normalizeMacAppReleaseVersion(version)
-	if normalized == "" {
-		return parts, false
-	}
-	core := strings.SplitN(normalized, "-", 2)[0]
-	segments := strings.Split(core, ".")
-	if len(segments) != 3 {
-		return parts, false
-	}
-	for i, segment := range segments {
-		value, err := strconv.Atoi(segment)
-		if err != nil {
-			return parts, false
-		}
-		parts[i] = value
-	}
-	return parts, true
+	return leftVersion.Compare(rightVersion)
 }
 
 func usageResponseFromPersisted(now time.Time, usage daemon.PersistedUsage) usageResponse {
@@ -3370,6 +3341,18 @@ func (s *Server) handleFirmwareLatest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	installedVersion, installedErr := versioning.ParseSemVer(installedFirmware)
+	if installedErr != nil {
+		writeJSON(w, http.StatusOK, firmwareLatestResponse{
+			CheckedAt:         checkedAt,
+			InstalledFirmware: installedFirmware,
+			UpdateAvailable:   false,
+			Status:            "check_failed",
+			Message:           fmt.Sprintf("Installed firmware version %q is not a valid version.", installedFirmware),
+		})
+		return
+	}
+
 	manifest, err := s.fetchFirmwareReleaseManifest(r.Context())
 	if err != nil {
 		writeJSON(w, http.StatusOK, firmwareLatestResponse{
@@ -3381,8 +3364,8 @@ func (s *Server) handleFirmwareLatest(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	artifact := latestFirmwareArtifactForBoard(manifest, board)
-	if strings.TrimSpace(artifact.FirmwareVersion) == "" {
+	artifact, latestVersion, hasArtifact := latestFirmwareArtifactForBoard(manifest, board)
+	if !hasArtifact {
 		writeJSON(w, http.StatusOK, firmwareLatestResponse{
 			CheckedAt:         checkedAt,
 			InstalledFirmware: installedFirmware,
@@ -3394,7 +3377,7 @@ func (s *Server) handleFirmwareLatest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updateAvailable := firmwareVersionCompare(artifact.FirmwareVersion, installedFirmware) > 0
+	updateAvailable := latestVersion.Compare(installedVersion) > 0
 	message := "Firmware is up to date."
 	status := "current"
 	if updateAvailable {
@@ -3442,28 +3425,26 @@ func (s *Server) fetchFirmwareReleaseManifest(ctx context.Context) (firmwareRele
 	return manifest, nil
 }
 
-func latestFirmwareArtifactForBoard(manifest firmwareReleaseManifest, board string) firmwareReleaseArtifact {
+func latestFirmwareArtifactForBoard(manifest firmwareReleaseManifest, board string) (firmwareReleaseArtifact, versioning.SemVer, bool) {
 	normalizedBoard := strings.ToLower(strings.TrimSpace(board))
 	var latest firmwareReleaseArtifact
+	var latestVersion versioning.SemVer
+	found := false
 	for _, artifact := range manifest.Artifacts {
 		if strings.ToLower(strings.TrimSpace(artifact.Board)) != normalizedBoard {
 			continue
 		}
-		if strings.TrimSpace(latest.FirmwareVersion) == "" ||
-			firmwareVersionCompare(artifact.FirmwareVersion, latest.FirmwareVersion) > 0 {
+		version, err := versioning.ParseSemVer(artifact.FirmwareVersion)
+		if err != nil {
+			continue
+		}
+		if !found || version.Compare(latestVersion) > 0 {
 			latest = artifact
+			latestVersion = version
+			found = true
 		}
 	}
-	return latest
-}
-
-func firmwareVersionCompare(left, right string) int {
-	leftVersion, leftErr := versioning.ParseSemVer(left)
-	rightVersion, rightErr := versioning.ParseSemVer(right)
-	if leftErr != nil || rightErr != nil {
-		return strings.Compare(strings.TrimSpace(left), strings.TrimSpace(right))
-	}
-	return leftVersion.Compare(rightVersion)
+	return latest, latestVersion, found
 }
 
 func (s *Server) handleFirmwareUpdateInstall(w http.ResponseWriter, r *http.Request) {

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -7025,3 +7025,133 @@ func diagnosticCheckDetail(checks []diagnosticCheck, name string) string {
 	}
 	return ""
 }
+
+func TestStatusOffersFinalMacAppReleaseToInstalledPrerelease(t *testing.T) {
+	t.Setenv(macAppVersionEnv, "1.0.44-rc.16")
+	t.Setenv(macAppBuildEnv, "4416")
+	server := newTestServer(t, runtimeconfig.Config{})
+	server.fetchMacAppRelease = func(context.Context) (githubRelease, error) {
+		return githubRelease{TagName: "v1.0.44"}, nil
+	}
+
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got statusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !got.Companion.Update.UpdateAvailable {
+		t.Fatalf("expected RC install to be offered the final release, got %+v", got.Companion.Update)
+	}
+	if got.Companion.Update.LatestVersion != "1.0.44" || got.Companion.Update.InstalledVersion != "1.0.44-rc.16" {
+		t.Fatalf("unexpected Mac App update versions: %+v", got.Companion.Update)
+	}
+}
+
+func TestStatusKeepsExactFinalMacAppReleaseCurrent(t *testing.T) {
+	t.Setenv(macAppVersionEnv, "1.0.44")
+	t.Setenv(macAppBuildEnv, "4400")
+	server := newTestServer(t, runtimeconfig.Config{})
+	server.fetchMacAppRelease = func(context.Context) (githubRelease, error) {
+		return githubRelease{TagName: "v1.0.44"}, nil
+	}
+
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got statusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Companion.Update.UpdateAvailable {
+		t.Fatalf("expected exact final release to stay current, got %+v", got.Companion.Update)
+	}
+}
+
+func TestCompareMacAppReleaseVersionsSemVerPrecedence(t *testing.T) {
+	cases := []struct {
+		left  string
+		right string
+		want  int
+	}{
+		{"1.0.44", "1.0.44-rc.16", 1},
+		{"1.0.44-rc.16", "1.0.44", -1},
+		{"1.0.44-beta.1", "1.0.44-rc.1", -1},
+		{"1.0.44-rc.2", "1.0.44-rc.10", -1},
+		{"v1.0.45", "1.0.44", 1},
+		{"1.0.44", "1.0.44", 0},
+		{"not-a-version", "1.0.44", 0},
+		{"1.0.44", "", 0},
+	}
+	for _, tc := range cases {
+		if got := compareMacAppReleaseVersions(tc.left, tc.right); got != tc.want {
+			t.Fatalf("compareMacAppReleaseVersions(%q, %q) = %d, want %d", tc.left, tc.right, got, tc.want)
+		}
+	}
+}
+
+func TestFirmwareLatestOffersFinalReleaseToPrerelease(t *testing.T) {
+	manifest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"release":"v1.0.36","artifacts":[{"board":"esp8266_smalltv_st7789","firmwareVersion":"1.0.36"},{"board":"esp8266_smalltv_st7789","firmwareVersion":"broken"}]}`))
+	}))
+	defer manifest.Close()
+	t.Setenv(firmwareManifestEnvVar, manifest.URL+"/firmware-manifest.json")
+	server := newTestServer(t, runtimeconfig.Config{})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/updates/latest?board=esp8266_smalltv_st7789&firmware=1.0.36-rc.2", nil)
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got firmwareLatestResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !got.UpdateAvailable || got.LatestFirmware != "1.0.36" || got.Status != "update_available" {
+		t.Fatalf("expected RC firmware to be offered the final release, got %+v", got)
+	}
+
+	current := httptest.NewRecorder()
+	currentReq := httptest.NewRequest(http.MethodGet, "/v1/updates/latest?board=esp8266_smalltv_st7789&firmware=1.0.36", nil)
+	server.Handler().ServeHTTP(current, currentReq)
+	var currentGot firmwareLatestResponse
+	if err := json.Unmarshal(current.Body.Bytes(), &currentGot); err != nil {
+		t.Fatalf("decode current response: %v", err)
+	}
+	if currentGot.UpdateAvailable || currentGot.Status != "current" {
+		t.Fatalf("expected exact final firmware to stay current, got %+v", currentGot)
+	}
+}
+
+func TestFirmwareLatestRejectsMalformedInstalledVersion(t *testing.T) {
+	manifest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("manifest must not be fetched for a malformed installed version")
+	}))
+	defer manifest.Close()
+	t.Setenv(firmwareManifestEnvVar, manifest.URL+"/firmware-manifest.json")
+	server := newTestServer(t, runtimeconfig.Config{})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/updates/latest?board=esp8266_smalltv_st7789&firmware=banana", nil)
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got firmwareLatestResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.UpdateAvailable || got.Status != "check_failed" {
+		t.Fatalf("expected malformed installed version to fail visibly, got %+v", got)
+	}
+	if !strings.Contains(got.Message, "banana") {
+		t.Fatalf("expected message to name the malformed version, got %q", got.Message)
+	}
+}

--- a/companion/internal/daemon/daemon.go
+++ b/companion/internal/daemon/daemon.go
@@ -922,16 +922,7 @@ func selectFirmwareUpdate(caps protocol.DeviceCapabilities, manifest firmwareMan
 }
 
 func firmwareReleaseNewerThanCurrent(latest, current versioning.SemVer) bool {
-	if latest.Major != current.Major {
-		return latest.Major > current.Major
-	}
-	if latest.Minor != current.Minor {
-		return latest.Minor > current.Minor
-	}
-	if latest.Patch != current.Patch {
-		return latest.Patch > current.Patch
-	}
-	return false
+	return latest.Compare(current) > 0
 }
 
 func selectCycleFrameFromProviders(state *runtimeState, allProviders []codexbar.ParsedFrame, now time.Time, deps runtimeDeps, emptyProvidersOp, emptyReason, emptyDetail, errorSource string) cycleResult {

--- a/companion/internal/daemon/daemon_test.go
+++ b/companion/internal/daemon/daemon_test.go
@@ -1761,17 +1761,30 @@ func TestSelectFirmwareUpdateComparesBoardRelease(t *testing.T) {
 		t.Fatalf("expected current state, got %+v", current)
 	}
 
-	devCurrent, err := selectFirmwareUpdate(protocol.DeviceCapabilities{
+	prereleaseUpdate, err := selectFirmwareUpdate(protocol.DeviceCapabilities{
 		Board:    "esp8266-smalltv-st7789",
 		Firmware: "1.0.1-dev",
 	}, firmwareManifest{Artifacts: []firmwareArtifact{
 		{Board: "esp8266-smalltv-st7789", FirmwareVersion: "1.0.1"},
 	}})
 	if err != nil {
-		t.Fatalf("select dev current: %v", err)
+		t.Fatalf("select prerelease update: %v", err)
 	}
-	if devCurrent.Available || devCurrent.Status != "current" {
-		t.Fatalf("expected dev build for same release to be current, got %+v", devCurrent)
+	if !prereleaseUpdate.Available || prereleaseUpdate.Status != "update_available" {
+		t.Fatalf("expected prerelease build to be offered the matching final release, got %+v", prereleaseUpdate)
+	}
+
+	rcUpdate, err := selectFirmwareUpdate(protocol.DeviceCapabilities{
+		Board:    "esp8266-smalltv-st7789",
+		Firmware: "1.0.36-rc.2",
+	}, firmwareManifest{Artifacts: []firmwareArtifact{
+		{Board: "esp8266-smalltv-st7789", FirmwareVersion: "1.0.36"},
+	}})
+	if err != nil {
+		t.Fatalf("select rc update: %v", err)
+	}
+	if !rcUpdate.Available || rcUpdate.LatestVersion != "1.0.36" || rcUpdate.Status != "update_available" {
+		t.Fatalf("expected RC firmware to be offered the matching final release, got %+v", rcUpdate)
 	}
 
 	nextRelease, err := selectFirmwareUpdate(protocol.DeviceCapabilities{

--- a/companion/internal/versioning/versioning_test.go
+++ b/companion/internal/versioning/versioning_test.go
@@ -35,6 +35,39 @@ func TestSemVerComparePreRelease(t *testing.T) {
 	}
 }
 
+func TestSemVerComparePrecedence(t *testing.T) {
+	cases := []struct {
+		left  string
+		right string
+		want  int
+	}{
+		{"1.0.44-rc.16", "1.0.44", -1},
+		{"1.0.36-rc.2", "1.0.36", -1},
+		{"1.0.44-beta.3", "1.0.44-rc.1", -1},
+		{"1.0.44-rc.2", "1.0.44-rc.10", -1},
+		{"1.0.44-alpha", "1.0.44-alpha.1", -1},
+		{"1.0.44-1", "1.0.44-alpha", -1},
+		{"1.0.44", "1.0.44", 0},
+		{"1.0.44+build7", "1.0.44", 0},
+		{"1.0.44-rc.1+build7", "1.0.44-rc.1", 0},
+		{"1.0.44", "1.0.44-rc.16", 1},
+		{"1.0.45-rc.1", "1.0.44", 1},
+	}
+	for _, tc := range cases {
+		left, err := ParseSemVer(tc.left)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.left, err)
+		}
+		right, err := ParseSemVer(tc.right)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.right, err)
+		}
+		if got := left.Compare(right); got != tc.want {
+			t.Fatalf("Compare(%q, %q) = %d, want %d", tc.left, tc.right, got, tc.want)
+		}
+	}
+}
+
 func TestCompatibilityMatrixAllowsV1(t *testing.T) {
 	ok, rule, err := IsCompatible("1.2.0", "1.9.4", 1)
 	if err != nil {

--- a/docs/control-center-customer-ui-approval.md
+++ b/docs/control-center-customer-ui-approval.md
@@ -142,3 +142,9 @@ issue scope, or release permission never implies UI permission.
 - User approval: After reporting that Overview changed to `Preview unavailable` immediately after installing another theme, the user explicitly answered `ja` to the proposed PR #169 fix and new preview build in the Codex task on 2026-07-19.
 - Approved customer-visible result: After Theme Studio installs a custom theme, Overview renders the exact active custom layout and assets with the live VibeTV usage frame instead of showing `Preview unavailable`. The installed render pack survives Mac App restarts, and an older local revision is never substituted for the active device theme. No new customer control or technical copy appears.
 - Approved files: `live-vibetv-preview.tsx`, `theme-studio-screen.tsx`, local theme render-pack storage and tests, Companion custom render-pack persistence and serving, and their Go and Control Center regression tests.
+
+## 2026-07-21 — Offer final releases to prerelease builds in update checks
+
+- User approval: The user explicitly ordered issue #173 to be implemented and the resulting PR #198 CI to be fixed in the Claude session on 2026-07-21.
+- Approved customer-visible result: Update checks treat prerelease builds as older than the matching final release, so a Mac App or VibeTV running an RC build is offered the final update instead of wrongly showing up to date. A version value that cannot be interpreted shows the existing check-failed state with a clear message instead of a wrong update decision. Theme Library firmware requirements use the same version ordering. No new customer controls and no new technical copy appear.
+- Approved files: the hosted firmware and Mac App update check routes, `theme-library-screen.tsx`, the shared version comparison in `lib/semver.ts`, and their route and unit tests.

--- a/scripts/verify-release-canary.sh
+++ b/scripts/verify-release-canary.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Post-publish canary: verifies against the real hosted endpoints that an
+# installed prerelease build (e.g. 1.0.44-rc.16) is offered the matching
+# final release, and that the exact final release stays current.
+#
+# See https://github.com/DreamyTalesPAN/CodexBar-Display/issues/173
+set -euo pipefail
+
+VERSION=""
+BASE_URL="https://app.vibetv.shop"
+FIRMWARE_CONFIG="release/firmware-versions.json"
+TIMEOUT_SECONDS=600
+RETRY_SLEEP_SECONDS=30
+
+usage() {
+  cat >&2 <<'EOF'
+usage: verify-release-canary.sh --version <x.y.z> [options]
+
+options:
+  --version <x.y.z>          published Mac App release version (no leading v)
+  --base-url <url>           hosted Control Center base URL (default https://app.vibetv.shop)
+  --firmware-config <path>   firmware versions config (default release/firmware-versions.json)
+  --timeout <seconds>        total retry budget per check (default 600)
+EOF
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) VERSION="${2:-}"; shift 2 ;;
+    --base-url) BASE_URL="${2:-}"; shift 2 ;;
+    --firmware-config) FIRMWARE_CONFIG="${2:-}"; shift 2 ;;
+    --timeout) TIMEOUT_SECONDS="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+VERSION="${VERSION#v}"
+if [[ -z "${VERSION}" ]]; then
+  usage
+fi
+if [[ ! -f "${FIRMWARE_CONFIG}" ]]; then
+  echo "error: firmware config not found: ${FIRMWARE_CONFIG}" >&2
+  exit 1
+fi
+
+# check <description> <url> <python-assertion>
+# The assertion runs with the decoded JSON body bound to `body`.
+check() {
+  local description="$1"
+  local url="$2"
+  local assertion="$3"
+  local deadline=$((SECONDS + TIMEOUT_SECONDS))
+  local last_error=""
+
+  while true; do
+    local payload
+    if payload="$(curl -fsS --max-time 20 "${url}" 2>&1)"; then
+      if last_error="$(PAYLOAD="${payload}" ASSERTION="${assertion}" python3 -c "
+import json, os
+body = json.loads(os.environ['PAYLOAD'])
+assertion = os.environ['ASSERTION']
+if not eval(assertion):
+    raise SystemExit('assertion failed: %s body=%r' % (assertion, body))
+" 2>&1)"; then
+        echo "ok: ${description}"
+        return 0
+      fi
+    else
+      last_error="${payload}"
+    fi
+
+    if (( SECONDS >= deadline )); then
+      echo "error: ${description}" >&2
+      echo "  url: ${url}" >&2
+      echo "  ${last_error}" >&2
+      return 1
+    fi
+    echo "retry: ${description} (${last_error})" >&2
+    sleep "${RETRY_SLEEP_SECONDS}"
+  done
+}
+
+echo "Verifying release canary for v${VERSION} against ${BASE_URL}"
+
+check "Mac App RC install is offered v${VERSION}" \
+  "${BASE_URL}/api/companion/latest?version=${VERSION}-rc.1" \
+  "body['updateAvailable'] is True and body['latestVersion'] == '${VERSION}'"
+
+check "Mac App v${VERSION} stays current" \
+  "${BASE_URL}/api/companion/latest?version=${VERSION}" \
+  "body['updateAvailable'] is False and body['status'] == 'available'"
+
+while IFS=$'\t' read -r BOARD FW_VERSION; do
+  check "firmware ${BOARD} RC install is offered v${FW_VERSION}" \
+    "${BASE_URL}/api/firmware/latest?board=${BOARD}&firmware=${FW_VERSION}-rc.1" \
+    "body['updateAvailable'] is True and body['latestFirmware'] == '${FW_VERSION}'"
+
+  check "firmware ${BOARD} v${FW_VERSION} stays current" \
+    "${BASE_URL}/api/firmware/latest?board=${BOARD}&firmware=${FW_VERSION}" \
+    "body['updateAvailable'] is False and body['status'] == 'current'"
+done < <(python3 -c "
+import json, sys
+with open('${FIRMWARE_CONFIG}', encoding='utf-8') as f:
+    config = json.load(f)
+for artifact in config.get('artifacts', []):
+    board = str(artifact.get('board', '')).strip()
+    version = str(artifact.get('firmwareVersion', '')).strip().lstrip('v')
+    if not board or not version:
+        raise SystemExit('firmware artifacts need board and firmwareVersion')
+    print(f'{board}\t{version}')
+")
+
+echo "Release canary passed for v${VERSION}"


### PR DESCRIPTION
## Summary

Fixes #173 — prerelease builds (`rc`, `beta`, `dev`) are now consistently treated as older than the matching final release in every update path, so `1.0.44-rc.16` is offered `1.0.44` and `1.0.36-rc.2` is offered `1.0.36`.

### Hosted Control Center (TypeScript)

- New shared helper `apps/control-center/src/lib/semver.ts` with full SemVer precedence: prerelease identifiers (numeric vs. alphanumeric, `beta < rc`, `rc.2 < rc.10`), build metadata ignored, leading `v` handled, malformed versions return `null` instead of degrading to `0.0.0`.
- `api/firmware/latest` and `api/companion/latest` use the helper for the update decision and manifest sorting; malformed installed or published versions now return `check_failed` with an explicit message.
- Theme library firmware gating (`requiresFirmware`) uses the same helper.

### Companion (Go)

- `compareMacAppReleaseVersions` now routes through `versioning.SemVer.Compare` instead of comparing only major/minor/patch.
- `firmwareReleaseNewerThanCurrent` in the daemon now uses `SemVer.Compare`, so a device on an RC is offered the matching final firmware.
- The local `/v1/updates/latest` endpoint validates the installed version up front, skips malformed manifest artifacts, and no longer falls back to lexicographic string comparison.

### Release canary

- New `scripts/verify-release-canary.sh` plus a `verify-release-canary` job in the release workflow: after publishing, the real hosted endpoints are checked so that a simulated RC install is offered the final Mac App release and final firmware for every board, and exact finals stay current.

## Tests

- `companion`: `go test ./...` (one unrelated flaky `codexbar` subprocess test passes in isolation); new coverage for SemVer precedence, RC→final offers on `/v1/status` and `/v1/updates/latest`, malformed-version failure, and manifest selection.
- `apps/control-center`: `vitest run` (55 tests, including new suites for the semver lib and both API routes) and `tsc --noEmit` clean.
- Canary script verified against a local stub server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)