### PR TITLE
CODEX: Show Mac-App firmware update notice across all themes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,7 +357,7 @@ jobs:
                       "asset": asset,
                       "sha256": sha,
                       "severity": str(artifact.get("severity") or "recommended"),
-                      "message": str(artifact.get("message") or "Firmware update available. Open app.vibetv.shop."),
+                      "message": str(artifact.get("message") or "Firmware update available. Open the VibeTV Mac App."),
                       "firmwareUrl": f"https://github.com/{repo}/releases/download/v{version}/{asset}",
                   }
               )

--- a/companion/internal/daemon/daemon_test.go
+++ b/companion/internal/daemon/daemon_test.go
@@ -1703,7 +1703,7 @@ func TestRunCycleWithDepsPreservesFirmwareUpdateNoticeForLegacyDevice(t *testing
 				LatestVersion: "1.0.20",
 				Status:        "update_available",
 				Severity:      "recommended",
-				Message:       strings.Repeat("Firmware update available. Open app.vibetv.shop. ", 20),
+				Message:       strings.Repeat("Firmware update available. Open the VibeTV Mac App. ", 20),
 				FirmwareURL:   "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.0.20/" + strings.Repeat("codexbar-display-firmware-esp8266-smalltv-st7789-", 10) + "v1.0.20.bin.gz",
 				SHA256:        strings.Repeat("a", 128),
 			}, nil

--- a/docs/firmware-guardrails.md
+++ b/docs/firmware-guardrails.md
@@ -18,7 +18,7 @@ Rules:
 ## Protocol/Theme Rules
 - Companion->device frame `v` is negotiated (prefer v2, fallback v1).
 - ThemeSpec is declarative data only. Never execute scripts on device.
-- ThemeSpec update notices must use the existing label binding. Do not draw the global bottom update bar over ThemeSpec layouts.
+- ThemeSpec update notices prefer the existing label binding (permanent rotating text swap). Themes without a label binding get a bounded edge overlay bar in timed visible/hidden windows, placed where no animated primitive repaints and removed with a region repaint — never a full-screen redraw. Update copy points to the VibeTV Mac App only; no hosted URLs. Showing the notice must never trigger a firmware write.
 - `themeId/themeRev` cache keys are required to detect unchanged ThemeSpec payloads.
 - Live theme removal is destructive. Firmware must ignore `themeSpec:null` unless the same frame also sets `confirmClearThemeSpec:true`.
 - Companion code must not emit `themeSpec:null` unless the caller explicitly marks that clear as confirmed. Normal recovery paths should reactivate a stored ThemeSpec or repair assets instead of clearing the live theme.

--- a/docs/theme-dev-guide.md
+++ b/docs/theme-dev-guide.md
@@ -18,7 +18,7 @@ The compiled scene copies normal strings and `idle`/`coding` `stateAssets` paths
 - Use `CBA1` animated sprites for character animation and state animation.
 - Make the main background full-screen at 240x240. If the design uses an inset panel or window, include the surrounding background in the background asset instead of leaving the display uncovered.
 - Keep ThemeSpec primitives for dynamic content: usage bars, percentages, reset time, provider label, time, date, and state-dependent asset selection.
-- Treat the provider label as the firmware update notice slot. When an update is available, ThemeSpec firmware swaps `{label}` / `label` to `Update available` and `app.vibetv.shop`; do not reserve a separate bottom bar for this.
+- Treat the provider label as the firmware update notice slot. When an update is available, ThemeSpec firmware rotates `{label}` / `label` through `Update available` and `Open VibeTV Mac App`; do not reserve a separate bar for this. Themes without a label binding instead get a temporary 24px overlay bar on the top (or bottom) edge in short visible windows, so keep at least one horizontal edge free of animated GIF/sprite primitives when possible.
 - Keep all primitives that can change at runtime inside stable bounds. Text without a width is allowed, but the firmware treats it conservatively up to the right display edge for partial render safety.
 - Combine many small decorative rects into one sprite asset.
 - Combine static text labels into a sprite when they do not need to change.

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -80,10 +80,13 @@ const char kActiveThemeSpecPathFile[] = "/theme-active";
 const char kAssetUploadTemporaryPath[] = "/.asset-upload.tmp";
 const char kDeviceAuthHeader[] = "X-VibeTV-Token";
 const char kFirmwareManifestUrl[] = "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/firmware-manifest.json";
-constexpr uint8_t kFirmwareUpdateNoticeTextCount = 3;
-constexpr uint8_t kFirmwareUpdateNoticeProviderPhase = 0;
-constexpr uint8_t kFirmwareUpdateNoticeAvailablePhase = 1;
-constexpr uint8_t kFirmwareUpdateNoticeAppPhase = 2;
+// Customer copy for the update notice. The installed VibeTV Mac App is the
+// only supported update destination; never point customers at a hosted URL.
+const char kFirmwareUpdateAvailableText[] = "Update available";
+const char kFirmwareUpdateMacAppText[] = "Open VibeTV Mac App";
+constexpr unsigned long kFirmwareUpdateOverlayVisibleMs = 10000UL;
+constexpr unsigned long kFirmwareUpdateOverlayHiddenMs = 60000UL;
+constexpr unsigned long kFirmwareUpdateSurfaceRecheckMs = 1000UL;
 
 String themeCapabilitiesJSON(bool enabled, bool compact = false) {
   String out;
@@ -134,9 +137,12 @@ struct FirmwareUpdateState {
   String lastError;
   unsigned long lastCheckedAtMs = 0;
   unsigned long nextCheckAtMs = 0;
-  bool noticeVisible = false;
-  uint8_t noticePhase = 0;
-  unsigned long noticeLastToggleAtMs = 0;
+  // Frame-driven gate: true while the Mac App reports an available update.
+  // Cleared when a frame arrives without update info or with a current
+  // firmware, which also removes the notice.
+  bool noticeEnabled = false;
+  codexbar_display::updatenotice::State notice;
+  unsigned long noticeSurfaceCheckedAtMs = 0;
 };
 
 struct OtaUploadDiagnostics {
@@ -481,8 +487,8 @@ void markFirmwareUpdateNoticeDirty() {
 }
 
 bool shouldShowFirmwareUpdateNotice() {
-  return firmwareUpdate.available &&
-         firmwareUpdate.noticeVisible &&
+  return firmwareUpdate.noticeEnabled &&
+         firmwareUpdate.notice.visible &&
          !setupMode &&
          !waitStatusRendered &&
          !frameStaleStatusRendered &&
@@ -492,14 +498,13 @@ bool shouldShowFirmwareUpdateNotice() {
 }
 
 const char* currentFirmwareUpdateNoticeText() {
-  if (firmwareUpdate.noticePhase >= kFirmwareUpdateNoticeTextCount) {
-    firmwareUpdate.noticePhase = 0;
-  }
-  if (firmwareUpdate.noticePhase == kFirmwareUpdateNoticeAvailablePhase) {
-    return "Update available";
-  }
-  if (firmwareUpdate.noticePhase == kFirmwareUpdateNoticeAppPhase) {
-    return kCustomerAppHost;
+  switch (codexbar_display::updatenotice::CurrentPhase(firmwareUpdate.notice)) {
+    case codexbar_display::updatenotice::Phase::Available:
+      return kFirmwareUpdateAvailableText;
+    case codexbar_display::updatenotice::Phase::MacApp:
+      return kFirmwareUpdateMacAppText;
+    case codexbar_display::updatenotice::Phase::Provider:
+      break;
   }
 
   const codexbar_display::core::Frame& frame = codexbar_display::app::CurrentFrame(runtimeCtx);
@@ -524,24 +529,29 @@ void drawFirmwareUpdateNotice() {
   firmwareUpdateNoticeDirty = false;
 }
 
-void clearFirmwareUpdateNotice() {
-  if (!firmwareUpdate.noticeVisible) {
+void restoreFirmwareUpdateNoticeSurface() {
+  if (!codexbar_display::app::HasFrame(runtimeCtx) ||
+      codexbar_display::app::CurrentFrame(runtimeCtx).hasError ||
+      waitStatusRendered ||
+      frameStaleStatusRendered) {
     return;
   }
-  firmwareUpdate.noticeVisible = false;
-  firmwareUpdate.noticePhase = 0;
-  firmwareUpdate.noticeLastToggleAtMs = 0;
-  firmwareUpdateNoticeDirty = false;
-  if (codexbar_display::app::HasFrame(runtimeCtx) &&
-      !codexbar_display::app::CurrentFrame(runtimeCtx).hasError &&
-      !waitStatusRendered &&
-      !frameStaleStatusRendered) {
+  if (!renderer.ClearFirmwareUpdateNoticeSurface(runtimeCtx)) {
     runtimeCtx.screenDirty = true;
   }
 }
 
+void clearFirmwareUpdateNotice() {
+  const codexbar_display::updatenotice::TickResult result =
+      codexbar_display::updatenotice::Deactivate(firmwareUpdate.notice);
+  firmwareUpdateNoticeDirty = false;
+  if (result.restore) {
+    restoreFirmwareUpdateNoticeSurface();
+  }
+}
+
 void maintainFirmwareUpdateNotice() {
-  if (!firmwareUpdate.available ||
+  if (!firmwareUpdate.noticeEnabled ||
       setupMode ||
       frameStaleStatusRendered ||
       !codexbar_display::app::HasFrame(runtimeCtx) ||
@@ -550,17 +560,34 @@ void maintainFirmwareUpdateNotice() {
     clearFirmwareUpdateNotice();
     return;
   }
-  if (!firmwareUpdate.noticeVisible) {
-    return;
-  }
+
   const unsigned long nowMs = millis();
-  if (firmwareUpdate.noticeLastToggleAtMs == 0) {
-    firmwareUpdate.noticeLastToggleAtMs = nowMs;
-    return;
+  // Surface detection walks the ThemeSpec, so re-check it at most once per
+  // second: once to activate the notice, afterwards to follow theme changes.
+  if (firmwareUpdate.noticeSurfaceCheckedAtMs == 0 ||
+      (nowMs - firmwareUpdate.noticeSurfaceCheckedAtMs) >= kFirmwareUpdateSurfaceRecheckMs) {
+    firmwareUpdate.noticeSurfaceCheckedAtMs = nowMs == 0 ? 1 : nowMs;
+    const codexbar_display::updatenotice::TickResult activated =
+        codexbar_display::updatenotice::Activate(
+            firmwareUpdate.notice, renderer.FirmwareUpdateNoticeSurface(runtimeCtx), nowMs);
+    if (activated.restore) {
+      restoreFirmwareUpdateNoticeSurface();
+    }
+    if (activated.draw) {
+      markFirmwareUpdateNoticeDirty();
+    }
   }
-  if ((nowMs - firmwareUpdate.noticeLastToggleAtMs) >= kFirmwareUpdateNoticeToggleMs) {
-    firmwareUpdate.noticeLastToggleAtMs = nowMs;
-    firmwareUpdate.noticePhase = (firmwareUpdate.noticePhase + 1) % kFirmwareUpdateNoticeTextCount;
+
+  codexbar_display::updatenotice::Config config;
+  config.phaseToggleMs = kFirmwareUpdateNoticeToggleMs;
+  config.overlayVisibleMs = kFirmwareUpdateOverlayVisibleMs;
+  config.overlayHiddenMs = kFirmwareUpdateOverlayHiddenMs;
+  const codexbar_display::updatenotice::TickResult ticked =
+      codexbar_display::updatenotice::Tick(firmwareUpdate.notice, config, nowMs);
+  if (ticked.restore) {
+    restoreFirmwareUpdateNoticeSurface();
+  }
+  if (ticked.draw) {
     markFirmwareUpdateNoticeDirty();
   }
 }
@@ -572,6 +599,7 @@ void applyFrameUpdateState() {
 
   const codexbar_display::core::Frame& frame = codexbar_display::app::CurrentFrame(runtimeCtx);
   if (!frame.hasUpdateAvailable) {
+    firmwareUpdate.noticeEnabled = false;
     clearFirmwareUpdateNotice();
     return;
   }
@@ -592,15 +620,17 @@ void applyFrameUpdateState() {
   firmwareUpdate.lastStatus = nextStatus;
 
   if (!firmwareUpdate.available) {
+    firmwareUpdate.noticeEnabled = false;
     clearFirmwareUpdateNotice();
     return;
   }
-  if (!firmwareUpdate.noticeVisible || changed) {
-    firmwareUpdate.noticeVisible = true;
-    firmwareUpdate.noticePhase = 0;
-    firmwareUpdate.noticeLastToggleAtMs = millis();
-    markFirmwareUpdateNoticeDirty();
+  if (changed) {
+    // Restart the notice cycle for a new update state; the next maintain pass
+    // re-activates it on the current theme's surface.
+    clearFirmwareUpdateNotice();
+    firmwareUpdate.noticeSurfaceCheckedAtMs = 0;
   }
+  firmwareUpdate.noticeEnabled = true;
 }
 
 void drawWaitingForCompanionStatus() {
@@ -663,6 +693,11 @@ void renderAcceptedFrame(const codexbar_display::core::SerialConsumeEvent& event
   const unsigned long partialSuccessesBefore =
       maybeThemeSpecPartial ? renderer.DebugSnapshot().themeSpecPartialSuccesses : 0;
   renderer.OnFrameAccepted(runtimeCtx, event);
+  if (shouldShowFirmwareUpdateNotice()) {
+    // A frame-driven partial repaint may have painted theme content over the
+    // visible notice (label line or overlay bar); re-assert it next loop.
+    markFirmwareUpdateNoticeDirty();
+  }
   if (maybeThemeSpecPartial) {
     const codexbar_display::esp8266::RendererDebugSnapshot snapshot = renderer.DebugSnapshot();
     if (snapshot.themeSpecPartialSuccesses > partialSuccessesBefore && !runtimeCtx.screenDirty) {

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -84,7 +84,7 @@ const char kFirmwareManifestUrl[] = "https://github.com/DreamyTalesPAN/CodexBar-
 // only supported update destination; never point customers at a hosted URL.
 const char kFirmwareUpdateAvailableText[] = "Update available";
 const char kFirmwareUpdateMacAppText[] = "Open VibeTV Mac App";
-constexpr unsigned long kFirmwareUpdateOverlayVisibleMs = 10000UL;
+constexpr unsigned long kFirmwareUpdateOverlayVisibleMs = 30000UL;
 constexpr unsigned long kFirmwareUpdateOverlayHiddenMs = 60000UL;
 constexpr unsigned long kFirmwareUpdateSurfaceRecheckMs = 1000UL;
 

--- a/firmware_esp8266/src/renderer_esp8266.cpp
+++ b/firmware_esp8266/src/renderer_esp8266.cpp
@@ -399,24 +399,121 @@ void RendererESP8266::DrawConnectedSetupInstructions(
 #endif
 }
 
+#ifndef CODEXBAR_DISPLAY_PROBE_ONLY
+#if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
+namespace {
+
+// Y position of the currently drawn overlay bar, or -1 when none is on
+// screen. Remembered so the clear pass repaints exactly the covered strip
+// even if the preferred placement changes between draw and clear.
+int lastDrawnOverlayBarY = -1;
+
+void drawFirmwareUpdateOverlayBar(const String& text, int y) {
+  TFT_eSPI& tft = display::Tft();
+  display::DisplayTransaction transaction;
+  display::PrimitiveFillRect(0, y, tft.width(), display::kFirmwareUpdateNoticeBarHeight, TFT_BLACK);
+  tft.setTextWrap(false);
+  tft.setTextFont(1);
+  const int textSize = display::ChooseTextSizeToFit(text.c_str(), 2, 1, tft.width() - 8);
+  display::SetTextSize(textSize);
+  tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  int textY = y + (display::kFirmwareUpdateNoticeBarHeight - display::TextPixelHeight(textSize)) / 2;
+  if (textY < y) {
+    textY = y;
+  }
+  tft.setCursor(display::CenteredTextX(text.c_str(), textSize), textY);
+  tft.print(text);
+}
+
+}  // namespace
+#endif
+#endif
+
+updatenotice::Surface RendererESP8266::FirmwareUpdateNoticeSurface(app::RuntimeContext& ctx) {
+#ifndef CODEXBAR_DISPLAY_PROBE_ONLY
+  display::AttachContext(ctx);
+  if (!display::CurrentFrame().hasThemeSpec) {
+    return updatenotice::Surface::None;
+  }
+#if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
+  if (!display::CurrentThemeSpecRenderedSuccessfully()) {
+    return updatenotice::Surface::None;
+  }
+  const String& raw = core::ThemeSpecRawForFrame(display::RuntimeState(), display::CurrentFrame());
+  if (core::ThemeSpecUsesBinding(raw, "label", "l")) {
+    return updatenotice::Surface::Label;
+  }
+  if (display::FirmwareUpdateOverlayBarPlacement().valid) {
+    return updatenotice::Surface::Overlay;
+  }
+#endif
+  return updatenotice::Surface::None;
+#else
+  return app::HasFrame(ctx) && app::CurrentFrame(ctx).hasThemeSpec
+             ? updatenotice::Surface::Label
+             : updatenotice::Surface::None;
+#endif
+}
+
 void RendererESP8266::DrawFirmwareUpdateNotice(app::RuntimeContext& ctx, const String& text) {
 #ifndef CODEXBAR_DISPLAY_PROBE_ONLY
   display::AttachContext(ctx);
-  if (display::CurrentFrame().hasThemeSpec) {
+  (void)text;
+  if (!display::CurrentFrame().hasThemeSpec) {
+    return;
+  }
 #if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
-    const String& raw = core::ThemeSpecRawForFrame(display::RuntimeState(), display::CurrentFrame());
-    if (display::CurrentThemeSpecRenderedSuccessfully() &&
-        core::ThemeSpecUsesBinding(raw, "label", "l")) {
+  switch (FirmwareUpdateNoticeSurface(ctx)) {
+    case updatenotice::Surface::Label:
       if (!display::RenderThemeSpecPartial(codexbar_display::themespec::kThemeSpecFieldLabel, text.c_str())) {
         display::ScreenDirty() = true;
       }
+      return;
+    case updatenotice::Surface::Overlay: {
+      const display::FirmwareUpdateOverlayPlacement placement = display::FirmwareUpdateOverlayBarPlacement();
+      if (!placement.valid) {
+        return;
+      }
+      drawFirmwareUpdateOverlayBar(text, placement.y);
+      lastDrawnOverlayBarY = placement.y;
+      return;
     }
-#endif
-    return;
+    case updatenotice::Surface::None:
+      return;
   }
+#endif
 #else
   (void)ctx;
   Serial.printf("probe_update_notice text=%s\n", text.c_str());
+#endif
+}
+
+bool RendererESP8266::ClearFirmwareUpdateNoticeSurface(app::RuntimeContext& ctx) {
+#ifndef CODEXBAR_DISPLAY_PROBE_ONLY
+  display::AttachContext(ctx);
+  if (!display::CurrentFrame().hasThemeSpec) {
+    return true;
+  }
+#if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
+  const int overlayY = lastDrawnOverlayBarY;
+  lastDrawnOverlayBarY = -1;
+  if (overlayY >= 0) {
+    return display::RenderThemeSpecRegion(
+        0, overlayY, display::Tft().width(), display::kFirmwareUpdateNoticeBarHeight);
+  }
+  const String& raw = core::ThemeSpecRawForFrame(display::RuntimeState(), display::CurrentFrame());
+  if (display::CurrentThemeSpecRenderedSuccessfully() &&
+      core::ThemeSpecUsesBinding(raw, "label", "l")) {
+    return display::RenderThemeSpecPartial(codexbar_display::themespec::kThemeSpecFieldLabel);
+  }
+  return true;
+#else
+  return true;
+#endif
+#else
+  (void)ctx;
+  Serial.printf("probe_update_notice_clear\n");
+  return true;
 #endif
 }
 

--- a/firmware_esp8266/src/renderer_esp8266.h
+++ b/firmware_esp8266/src/renderer_esp8266.h
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 
 #include "../../firmware_shared/app_renderer.h"
+#include "../../firmware_shared/update_notice_policy.h"
 
 namespace codexbar_display {
 namespace esp8266 {
@@ -81,6 +82,12 @@ class RendererESP8266 : public app::Renderer {
   void DrawSetupInstructions(app::RuntimeContext& ctx, const String& ssid, const String& address);
   void DrawConnectedSetupInstructions(app::RuntimeContext& ctx, const String& host, const String& fallbackIp);
   void DrawFirmwareUpdateNotice(app::RuntimeContext& ctx, const String& text);
+  // Which notice surface the active theme offers: label swap, overlay bar, or
+  // none (no ThemeSpec rendered / no safe bar area free of animations).
+  updatenotice::Surface FirmwareUpdateNoticeSurface(app::RuntimeContext& ctx);
+  // Removes the notice with a bounded repaint. Returns false when only a full
+  // redraw could restore the theme; the caller then marks the screen dirty.
+  bool ClearFirmwareUpdateNoticeSurface(app::RuntimeContext& ctx);
   void TickActive(app::RuntimeContext& ctx) override;
   void DrawError(app::RuntimeContext& ctx, const String& message) override;
   void DrawUsage(app::RuntimeContext& ctx) override;

--- a/firmware_esp8266/src/renderer_esp8266_display_state.h
+++ b/firmware_esp8266/src/renderer_esp8266_display_state.h
@@ -104,10 +104,25 @@ int CenteredTextX(const char* text, int textSize);
 void SetTextSize(int size);
 const char* ProviderLabelText();
 
+// Height of the firmware update overlay bar drawn over themes without a
+// label binding. Bounded so the notice never covers more than one edge strip.
+constexpr int kFirmwareUpdateNoticeBarHeight = 24;
+
+struct FirmwareUpdateOverlayPlacement {
+  bool valid = false;
+  int y = 0;
+};
+
 bool DrawThemeSpecUsage();
 bool TickThemeSpecGifs();
 bool ThemeSpecAnimationWorkPending();
 bool RenderThemeSpecPartial(uint32_t changedFields, const char* updateNoticeText = nullptr);
+// Repaints one bounded display region from the cached ThemeSpec scene without
+// a full-screen redraw. Used to remove the update-notice overlay bar.
+bool RenderThemeSpecRegion(int x, int y, int width, int height);
+// Picks a bar position (top preferred, bottom fallback) that no animated
+// GIF/sprite primitive repaints, so animations keep rendering correctly.
+FirmwareUpdateOverlayPlacement FirmwareUpdateOverlayBarPlacement();
 void ResetThemeSpecSpriteCaches();
 bool ThemeSpecFullRenderRetryPending();
 bool CurrentThemeSpecRenderedSuccessfully();

--- a/firmware_esp8266/src/renderer_esp8266_theme_spec.cpp
+++ b/firmware_esp8266/src/renderer_esp8266_theme_spec.cpp
@@ -11,6 +11,7 @@
 #include <LittleFS.h>
 
 #include <cstdio>
+#include <cstring>
 #include <new>
 
 #include "../../firmware_shared/theme_spec_renderer_core.h"
@@ -1054,7 +1055,7 @@ const char* usageModeText() {
 }
 
 const char* themeSpecUpdateNoticeText() {
-  return "app.vibetv.shop";
+  return "Open VibeTV Mac App";
 }
 
 themespec::FrameData currentThemeSpecFrameData(const char* updateNoticeText = nullptr) {
@@ -1207,6 +1208,65 @@ bool RenderThemeSpecPartial(uint32_t changedFields, const char* updateNoticeText
   return true;
 }
 
+bool RenderThemeSpecRegion(int x, int y, int width, int height) {
+  const String& raw = currentThemeSpecRaw();
+  if (!CurrentFrame().hasThemeSpec || !codexbar_display::core::ThemeSpecRawLooksRenderable(raw)) {
+    return false;
+  }
+  if (!hasThemeSpecHeap(false)) {
+    return false;
+  }
+  if (!ensureThemeSpecSceneCached(raw)) {
+    return false;
+  }
+
+  themespec::Bounds region;
+  region.x = x;
+  region.y = y;
+  region.width = width;
+  region.height = height;
+  const auto frameData = currentThemeSpecFrameData();
+  ThemeSpecSink sink(false, SpriteRenderMode::StaticOnly, true);
+  const char* regionError = nullptr;
+  if (themespec::RenderCompiledThemeSpecRegionPrimitives(
+          cachedThemeSpecScene, frameData, region, sink, &regionError, nullptr)) {
+    return true;
+  }
+  // The background fill already restored a region no primitive overlaps.
+  return regionError != nullptr && strcmp(regionError, "no_overlap_rendered") == 0;
+}
+
+FirmwareUpdateOverlayPlacement FirmwareUpdateOverlayBarPlacement() {
+  FirmwareUpdateOverlayPlacement placement;
+  const String& raw = currentThemeSpecRaw();
+  if (!CurrentFrame().hasThemeSpec || !codexbar_display::core::ThemeSpecRawLooksRenderable(raw)) {
+    return placement;
+  }
+  if (!ensureThemeSpecSceneCached(raw)) {
+    return placement;
+  }
+
+  const auto frameData = currentThemeSpecFrameData();
+  themespec::Bounds bar;
+  bar.x = 0;
+  bar.width = Tft().width();
+  bar.height = kFirmwareUpdateNoticeBarHeight;
+  bar.y = 0;
+  if (!themespec::AnyAnimatedCompiledPrimitiveOverlaps(cachedThemeSpecScene, frameData, bar)) {
+    placement.valid = true;
+    placement.y = bar.y;
+    return placement;
+  }
+  // Animated GIF/sprite frames repaint their full bounds on every tick and
+  // would fight with an overlay drawn on top. Fall back to the bottom edge.
+  bar.y = Tft().height() - bar.height;
+  if (!themespec::AnyAnimatedCompiledPrimitiveOverlaps(cachedThemeSpecScene, frameData, bar)) {
+    placement.valid = true;
+    placement.y = bar.y;
+  }
+  return placement;
+}
+
 void ResetThemeSpecSpriteCaches() {
   resetAnimatedSpriteCaches();
   releaseCbaFrameBuffer();
@@ -1298,6 +1358,18 @@ bool ThemeSpecFullRenderRetryPending() {
 
 bool CurrentThemeSpecRenderedSuccessfully() {
   return false;
+}
+
+bool RenderThemeSpecRegion(int x, int y, int width, int height) {
+  (void)x;
+  (void)y;
+  (void)width;
+  (void)height;
+  return false;
+}
+
+FirmwareUpdateOverlayPlacement FirmwareUpdateOverlayBarPlacement() {
+  return FirmwareUpdateOverlayPlacement{};
 }
 
 bool ThemeSpecRenderOk() {

--- a/firmware_esp8266/test/test_native_theme_spec/test_theme_spec_renderer.cpp
+++ b/firmware_esp8266/test/test_native_theme_spec/test_theme_spec_renderer.cpp
@@ -1,5 +1,6 @@
 #include "../../../firmware_shared/theme_spec_renderer_core.h"
 #include "../../../firmware_shared/codexbar_display_core.h"
+#include "../../../firmware_shared/update_notice_policy.h"
 #include "../../src/theme_spec_runtime_policy.h"
 
 #include <string>
@@ -17,9 +18,12 @@ using codexbar_display::themespec::RectCommand;
 using codexbar_display::themespec::CompileThemeSpec;
 using codexbar_display::themespec::CompiledThemeSpec;
 using codexbar_display::themespec::CompiledThemeSpecHasGifAssets;
+using codexbar_display::themespec::AnyAnimatedCompiledPrimitiveOverlaps;
+using codexbar_display::themespec::Bounds;
 using codexbar_display::themespec::RenderCompiledThemeSpec;
 using codexbar_display::themespec::RenderCompiledThemeSpecAnimatedPrimitives;
 using codexbar_display::themespec::RenderCompiledThemeSpecChangedPrimitives;
+using codexbar_display::themespec::RenderCompiledThemeSpecRegionPrimitives;
 using codexbar_display::themespec::RenderCompiledThemeSpecStaticPrimitives;
 using codexbar_display::themespec::ReleaseCompiledThemeSpec;
 using codexbar_display::themespec::Sink;
@@ -404,7 +408,7 @@ void testLabelBindingUsesProviderLabelWithoutUpdateNotice() {
 
   FrameData frame = testFrame();
   frame.updateAvailable = true;
-  frame.updateNotice = "app.vibetv.shop";
+  frame.updateNotice = "Open VibeTV Mac App";
 
   RecordingSink sink;
   TEST_ASSERT_TRUE(renderSpec(spec, frame, sink));
@@ -429,13 +433,13 @@ void testChangedLabelPassUsesSynchronizedUpdateNoticeText() {
   FrameData frame = testFrame();
   frame.updateAvailable = true;
   frame.showUpdateNotice = true;
-  frame.updateNotice = "app.vibetv.shop";
+  frame.updateNotice = "Open VibeTV Mac App";
 
   RecordingSink sink;
   TEST_ASSERT_TRUE(renderChangedSpec(spec, frame, kThemeSpecFieldLabel, sink));
   TEST_ASSERT_EQUAL_UINT32(4, sink.commands.size());
   TEST_ASSERT_EQUAL_INT(static_cast<int>(CommandType::Text), static_cast<int>(sink.commands[2].type));
-  TEST_ASSERT_EQUAL_STRING("app.vibetv.shop", sink.commands[2].text.c_str());
+  TEST_ASSERT_EQUAL_STRING("Open VibeTV Mac App", sink.commands[2].text.c_str());
 }
 
 void testChangedLabelPassCanRestoreProviderText() {
@@ -459,6 +463,235 @@ void testChangedLabelPassCanRestoreProviderText() {
   TEST_ASSERT_EQUAL_UINT32(4, sink.commands.size());
   TEST_ASSERT_EQUAL_INT(static_cast<int>(CommandType::Text), static_cast<int>(sink.commands[2].type));
   TEST_ASSERT_EQUAL_STRING("Codex", sink.commands[2].text.c_str());
+}
+
+bool renderRegionSpec(
+    const char* spec,
+    const FrameData& frame,
+    const Bounds& region,
+    RecordingSink& sink,
+    const char** error = nullptr,
+    bool* skippedAnimated = nullptr) {
+  JsonDocument doc;
+  CompiledThemeSpec scene;
+  if (!CompileThemeSpec(spec, doc, scene)) {
+    return false;
+  }
+  const bool ok = RenderCompiledThemeSpecRegionPrimitives(scene, frame, region, sink, error, skippedAnimated);
+  ReleaseCompiledThemeSpec(scene);
+  return ok;
+}
+
+// A theme without a label binding: static text top and bottom plus a GIF in
+// the middle, mirroring a custom ThemeSpec that needs the overlay-bar notice.
+const char* kOverlayRegionSpec = R"JSON({
+  "v": 1,
+  "id": "no-label",
+  "rev": 1,
+  "bg": "#000000",
+  "p": [
+    {"t":"tx","x":0,"y":4,"w":240,"v":"{session}%","s":2,"al":"center","c":"#CCFF00"},
+    {"t":"g","x":80,"y":100,"w":76,"h":76,"a":"/themes/mini/mini.gif"},
+    {"t":"tx","x":0,"y":210,"w":240,"v":"Reset in {reset}","s":2,"al":"center","c":"#999999"}
+  ]
+})JSON";
+
+void testRegionRepaintRedrawsOnlyOverlappingPrimitives() {
+  Bounds region;
+  region.x = 0;
+  region.y = 0;
+  region.width = 240;
+  region.height = 24;
+
+  RecordingSink sink;
+  TEST_ASSERT_TRUE(renderRegionSpec(kOverlayRegionSpec, testFrame(), region, sink));
+  TEST_ASSERT_EQUAL_UINT32(4, sink.commands.size());
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(CommandType::BeginClip), static_cast<int>(sink.commands[0].type));
+  TEST_ASSERT_EQUAL_INT(0, sink.commands[0].y);
+  TEST_ASSERT_EQUAL_INT(24, sink.commands[0].height);
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(CommandType::FillRect), static_cast<int>(sink.commands[1].type));
+  TEST_ASSERT_EQUAL_INT(240, sink.commands[1].width);
+  TEST_ASSERT_EQUAL_INT(24, sink.commands[1].height);
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(CommandType::Text), static_cast<int>(sink.commands[2].type));
+  TEST_ASSERT_EQUAL_STRING("97%", sink.commands[2].text.c_str());
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(CommandType::EndClip), static_cast<int>(sink.commands[3].type));
+}
+
+void testRegionRepaintSkipsAnimatedPrimitivesButReportsThem() {
+  Bounds region;
+  region.x = 0;
+  region.y = 90;
+  region.width = 240;
+  region.height = 24;
+
+  RecordingSink sink;
+  bool skippedAnimated = false;
+  TEST_ASSERT_TRUE(renderRegionSpec(kOverlayRegionSpec, testFrame(), region, sink, nullptr, &skippedAnimated));
+  TEST_ASSERT_TRUE(skippedAnimated);
+  for (const RecordedCommand& cmd : sink.commands) {
+    TEST_ASSERT_NOT_EQUAL(static_cast<int>(CommandType::Gif), static_cast<int>(cmd.type));
+  }
+}
+
+void testRegionRepaintWithoutOverlapFillsBackgroundOnly() {
+  Bounds region;
+  region.x = 0;
+  region.y = 40;
+  region.width = 240;
+  region.height = 24;
+
+  RecordingSink sink;
+  const char* error = nullptr;
+  TEST_ASSERT_FALSE(renderRegionSpec(kOverlayRegionSpec, testFrame(), region, sink, &error));
+  TEST_ASSERT_EQUAL_STRING("no_overlap_rendered", error);
+  TEST_ASSERT_EQUAL_UINT32(3, sink.commands.size());
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(CommandType::FillRect), static_cast<int>(sink.commands[1].type));
+  TEST_ASSERT_EQUAL_INT(40, sink.commands[1].y);
+}
+
+void testAnimatedOverlapQueryFindsGifOnlyInsideItsBounds() {
+  JsonDocument doc;
+  CompiledThemeSpec scene;
+  TEST_ASSERT_TRUE(CompileThemeSpec(kOverlayRegionSpec, doc, scene));
+
+  Bounds top;
+  top.x = 0;
+  top.y = 0;
+  top.width = 240;
+  top.height = 24;
+  TEST_ASSERT_FALSE(AnyAnimatedCompiledPrimitiveOverlaps(scene, testFrame(), top));
+
+  Bounds middle;
+  middle.x = 0;
+  middle.y = 100;
+  middle.width = 240;
+  middle.height = 24;
+  TEST_ASSERT_TRUE(AnyAnimatedCompiledPrimitiveOverlaps(scene, testFrame(), middle));
+
+  ReleaseCompiledThemeSpec(scene);
+}
+
+using codexbar_display::updatenotice::Activate;
+using codexbar_display::updatenotice::CurrentPhase;
+using codexbar_display::updatenotice::Deactivate;
+using codexbar_display::updatenotice::Phase;
+using codexbar_display::updatenotice::Surface;
+using codexbar_display::updatenotice::Tick;
+using UpdateNoticeConfig = codexbar_display::updatenotice::Config;
+using UpdateNoticeState = codexbar_display::updatenotice::State;
+using UpdateNoticeTickResult = codexbar_display::updatenotice::TickResult;
+
+UpdateNoticeConfig testNoticeConfig() {
+  UpdateNoticeConfig config;
+  config.phaseToggleMs = 1500;
+  config.overlayVisibleMs = 10000;
+  config.overlayHiddenMs = 60000;
+  return config;
+}
+
+void testUpdateNoticeLabelSurfaceStaysVisibleAndRotatesPhases() {
+  UpdateNoticeState state;
+  UpdateNoticeTickResult result = Activate(state, Surface::Label, 1000);
+  TEST_ASSERT_TRUE(result.draw);
+  TEST_ASSERT_FALSE(result.restore);
+  TEST_ASSERT_TRUE(state.visible);
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(Phase::Provider), static_cast<int>(CurrentPhase(state)));
+
+  result = Tick(state, testNoticeConfig(), 2000);
+  TEST_ASSERT_FALSE(result.draw);
+
+  result = Tick(state, testNoticeConfig(), 2500);
+  TEST_ASSERT_TRUE(result.draw);
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(Phase::Available), static_cast<int>(CurrentPhase(state)));
+
+  result = Tick(state, testNoticeConfig(), 4000);
+  TEST_ASSERT_TRUE(result.draw);
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(Phase::MacApp), static_cast<int>(CurrentPhase(state)));
+
+  result = Tick(state, testNoticeConfig(), 5500);
+  TEST_ASSERT_TRUE(result.draw);
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(Phase::Provider), static_cast<int>(CurrentPhase(state)));
+
+  // The label surface never leaves the screen while the update is available.
+  for (unsigned long at = 6000; at < 200000; at += 700) {
+    result = Tick(state, testNoticeConfig(), at);
+    TEST_ASSERT_FALSE(result.restore);
+    TEST_ASSERT_TRUE(state.visible);
+  }
+}
+
+void testUpdateNoticeOverlaySurfaceDutyCyclesVisibility() {
+  UpdateNoticeState state;
+  UpdateNoticeTickResult result = Activate(state, Surface::Overlay, 0);
+  TEST_ASSERT_TRUE(result.draw);
+  TEST_ASSERT_TRUE(state.visible);
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(Phase::Available), static_cast<int>(CurrentPhase(state)));
+
+  // Two-phase rotation while the overlay window is visible.
+  result = Tick(state, testNoticeConfig(), 1500);
+  TEST_ASSERT_TRUE(result.draw);
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(Phase::MacApp), static_cast<int>(CurrentPhase(state)));
+  result = Tick(state, testNoticeConfig(), 3000);
+  TEST_ASSERT_TRUE(result.draw);
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(Phase::Available), static_cast<int>(CurrentPhase(state)));
+
+  // The visible window ends after overlayVisibleMs and asks for a restore.
+  result = Tick(state, testNoticeConfig(), 10000);
+  TEST_ASSERT_TRUE(result.restore);
+  TEST_ASSERT_FALSE(result.draw);
+  TEST_ASSERT_FALSE(state.visible);
+
+  // Hidden window: no draws until overlayHiddenMs elapses.
+  result = Tick(state, testNoticeConfig(), 40000);
+  TEST_ASSERT_FALSE(result.draw);
+  TEST_ASSERT_FALSE(result.restore);
+  TEST_ASSERT_FALSE(state.visible);
+
+  result = Tick(state, testNoticeConfig(), 70000);
+  TEST_ASSERT_TRUE(result.draw);
+  TEST_ASSERT_TRUE(state.visible);
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(Phase::Available), static_cast<int>(CurrentPhase(state)));
+}
+
+void testUpdateNoticeDeactivateRestoresOnlyWhenVisible() {
+  UpdateNoticeState state;
+  (void)Activate(state, Surface::Overlay, 0);
+  TEST_ASSERT_TRUE(state.visible);
+
+  UpdateNoticeTickResult result = Deactivate(state);
+  TEST_ASSERT_TRUE(result.restore);
+  TEST_ASSERT_FALSE(state.active);
+  TEST_ASSERT_FALSE(state.visible);
+
+  // Hidden overlay window: firmware became current while the bar was hidden.
+  (void)Activate(state, Surface::Overlay, 0);
+  (void)Tick(state, testNoticeConfig(), 10000);
+  TEST_ASSERT_FALSE(state.visible);
+  result = Deactivate(state);
+  TEST_ASSERT_FALSE(result.restore);
+  TEST_ASSERT_FALSE(state.active);
+}
+
+void testUpdateNoticeSurfaceChangeRestoresOldSurface() {
+  UpdateNoticeState state;
+  (void)Activate(state, Surface::Label, 0);
+  TEST_ASSERT_TRUE(state.visible);
+
+  // Theme switch: label binding disappeared, overlay takes over.
+  UpdateNoticeTickResult result = Activate(state, Surface::Overlay, 5000);
+  TEST_ASSERT_TRUE(result.restore);
+  TEST_ASSERT_TRUE(result.draw);
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(Surface::Overlay), static_cast<int>(state.surface));
+
+  // Re-activating with the same surface is a no-op.
+  result = Activate(state, Surface::Overlay, 6000);
+  TEST_ASSERT_FALSE(result.draw);
+  TEST_ASSERT_FALSE(result.restore);
+
+  // No surface at all (theme not renderable): notice leaves the screen.
+  result = Activate(state, Surface::None, 7000);
+  TEST_ASSERT_TRUE(result.restore);
+  TEST_ASSERT_FALSE(state.active);
 }
 
 void testRendersCompactCommandsAndBindings() {
@@ -1483,6 +1716,14 @@ int main() {
   RUN_TEST(testLabelBindingUsesProviderLabelWithoutUpdateNotice);
   RUN_TEST(testChangedLabelPassUsesSynchronizedUpdateNoticeText);
   RUN_TEST(testChangedLabelPassCanRestoreProviderText);
+  RUN_TEST(testRegionRepaintRedrawsOnlyOverlappingPrimitives);
+  RUN_TEST(testRegionRepaintSkipsAnimatedPrimitivesButReportsThem);
+  RUN_TEST(testRegionRepaintWithoutOverlapFillsBackgroundOnly);
+  RUN_TEST(testAnimatedOverlapQueryFindsGifOnlyInsideItsBounds);
+  RUN_TEST(testUpdateNoticeLabelSurfaceStaysVisibleAndRotatesPhases);
+  RUN_TEST(testUpdateNoticeOverlaySurfaceDutyCyclesVisibility);
+  RUN_TEST(testUpdateNoticeDeactivateRestoresOnlyWhenVisible);
+  RUN_TEST(testUpdateNoticeSurfaceChangeRestoresOldSurface);
   RUN_TEST(testRendersCompactCommandsAndBindings);
   RUN_TEST(testCompactTextWidthMapsToMaxWidthForAlignment);
   RUN_TEST(testRendersMulticolorRlePixelsAsFillRects);

--- a/firmware_shared/theme_spec_renderer_core.h
+++ b/firmware_shared/theme_spec_renderer_core.h
@@ -1331,6 +1331,66 @@ inline bool RenderCompiledThemeSpecAnimatedPrimitives(const CompiledThemeSpec& s
   return rendered;
 }
 
+inline bool RenderCompiledThemeSpecRegionPrimitives(
+    const CompiledThemeSpec& scene,
+    const FrameData& frame,
+    const Bounds& region,
+    Sink& sink,
+    const char** error = nullptr,
+    bool* skippedAnimatedOverlap = nullptr) {
+  if (error != nullptr) {
+    *error = "";
+  }
+  if (skippedAnimatedOverlap != nullptr) {
+    *skippedAnimatedOverlap = false;
+  }
+  if (scene.primitiveCount == 0) {
+    if (error != nullptr) {
+      *error = "empty_scene";
+    }
+    return false;
+  }
+  if (region.width <= 0 || region.height <= 0) {
+    if (error != nullptr) {
+      *error = "empty_region";
+    }
+    return false;
+  }
+
+  sink.PrimeBackground(scene.bgColor);
+  sink.BeginClip(region.x, region.y, region.width, region.height);
+  RectCommand background;
+  background.x = region.x;
+  background.y = region.y;
+  background.width = region.width;
+  background.height = region.height;
+  background.color = scene.bgColor;
+  sink.FillRect(background);
+
+  bool rendered = false;
+  for (size_t i = 0; i < scene.primitiveCount; ++i) {
+    Bounds primitiveBounds;
+    const CompiledPrimitive& primitive = scene.primitives[i];
+    if (CompiledPrimitiveBounds(primitive, frame, false, primitiveBounds) &&
+        BoundsOverlap(region, primitiveBounds)) {
+      if (CompiledPrimitiveIsAnimated(primitive, frame)) {
+        if (skippedAnimatedOverlap != nullptr) {
+          *skippedAnimatedOverlap = true;
+        }
+        rendered = true;
+        continue;
+      }
+      rendered = DrawCompiledPrimitive(primitive, frame, sink) || rendered;
+      RenderYield();
+    }
+  }
+  sink.EndClip();
+  if (!rendered && error != nullptr) {
+    *error = "no_overlap_rendered";
+  }
+  return rendered;
+}
+
 inline bool RenderCompiledThemeSpecChangedPrimitives(
     const CompiledThemeSpec& scene,
     const FrameData& frame,
@@ -1387,38 +1447,25 @@ inline bool RenderCompiledThemeSpecChangedPrimitives(
     return false;
   }
 
-  sink.PrimeBackground(scene.bgColor);
-  sink.BeginClip(dirty.x, dirty.y, dirty.width, dirty.height);
-  RectCommand background;
-  background.x = dirty.x;
-  background.y = dirty.y;
-  background.width = dirty.width;
-  background.height = dirty.height;
-  background.color = scene.bgColor;
-  sink.FillRect(background);
+  return RenderCompiledThemeSpecRegionPrimitives(scene, frame, dirty, sink, error, skippedAnimatedOverlap);
+}
 
-  bool rendered = false;
+inline bool AnyAnimatedCompiledPrimitiveOverlaps(
+    const CompiledThemeSpec& scene,
+    const FrameData& frame,
+    const Bounds& region) {
   for (size_t i = 0; i < scene.primitiveCount; ++i) {
-    Bounds primitiveBounds;
     const CompiledPrimitive& primitive = scene.primitives[i];
+    if (!CompiledPrimitiveIsAnimated(primitive, frame)) {
+      continue;
+    }
+    Bounds primitiveBounds;
     if (CompiledPrimitiveBounds(primitive, frame, false, primitiveBounds) &&
-        BoundsOverlap(dirty, primitiveBounds)) {
-      if (CompiledPrimitiveIsAnimated(primitive, frame)) {
-        if (skippedAnimatedOverlap != nullptr) {
-          *skippedAnimatedOverlap = true;
-        }
-        rendered = true;
-        continue;
-      }
-      rendered = DrawCompiledPrimitive(primitive, frame, sink) || rendered;
-      RenderYield();
+        BoundsOverlap(region, primitiveBounds)) {
+      return true;
     }
   }
-  sink.EndClip();
-  if (!rendered && error != nullptr) {
-    *error = "no_overlap_rendered";
-  }
-  return rendered;
+  return false;
 }
 
 }  // namespace themespec

--- a/firmware_shared/update_notice_policy.h
+++ b/firmware_shared/update_notice_policy.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace codexbar_display {
+namespace updatenotice {
+
+// Firmware update notices never trigger hardware writes. This policy only
+// decides when the customer-facing availability notice is visible and which
+// short text phase it shows; the VibeTV Mac App owns the actual update flow.
+enum class Surface : uint8_t {
+  None = 0,
+  // Theme has a label binding: the notice text replaces the label line and
+  // stays visible (rotating) while an update is available.
+  Label,
+  // Theme has no label binding: a top overlay bar is shown in bounded
+  // visible/hidden windows so custom themes stay mostly uncovered.
+  Overlay,
+};
+
+enum class Phase : uint8_t {
+  Provider = 0,
+  Available,
+  MacApp,
+};
+
+struct Config {
+  unsigned long phaseToggleMs = 1500UL;
+  unsigned long overlayVisibleMs = 10000UL;
+  unsigned long overlayHiddenMs = 60000UL;
+};
+
+struct State {
+  bool active = false;
+  bool visible = false;
+  Surface surface = Surface::None;
+  uint8_t phaseIndex = 0;
+  unsigned long phaseChangedAtMs = 0;
+  unsigned long windowChangedAtMs = 0;
+};
+
+struct TickResult {
+  // Redraw the notice with the current phase text.
+  bool draw = false;
+  // The notice left the screen; repaint the area it covered.
+  bool restore = false;
+};
+
+inline uint8_t PhaseCount(Surface surface) {
+  return surface == Surface::Label ? 3 : 2;
+}
+
+inline Phase CurrentPhase(const State& state) {
+  if (state.surface == Surface::Label) {
+    switch (state.phaseIndex % 3) {
+      case 0:
+        return Phase::Provider;
+      case 1:
+        return Phase::Available;
+      default:
+        return Phase::MacApp;
+    }
+  }
+  return (state.phaseIndex % 2) == 0 ? Phase::Available : Phase::MacApp;
+}
+
+inline TickResult Activate(State& state, Surface surface, unsigned long nowMs) {
+  TickResult result;
+  if (surface == Surface::None) {
+    if (state.visible) {
+      result.restore = true;
+    }
+    state = State{};
+    return result;
+  }
+  if (state.active && state.surface == surface) {
+    return result;
+  }
+  if (state.visible && state.surface != surface) {
+    result.restore = true;
+  }
+  state.active = true;
+  state.surface = surface;
+  state.visible = true;
+  state.phaseIndex = 0;
+  state.phaseChangedAtMs = nowMs;
+  state.windowChangedAtMs = nowMs;
+  result.draw = true;
+  return result;
+}
+
+inline TickResult Deactivate(State& state) {
+  TickResult result;
+  result.restore = state.visible;
+  state = State{};
+  return result;
+}
+
+inline TickResult Tick(State& state, const Config& config, unsigned long nowMs) {
+  TickResult result;
+  if (!state.active) {
+    return result;
+  }
+
+  if (state.surface == Surface::Overlay) {
+    if (state.visible &&
+        (nowMs - state.windowChangedAtMs) >= config.overlayVisibleMs) {
+      state.visible = false;
+      state.windowChangedAtMs = nowMs;
+      result.restore = true;
+      return result;
+    }
+    if (!state.visible) {
+      if ((nowMs - state.windowChangedAtMs) >= config.overlayHiddenMs) {
+        state.visible = true;
+        state.phaseIndex = 0;
+        state.phaseChangedAtMs = nowMs;
+        state.windowChangedAtMs = nowMs;
+        result.draw = true;
+      }
+      return result;
+    }
+  }
+
+  if (state.visible &&
+      (nowMs - state.phaseChangedAtMs) >= config.phaseToggleMs) {
+    state.phaseChangedAtMs = nowMs;
+    state.phaseIndex = static_cast<uint8_t>((state.phaseIndex + 1) % PhaseCount(state.surface));
+    result.draw = true;
+  }
+  return result;
+}
+
+}  // namespace updatenotice
+}  // namespace codexbar_display

--- a/known-good/firmware-manifest.template.json
+++ b/known-good/firmware-manifest.template.json
@@ -8,7 +8,7 @@
       "board": "esp8266-smalltv-st7789",
       "firmwareVersion": "X.Y.Z",
       "severity": "recommended",
-      "message": "Firmware update available. Open app.vibetv.shop.",
+      "message": "Firmware update available. Open the VibeTV Mac App.",
       "asset": "codexbar-display-firmware-esp8266_smalltv_st7789-vX.Y.Z.bin",
       "firmwareUrl": "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/vX.Y.Z/codexbar-display-firmware-esp8266_smalltv_st7789-vX.Y.Z.bin",
       "sha256": "<filled-by-release-workflow>"
@@ -18,7 +18,7 @@
       "board": "esp32-lilygo-t-display-s3",
       "firmwareVersion": "X.Y.Z",
       "severity": "recommended",
-      "message": "Firmware update available. Open app.vibetv.shop.",
+      "message": "Firmware update available. Open the VibeTV Mac App.",
       "asset": "codexbar-display-firmware-lilygo_t_display_s3-vX.Y.Z.bin",
       "firmwareUrl": "https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/vX.Y.Z/codexbar-display-firmware-lilygo_t_display_s3-vX.Y.Z.bin",
       "sha256": "<filled-by-release-workflow>"

--- a/release/firmware-versions.json
+++ b/release/firmware-versions.json
@@ -7,14 +7,14 @@
       "board": "esp8266-smalltv-st7789",
       "firmwareVersion": "1.0.37",
       "severity": "recommended",
-      "message": "Firmware update available. Open app.vibetv.shop."
+      "message": "Firmware update available. Open the VibeTV Mac App."
     },
     {
       "firmwareEnv": "lilygo_t_display_s3",
       "board": "esp32-lilygo-t-display-s3",
       "firmwareVersion": "1.0.35",
       "severity": "recommended",
-      "message": "Firmware update available. Open app.vibetv.shop."
+      "message": "Firmware update available. Open the VibeTV Mac App."
     }
   ]
 }

--- a/scripts/test-control-center-release-workflow.sh
+++ b/scripts/test-control-center-release-workflow.sh
@@ -344,6 +344,17 @@ main() {
   assert_contains "$release_installer" 'run_quiet "$BIN_PATH" install-update' \
     "installer must hide firmware update command output by default"
 
+  # Firmware update copy reaches customers through the manifest message, so it
+  # must name the VibeTV Mac App instead of sending them to a hosted URL.
+  local firmware_versions
+  firmware_versions="$(cat "${ROOT}/release/firmware-versions.json")"
+  assert_not_contains "$firmware_versions" "vibetv.shop" \
+    "firmware update messages must not send customers to a hosted URL"
+  assert_contains "$firmware_versions" "VibeTV Mac App" \
+    "firmware update messages must name the VibeTV Mac App"
+  assert_not_contains "$(grep '"message"' "$WORKFLOW")" "vibetv.shop" \
+    "release workflow firmware message fallback must not send customers to a hosted URL"
+
   printf 'control-center release workflow test passed\n'
 }
 


### PR DESCRIPTION
Closes #78

## Was sich ändert

Firmware-Update-Hinweise erscheinen jetzt auf **allen** aktiven Themes, nicht nur auf solchen mit `label`-Binding, und die Copy verweist ausschließlich auf die **VibeTV Mac App** — `app.vibetv.shop` ist aus der Update-Notice entfernt.

Zwei Darstellungs-Oberflächen, automatisch nach Theme gewählt:

| Theme | Oberfläche | Verhalten |
|---|---|---|
| mit `label`-Binding | Label-Zeile | dauerhaft sichtbar, 3-Phasen-Rotation alle 1,5s: Provider → „Update available" → „Open VibeTV Mac App" |
| ohne `label`-Binding | 24px-Overlay-Leiste am Rand | 30s sichtbar / 60s verborgen, 2-Phasen-Rotation |

Die Overlay-Platzierung meidet Bereiche, die von animierten GIF/Sprite-Primitiven neu gezeichnet werden (oben bevorzugt, unten als Fallback, sonst keine Overlay-Notice). Damit kämpft die Leiste nie gegen einen 20ms-Animations-Tick.

## Kein Full-Screen-Flicker

Neu ist `RenderCompiledThemeSpecRegionPrimitives` im Shared Core: Beim Ausblenden wird nur der abgedeckte Streifen aus der gecachten Szene neu gezeichnet. Vorher erzwang der Clear-Pfad ein `screenDirty = true`, also einen kompletten Redraw — genau der Flicker-Modus aus der Issue-Diskussion.

Die Anzeige der Notice löst **keinen** Firmware-Write aus; der eigentliche Update-Flow bleibt vollständig bei der Mac App.

## Update-Copy außerhalb des Displays

Die Manifest-`message` ist ebenfalls kundensichtbar: Der Companion-Daemon liest sie aus `firmware-manifest.json`, und sowohl `/v1/firmware/latest` als auch die gehostete Firmware-Route reichen sie unverändert an den Updates-Screen weiter. Dort stand weiterhin „Open app.vibetv.shop.".

Da Issue #78 unter Scope die VibeTV Mac App als einzige genannte Update-Destination verlangt, sind `release/firmware-versions.json`, der Workflow-Fallback und das `known-good`-Template mit umgestellt, abgesichert durch eine neue Prüfung im Release-Workflow-Test.

Das Display war davon nie betroffen — die Firmware parst `update.message` gar nicht. Der Sparkle-Appcast-Link und die Mac-App-Download-Hinweise bleiben unverändert, weil Kunden die App dort tatsächlich beziehen.

## Tests

Die Show/Hide-Logik liegt als reiner Header in `firmware_shared/update_notice_policy.h` und ist damit ohne Hardware testbar. 8 neue native Tests (Duty-Cycle, Phasen-Rotation, Restore bei Deaktivierung und Oberflächenwechsel, Region-Repaint, Animations-Overlap-Query); insgesamt 56/56 grün.

Flash 44,5% (Budget 46%), RAM 52,1% (Budget 82%).

## Hardware-Smoke

Durchgeführt auf `esp8266-smalltv-st7789` (deviceId 9517433) mit Test-Build `1.0.38-pr78.x`, Display-Stream während des Flashens pausiert. Gerät steht danach wieder auf Release `1.0.37`.

- **Stored ThemeSpec mit Label** (`claude-creature`): 3-Phasen-Rotation in der Kopfzeile, Creature-Animation lief ununterbrochen weiter. `fullCount` konstant, `lastKind: update_notice`.
- **ThemeSpec ohne Label** (Test-Theme): Overlay-Leiste oben, Duty-Cycle in den Health-Countern verifiziert — ~20 Draws über 30s sichtbar, danach ~60s ohne einen einzigen Draw.
- **Firmware wird aktuell** (`update.available:false`): Notice verschwindet auf beiden Oberflächen sofort und bleibt über mehr als einen vollen Zyklus weg. `fullCount` blieb dabei konstant, also Region-Repaint statt Full-Redraw.

Das ursprüngliche 10s-Sichtfenster war am echten Gerät zu kurz zum Lesen und wurde nach dem Smoke-Test auf 30s erhöht.

## Hinweis zum Rollout

Die Copy-Änderung wirkt auf **künftige** Releases. Das aktuell veröffentlichte Manifest (v1.0.49) trägt noch den alten Text, bis das nächste Release gebaut wird.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
