### PR TITLE
CODEX: Add manual VibeTV IP setup for large networks

### DIFF
--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -352,7 +352,20 @@ async function main() {
       appContext.appUrl,
     );
     await testLocalWifiSetupRescansAfterNoResults(browser, appContext.appUrl);
-    await testLocalWifiSearchHidesFallbackWhileSearching(
+    await testLocalWifiSearchOffersImmediateManualEntry(
+      browser,
+      appContext.appUrl,
+    );
+    await testManualVibeTVTargetValidationErrors(browser, appContext.appUrl);
+    await testManualVibeTVTargetRejectsUnreachableAddress(
+      browser,
+      appContext.appUrl,
+    );
+    await testManualVibeTVTargetRejectsIdentityChange(
+      browser,
+      appContext.appUrl,
+    );
+    await testManualVibeTVTargetShowsPairingRecovery(
       browser,
       appContext.appUrl,
     );
@@ -1267,40 +1280,183 @@ async function testOverviewKeepsTransientConnectionCustomerFriendly(
   await page.close();
 }
 
-async function testLocalWifiSearchHidesFallbackWhileSearching(browser, appUrl) {
+async function testLocalWifiSearchOffersImmediateManualEntry(browser, appUrl) {
   const page = await newCustomerPage(browser, appUrl, { viewport });
   const installRequests = [];
+  const requests = [];
   await routeCompanionOnline(page, installRequests, () => {}, {
     device: { connected: false, paired: false },
     searchDelayMs: 750,
     searchDevices: [],
+    onSearch: (_device, postData) => {
+      const target = parseJSON(postData)?.target;
+      return target
+        ? [
+            {
+              target,
+              deviceId: "manual-large-network-device",
+              board: companionDevice.board,
+              firmware: companionDevice.firmware,
+              networkMode: "station",
+              known: false,
+              active: false,
+            },
+          ]
+        : [];
+    },
+    onRequest: (pathname, method, postData) =>
+      requests.push(`${method} ${pathname} ${postData}`),
   });
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page.getByRole("heading", { name: "Looking for your VibeTV" }).waitFor({
     timeout: 10_000,
   });
-  assert(
-    (await page.getByLabel("VibeTV address").count()) === 0,
-    "Manual address must stay hidden while search is running",
-  );
-  assert(
-    (await page.getByRole("button", { name: "VibeTV is on WiFi" }).count()) ===
-      0,
-    "Search must not show a second WiFi search button",
-  );
-  await page.getByRole("button", { name: "VibeTV is on WiFi" }).waitFor({
+  await page.getByRole("button", { name: "Enter VibeTV IP" }).click();
+  await page.getByLabel("VibeTV address").fill("172.30.12.34");
+  await page.getByRole("button", { name: "Connect VibeTV" }).click();
+  await page.getByRole("button", { name: "Overview", exact: true }).waitFor({
     timeout: 10_000,
   });
-  await page.getByText("Plug VibeTV into power.").waitFor();
-  await page.getByText("Wait until VibeTV shows VibeTV-Setup.").waitFor();
-  await page.getByText("192.168.4.1").waitFor();
+  assert(
+    requests.filter((request) => request.startsWith("POST /v1/device/select ")).length ===
+      1,
+    `Manual entry must validate then select exactly once, got ${requests}`,
+  );
+  assert(
+    requests.filter((request) => request.startsWith("POST /v1/device/search ")).length >=
+      2,
+    `Manual validation must use a targeted read-only search alongside automatic discovery, got ${requests}`,
+  );
+  assertNoInstallRequests(installRequests);
+  await page.close();
+}
+
+async function testManualVibeTVTargetValidationErrors(browser, appUrl) {
+  const page = await newCustomerPage(browser, appUrl, { viewport });
+  let targetedSearches = 0;
+  await routeCompanionOnline(page, [], () => {}, {
+    device: { connected: false, paired: false },
+    searchDelayMs: 750,
+    searchDevices: [],
+    onSearch: (_device, postData) => {
+      if (parseJSON(postData)?.target) targetedSearches += 1;
+      return [];
+    },
+  });
+
+  await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+  await page.getByRole("button", { name: "Enter VibeTV IP" }).click();
+  await page.getByLabel("VibeTV address").fill("172.30.12.999");
+  await page.getByRole("button", { name: "Connect VibeTV" }).click();
+  await page.locator("#startup-device-target-error").waitFor();
+  assert(
+    targetedSearches === 0,
+    "Invalid IPv4 input must be rejected before any network request",
+  );
+  await page.close();
+}
+
+async function testManualVibeTVTargetRejectsUnreachableAddress(browser, appUrl) {
+  const page = await newCustomerPage(browser, appUrl, { viewport });
+  await routeCompanionOnline(page, [], () => {}, {
+    device: { connected: false, paired: false },
+    searchDelayMs: 750,
+    searchDevices: [],
+    onSearch: () => [],
+  });
+
+  await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+  await page.getByRole("button", { name: "Enter VibeTV IP" }).click();
+  await page.getByLabel("VibeTV address").fill("172.30.12.99");
+  await page.getByRole("button", { name: "Connect VibeTV" }).click();
+  await page
+    .getByText("No VibeTV answered at that IP address.", { exact: true })
+    .waitFor({ timeout: 10_000 });
+  await page.close();
+}
+
+async function testManualVibeTVTargetRejectsIdentityChange(browser, appUrl) {
+  const page = await newCustomerPage(browser, appUrl, { viewport });
+  await routeCompanionOnline(page, [], () => {}, {
+    device: { connected: false, paired: false },
+    searchDelayMs: 750,
+    searchDevices: [],
+    onSearch: (_device, postData) => {
+      const target = parseJSON(postData)?.target;
+      return target
+        ? [
+            {
+              target,
+              deviceId: "hello-identity",
+              networkMode: "station",
+              known: false,
+              active: false,
+            },
+          ]
+        : [];
+    },
+    selectError: {
+      status: 409,
+      code: "device_identity_changed",
+      message: "That address answered as a different VibeTV.",
+      nextAction: "Check the IP on the VibeTV screen, then try again.",
+    },
+  });
+
+  await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+  await page.getByRole("button", { name: "Enter VibeTV IP" }).click();
+  await page.getByLabel("VibeTV address").fill("172.30.12.34");
+  await page.getByRole("button", { name: "Connect VibeTV" }).click();
+  await page
+    .getByText("That address answered as a different VibeTV.", { exact: true })
+    .waitFor({ timeout: 10_000 });
   assert(
     (await page.getByRole("navigation", { name: "Control Center" }).count()) ===
       0,
-    "The WiFi guide must stay inside the full-screen startup experience",
+    "A changed VibeTV identity must not be accepted",
   );
-  assertNoInstallRequests(installRequests);
+  await page.close();
+}
+
+async function testManualVibeTVTargetShowsPairingRecovery(browser, appUrl) {
+  const page = await newCustomerPage(browser, appUrl, { viewport });
+  await routeCompanionOnline(page, [], () => {}, {
+    device: { connected: false, paired: false },
+    searchDelayMs: 750,
+    searchDevices: [],
+    onSearch: (_device, postData) => {
+      const target = parseJSON(postData)?.target;
+      return target
+        ? [
+            {
+              target,
+              deviceId: "pairing-required-device",
+              networkMode: "station",
+              known: false,
+              active: false,
+            },
+          ]
+        : [];
+    },
+    selectError: {
+      status: 409,
+      code: "pairing_window_closed",
+      message: "VibeTV is not accepting a new pairing.",
+      nextAction: "Restart VibeTV to reopen pairing.",
+    },
+  });
+
+  await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+  await page.getByRole("button", { name: "Enter VibeTV IP" }).click();
+  await page.getByLabel("VibeTV address").fill("172.30.12.34");
+  await page.getByRole("button", { name: "Connect VibeTV" }).click();
+  await page
+    .getByText("Pairing needs physical recovery.", { exact: true })
+    .waitFor({ timeout: 10_000 });
+  await page
+    .getByText(/Unplug VibeTV during early boot three times in a row/)
+    .waitFor();
   await page.close();
 }
 
@@ -5339,7 +5495,11 @@ async function routeCompanionOnline(
   let currentProviderSetup = providerSetup;
   const handler = async (route) => {
     const pathname = companionPath(route);
-    onRequest(pathname, route.request().method());
+    onRequest(
+      pathname,
+      route.request().method(),
+      route.request().postData() || "",
+    );
     if (pathname === "/v1/providers/retry") {
       currentProviderSetup =
         onProviderRetry?.(currentProviderSetup) || currentProviderSetup;
@@ -5692,7 +5852,9 @@ async function routeCompanionOnline(
       return;
     }
     if (pathname === "/v1/device/search") {
-      if (searchDelayMs > 0) {
+      const postData = route.request().postData() || "";
+      const requestedTarget = parseJSON(postData)?.target;
+      if (searchDelayMs > 0 && !requestedTarget) {
         await new Promise((resolve) => setTimeout(resolve, searchDelayMs));
       }
       if (searchError) {
@@ -5703,7 +5865,7 @@ async function routeCompanionOnline(
         });
         return;
       }
-      const devices = onSearch?.(currentDevice) ||
+      const devices = onSearch?.(currentDevice, postData) ||
         searchDevices || [
           {
             target: currentDevice?.target || companionDevice.target,
@@ -5724,16 +5886,21 @@ async function routeCompanionOnline(
     }
     if (pathname === "/v1/device/select") {
       if (selectError) {
+        const error =
+          typeof selectError === "object"
+            ? selectError
+            : {
+                status: 502,
+                code: "device_selection_failed",
+                message: "The selected VibeTV could not be connected.",
+                nextAction: "Keep both VibeTVs powered on, then try again.",
+              };
         await route.fulfill({
-          status: 502,
+          status: error.status || 502,
           contentType: "application/json",
           body: JSON.stringify({
             ok: false,
-            error: {
-              code: "device_selection_failed",
-              message: "The selected VibeTV could not be connected.",
-              nextAction: "Keep both VibeTVs powered on, then try again.",
-            },
+            error,
           }),
         });
         return;

--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -739,7 +739,7 @@ async function testSetupDoesNotRequestBrowserPermission(browser, appUrl) {
     "Mac App errors should stay hidden before the customer checks the Mac App",
   );
   await page
-    .getByRole("button", { name: "VibeTV is on WiFi" })
+    .getByRole("button", { name: "Scan WiFi again" })
     .waitFor({ timeout: 10_000 });
   await page.getByText("Plug VibeTV into power.").waitFor({ timeout: 10_000 });
   await page
@@ -819,7 +819,7 @@ async function testLocalWifiVerificationFailureStaysInSetup(browser, appUrl) {
   });
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
-  await page.getByRole("heading", { name: "VibeTV was not found" }).waitFor({
+  await page.getByRole("heading", { name: "We couldn't find your VibeTV" }).waitFor({
     timeout: 10_000,
   });
   await page.getByRole("button", { name: "Search again" }).waitFor({
@@ -870,7 +870,7 @@ async function testLocalWifiVerificationWithoutFrameOpensOverview(
   });
   assert(
     (await page
-      .getByRole("heading", { name: "VibeTV was not found" })
+      .getByRole("heading", { name: "We couldn't find your VibeTV" })
       .count()) === 0,
     "A paired VibeTV waiting for usage must not be reported as missing",
   );
@@ -919,13 +919,15 @@ async function testLocalWifiSetupRescansAfterNoResults(browser, appUrl) {
   });
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
-  await page.getByRole("heading", { name: "Connect VibeTV to WiFi" }).waitFor();
+  await page
+    .getByRole("heading", { name: "We couldn't find your VibeTV" })
+    .waitFor();
   assert(
-    (await page.getByLabel("VibeTV address").count()) === 0,
-    "No-result setup must show the WiFi guide instead of a manual address",
+    (await page.getByLabel("VibeTV address").count()) === 1,
+    "No-result setup must show the manual VibeTV address immediately",
   );
   assert(searchRequests === 1, "Fresh setup should search automatically once");
-  await page.getByRole("button", { name: "VibeTV is on WiFi" }).click();
+  await page.getByRole("button", { name: "Scan WiFi again" }).click();
   await page.getByRole("heading", { name: "Looking for your VibeTV" }).waitFor({
     timeout: 10_000,
   });
@@ -1043,12 +1045,58 @@ async function testMissingVibeTVOffersRetry(browser, appUrl) {
   });
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
-  await page.getByRole("heading", { name: "Connect VibeTV to WiFi" }).waitFor({
+  await page
+    .getByRole("heading", { name: "We couldn't find your VibeTV" })
+    .waitFor({ timeout: 10_000 });
+  await page
+    .getByText("Or enter the IP address shown on your VibeTV screen:", {
+      exact: true,
+    })
+    .waitFor({ timeout: 10_000 });
+  await page.getByLabel("VibeTV address").waitFor({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Scan WiFi again" }).waitFor({
     timeout: 10_000,
   });
-  await page.getByRole("button", { name: "VibeTV is on WiFi" }).waitFor({
-    timeout: 10_000,
+  const notFoundInformationOrderIsCorrect = await page.evaluate(() => {
+    const heading = [...document.querySelectorAll("h1")].find(
+      (element) => element.textContent?.trim() === "We couldn't find your VibeTV",
+    );
+    const firstSetupStep = [...document.querySelectorAll("li")].find((element) =>
+      element.textContent?.trim().startsWith("1. Plug VibeTV into power."),
+    );
+    const scanButton = [...document.querySelectorAll("button")].find(
+      (element) => element.textContent?.trim() === "Scan WiFi again",
+    );
+    const manualPrompt = [...document.querySelectorAll("p")].find(
+      (element) =>
+        element.textContent?.trim() ===
+        "Or enter the IP address shown on your VibeTV screen:",
+    );
+    const input = document.querySelector("#startup-device-target");
+    const precedes = (first, second) =>
+      Boolean(
+        first &&
+          second &&
+          first.compareDocumentPosition(second) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+      );
+
+    return (
+      precedes(heading, firstSetupStep) &&
+      precedes(firstSetupStep, scanButton) &&
+      precedes(scanButton, manualPrompt) &&
+      precedes(manualPrompt, input)
+    );
   });
+  assert(
+    notFoundInformationOrderIsCorrect,
+    "The no-result screen must show WiFi setup, rescan, then manual IP entry",
+  );
+  assert(
+    (await page.getByRole("button", { name: "VibeTV is on WiFi" }).count()) ===
+      0,
+    "The no-result screen must name the rescan action directly",
+  );
   assert(
     (await page.getByRole("button", { name: "Not now" }).count()) === 0,
     "The not-found screen must only offer another search",
@@ -1312,7 +1360,29 @@ async function testLocalWifiSearchOffersImmediateManualEntry(browser, appUrl) {
   await page.getByRole("heading", { name: "Looking for your VibeTV" }).waitFor({
     timeout: 10_000,
   });
-  await page.getByRole("button", { name: "Enter VibeTV IP" }).click();
+  await page
+    .getByText("Or enter the IP address shown on your VibeTV screen:", {
+      exact: true,
+    })
+    .waitFor();
+  assert(
+    (await page.getByRole("button", { name: "Enter VibeTV IP" }).count()) === 0,
+    "Manual IP entry must not be hidden behind another button",
+  );
+  const searchStatusPrecedesInput = await page.evaluate(() => {
+    const status = document.querySelector('[role="status"]');
+    const input = document.querySelector("#startup-device-target");
+    return Boolean(
+      status &&
+        input &&
+        status.compareDocumentPosition(input) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+  assert(
+    searchStatusPrecedesInput,
+    "The automatic-search spinner must appear before manual IP entry",
+  );
   await page.getByLabel("VibeTV address").fill("172.30.12.34");
   await page.getByRole("button", { name: "Connect VibeTV" }).click();
   await page.getByRole("button", { name: "Overview", exact: true }).waitFor({
@@ -1346,7 +1416,6 @@ async function testManualVibeTVTargetValidationErrors(browser, appUrl) {
   });
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
-  await page.getByRole("button", { name: "Enter VibeTV IP" }).click();
   await page.getByLabel("VibeTV address").fill("172.30.12.999");
   await page.getByRole("button", { name: "Connect VibeTV" }).click();
   await page.locator("#startup-device-target-error").waitFor();
@@ -1367,7 +1436,6 @@ async function testManualVibeTVTargetRejectsUnreachableAddress(browser, appUrl) 
   });
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
-  await page.getByRole("button", { name: "Enter VibeTV IP" }).click();
   await page.getByLabel("VibeTV address").fill("172.30.12.99");
   await page.getByRole("button", { name: "Connect VibeTV" }).click();
   await page
@@ -1405,7 +1473,6 @@ async function testManualVibeTVTargetRejectsIdentityChange(browser, appUrl) {
   });
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
-  await page.getByRole("button", { name: "Enter VibeTV IP" }).click();
   await page.getByLabel("VibeTV address").fill("172.30.12.34");
   await page.getByRole("button", { name: "Connect VibeTV" }).click();
   await page
@@ -1448,7 +1515,6 @@ async function testManualVibeTVTargetShowsPairingRecovery(browser, appUrl) {
   });
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
-  await page.getByRole("button", { name: "Enter VibeTV IP" }).click();
   await page.getByLabel("VibeTV address").fill("172.30.12.34");
   await page.getByRole("button", { name: "Connect VibeTV" }).click();
   await page
@@ -1493,7 +1559,7 @@ async function testOfflineActiveDeviceIgnoresOtherDevices(browser, appUrl) {
   });
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
-  await page.getByRole("heading", { name: "VibeTV was not found" }).waitFor({
+  await page.getByRole("heading", { name: "We couldn't find your VibeTV" }).waitFor({
     timeout: 10_000,
   });
   assert(
@@ -1509,7 +1575,7 @@ async function testOfflineActiveDeviceIgnoresOtherDevices(browser, appUrl) {
   );
   await page
     .getByText(
-      "Make sure VibeTV and this Mac are on the same WiFi, then search again.",
+      "Please enter the IP address shown on your VibeTV screen below.",
     )
     .waitFor();
   assert(
@@ -1623,7 +1689,7 @@ async function testLegacyTargetDoesNotAutoconnectDiscoveredIdentity(
   });
 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
-  await page.getByRole("heading", { name: "VibeTV was not found" }).waitFor({
+  await page.getByRole("heading", { name: "We couldn't find your VibeTV" }).waitFor({
     timeout: 10_000,
   });
   assert(
@@ -1943,7 +2009,7 @@ async function testHostedEntryShowsMacAppDownload(
     timeout: 10_000,
   });
   assert(
-    (await page.getByRole("button", { name: "VibeTV is on WiFi" }).count()) ===
+    (await page.getByRole("button", { name: "Scan WiFi again" }).count()) ===
       0,
     "Hosted entry must not start the VibeTV WiFi flow",
   );
@@ -2050,7 +2116,7 @@ async function testHostedPriorVisitStillShowsMacAppDownload(
     await assertNoDmgDownloadActions(page);
   }
   assert(
-    (await page.getByRole("button", { name: "VibeTV is on WiFi" }).count()) ===
+    (await page.getByRole("button", { name: "Scan WiFi again" }).count()) ===
       0,
     "A prior hosted visit must not own device onboarding",
   );
@@ -2090,10 +2156,10 @@ async function testLocalFreshAppSearchesBeforeWifiSetup(browser, appUrl) {
       .count()) === 0,
     "Fresh local onboarding must never show the old Setup screen",
   );
-  await page.getByRole("heading", { name: "Connect VibeTV to WiFi" }).waitFor({
+  await page.getByRole("heading", { name: "We couldn't find your VibeTV" }).waitFor({
     timeout: 10_000,
   });
-  await page.getByRole("button", { name: "VibeTV is on WiFi" }).waitFor({
+  await page.getByRole("button", { name: "Scan WiFi again" }).waitFor({
     timeout: 10_000,
   });
   assert(
@@ -2111,11 +2177,11 @@ async function testLocalFreshAppSearchesBeforeWifiSetup(browser, appUrl) {
     searchRequests === 1,
     "Fresh local onboarding must search automatically",
   );
-  await page.getByRole("button", { name: "VibeTV is on WiFi" }).click();
+  await page.getByRole("button", { name: "Scan WiFi again" }).click();
   await page.getByRole("heading", { name: "Looking for your VibeTV" }).waitFor({
     timeout: 10_000,
   });
-  await page.getByRole("heading", { name: "Connect VibeTV to WiFi" }).waitFor({
+  await page.getByRole("heading", { name: "We couldn't find your VibeTV" }).waitFor({
     timeout: 10_000,
   });
   assert(
@@ -2206,7 +2272,9 @@ async function testConfiguredDeviceShowsReconnectingWithoutSetup(
       0,
     "Reconnect and search must finish before Overview or Setup is rendered",
   );
-  await page.getByRole("heading", { name: "VibeTV was not found" }).waitFor();
+  await page
+    .getByRole("heading", { name: "We couldn't find your VibeTV" })
+    .waitFor();
   await page.getByRole("button", { name: "Open Control Center" }).waitFor();
   assert(
     repairRequests.length === 0,
@@ -2366,7 +2434,7 @@ async function testLocalExistingSetupOpensOverviewWithoutRepair(
     `Existing healthy setup must not write or repair on open, got ${JSON.stringify(repairRequests)}`,
   );
   assert(
-    (await page.getByRole("button", { name: "VibeTV is on WiFi" }).count()) ===
+    (await page.getByRole("button", { name: "Scan WiFi again" }).count()) ===
       0 &&
       (await page.getByRole("link", { name: "Download Mac App" }).count()) ===
         0,
@@ -2464,7 +2532,7 @@ async function testInstallThemeLinkStaysOnSetupWhenThemeLibraryLocked(
   await assertThemeLibraryLockedBehindSetup(page);
   await assertNoSetupJargon(page);
   await assertNoDmgDownloadActions(page);
-  await page.getByRole("button", { name: "VibeTV is on WiFi" }).click();
+  await page.getByRole("button", { name: "Scan WiFi again" }).click();
   await assertNoDmgDownloadActions(page);
 
   assert(
@@ -5008,7 +5076,7 @@ async function testUnpairedThemeDeepLinkWaitsForWifiConfirmation(
     timeout: 10_000,
   });
   assert(
-    (await page.getByRole("button", { name: "VibeTV is on WiFi" }).count()) ===
+    (await page.getByRole("button", { name: "Scan WiFi again" }).count()) ===
       0,
     "A VibeTV found by the startup scan must not show the no-results WiFi guide",
   );

--- a/apps/control-center/src/components/control-center-app.tsx
+++ b/apps/control-center/src/components/control-center-app.tsx
@@ -263,6 +263,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
     useState<SupportDiagnostics | null>(null);
   const hasEnteredControlCenterRef = useRef(false);
   const setupGenerationRef = useRef(0);
+  const deviceSearchAttemptRef = useRef(0);
   const didRunInitialConnectionCheck = useRef(false);
   const didRunAutomaticDeviceSearch = useRef(false);
   const didRunAutoDisplayReload = useRef(false);
@@ -1253,6 +1254,10 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
   const searchAndConnect = useCallback(
     async (mode: DeviceSearchMode = "onboarding") => {
       const setupGeneration = setupGenerationRef.current;
+      const searchAttempt = ++deviceSearchAttemptRef.current;
+      const searchIsCurrent = () =>
+        setupGeneration === setupGenerationRef.current &&
+        searchAttempt === deviceSearchAttemptRef.current;
       setBusyAction("search");
       setDeviceCandidates([]);
       setDeviceSearchState("searching");
@@ -1263,7 +1268,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
           { method: "POST" },
           { timeoutMs: DEVICE_SEARCH_REQUEST_TIMEOUT_MS },
         );
-        if (setupGeneration !== setupGenerationRef.current) {
+        if (!searchIsCurrent()) {
           return;
         }
         const candidates = (payload.devices || []).filter(
@@ -1290,7 +1295,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
             undefined,
             { preserveLastError: true },
           );
-          if (setupGeneration !== setupGenerationRef.current) {
+          if (!searchIsCurrent()) {
             return;
           }
           if (
@@ -1313,7 +1318,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
           });
           if (
             outcome === "stale" ||
-            setupGeneration !== setupGenerationRef.current
+            !searchIsCurrent()
           ) {
             return;
           }
@@ -1337,7 +1342,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
         setDeviceSearchState("not-found");
         setDeviceState("offline");
       } catch (error) {
-        if (setupGeneration !== setupGenerationRef.current) {
+        if (!searchIsCurrent()) {
           return;
         }
         const normalized = normalizeCaughtError(
@@ -1356,7 +1361,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
           setLastError(normalized);
         }
       } finally {
-        if (setupGeneration === setupGenerationRef.current) {
+        if (searchIsCurrent()) {
           setBusyAction(null);
         }
       }
@@ -1445,6 +1450,70 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
       }
     },
     [addEvent, loadSettings, mergeDevice, providerSetup, runCompanion],
+  );
+
+  const connectManualTarget = useCallback(
+    async (targetOverride: string) => {
+      const setupGeneration = setupGenerationRef.current;
+      const searchAttempt = ++deviceSearchAttemptRef.current;
+      const searchIsCurrent = () =>
+        setupGeneration === setupGenerationRef.current &&
+        searchAttempt === deviceSearchAttemptRef.current;
+      const target = normalizeDeviceTarget(targetOverride);
+      setBusyAction("manual-target");
+      setDeviceCandidates([]);
+      setDeviceSearchState("not-found");
+      setLastError(null);
+      try {
+        const payload = await runCompanion<{ devices?: DeviceCandidate[] }>(
+          "/v1/device/search",
+          {
+            method: "POST",
+            body: JSON.stringify({ target }),
+          },
+          { timeoutMs: DEVICE_SEARCH_REQUEST_TIMEOUT_MS },
+        );
+        if (!searchIsCurrent()) {
+          return;
+        }
+        const candidate = (payload.devices || []).find(
+          (entry) =>
+            entry.networkMode !== "setup" &&
+            Boolean(entry.deviceId?.trim()) &&
+            normalizeDeviceTarget(entry.target) === target,
+        );
+        if (!candidate) {
+          setLastError({
+            code: "device_not_found",
+            message: "No VibeTV answered at that IP address.",
+            nextAction:
+              "Check the IP address shown on the VibeTV screen, then try again.",
+          });
+          return;
+        }
+        await selectAndConnectDevice(candidate);
+      } catch (error) {
+        if (!searchIsCurrent()) {
+          return;
+        }
+        const normalized = normalizeCaughtError(
+          error,
+          "That IP address did not answer as a VibeTV.",
+        );
+        setLastError(normalized);
+        setDeviceSearchState("not-found");
+        addEvent({
+          label: "Manual VibeTV connection failed",
+          detail: normalized.nextAction,
+          tone: "attention",
+        });
+      } finally {
+        if (searchIsCurrent()) {
+          setBusyAction(null);
+        }
+      }
+    },
+    [addEvent, runCompanion, selectAndConnectDevice],
   );
 
   useEffect(() => {
@@ -2687,7 +2756,9 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
       }}
       onRepairConnection={(targetOverride) => {
         didRunSetupVerification.current = true;
-        repairConnection({ targetOverride });
+        if (targetOverride) {
+          void connectManualTarget(targetOverride);
+        }
       }}
       onResetSetup={resetSetup}
       onOpenCodexBar={() => runProviderAction("open-codexbar")}
@@ -2749,6 +2820,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
         diagnostics={supportDiagnostics}
         deviceCandidates={deviceCandidates}
         deviceSearchState={deviceSearchState}
+        deviceTarget={deviceTarget}
         hasConfiguredDevice={hasConfiguredDevice}
         lastError={lastError}
         onDecline={() => {
@@ -2758,6 +2830,11 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
           hasEnteredControlCenterRef.current = true;
           setHasEnteredControlCenter(true);
           setActiveTab("overview");
+        }}
+        onDeviceTargetChange={handleDeviceTargetChange}
+        onManualTarget={(target) => {
+          didRunSetupVerification.current = true;
+          void connectManualTarget(target);
         }}
         onCreateSupportReport={loadSupportDiagnostics}
         onSearch={() => {

--- a/apps/control-center/src/components/device-startup-screen.tsx
+++ b/apps/control-center/src/components/device-startup-screen.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { Check, Loader2, Monitor, RefreshCw } from "lucide-react";
-import { useState } from "react";
+import { Loader2, Monitor, RefreshCw } from "lucide-react";
 import { ControlCenterButton } from "./control-center-button";
 import { DeviceTargetForm } from "./device-target-form";
 import type {
@@ -43,7 +42,6 @@ export function DeviceStartupScreen({
   onSearch,
   onSelect,
 }: Props) {
-  const [manualEntryOpen, setManualEntryOpen] = useState(false);
   const selecting = busyAction === "select";
   const manualConnecting =
     busyAction === "manual-target" || busyAction === "select";
@@ -86,17 +84,21 @@ export function DeviceStartupScreen({
     detail =
       "More than one VibeTV was found. Choose the one you want to connect.";
   } else if (wifiSetupNeeded) {
-    title = "Connect VibeTV to WiFi";
-    detail = "No VibeTV was found. Connect it to WiFi, then search again.";
+    title = "We couldn't find your VibeTV";
+    detail = "";
   } else if (
     configuredDeviceNotFound ||
     deviceSearchState === "failed" ||
     deviceSearchState === "repair-failed"
   ) {
-    title = "VibeTV was not found";
+    title = "We couldn't find your VibeTV";
     detail =
-      "Make sure VibeTV and this Mac are on the same WiFi, then search again.";
+      "Please enter the IP address shown on your VibeTV screen below.";
   }
+
+  const manualEntryPrompt = searching || multiple || wifiSetupNeeded
+    ? "Or enter the IP address shown on your VibeTV screen:"
+    : "";
 
   return (
     <main
@@ -116,10 +118,30 @@ export function DeviceStartupScreen({
           <h1 className="text-[clamp(2rem,4vw,3.25rem)] font-black leading-tight">
             {title}
           </h1>
-          <p className="mx-auto max-w-[620px] text-base leading-7 text-[#444933] sm:text-lg">
-            {detail}
-          </p>
+          {detail ? (
+            <p className="mx-auto max-w-[620px] text-base leading-7 text-[#444933] sm:text-lg">
+              {detail}
+            </p>
+          ) : null}
         </div>
+
+        {searching || selecting || reconnecting || waiting ? (
+          <div
+            className="flex min-h-12 items-center justify-center gap-3 text-base font-semibold text-[#444933]"
+            role="status"
+          >
+            <Loader2 className="animate-spin" size={20} aria-hidden />
+            <span>
+              {selecting
+                ? "Connecting…"
+                : reconnecting
+                  ? "Reconnecting…"
+                  : waiting
+                    ? "Waiting for usage…"
+                    : "Searching…"}
+            </span>
+          </div>
+        ) : null}
 
         {multiple ? (
           <div className="grid gap-3 text-left">
@@ -143,44 +165,45 @@ export function DeviceStartupScreen({
           </div>
         ) : null}
 
-        {manualEntryAvailable ? (
-          manualEntryOpen ? (
-            <div className="grid gap-3 border border-[#747A60] bg-[#F9F9F9] p-4 text-left">
-              <p className="text-sm leading-6 text-[#444933]">
-                Enter the IP address shown on the VibeTV screen. You do not
-                need to wait for automatic search to finish.
-              </p>
-              <DeviceTargetForm
-                busy={manualConnecting}
-                buttonLabel="Connect VibeTV"
-                className="grid gap-4"
-                disabled={
-                  Boolean(busyAction) &&
-                  busyAction !== "search" &&
-                  !manualConnecting
-                }
-                id="startup-device-target"
-                lastError={lastError}
-                onChange={onDeviceTargetChange}
-                onSubmit={onManualTarget}
-                searchingLabel="Connecting"
-                value={deviceTarget}
-              />
-            </div>
-          ) : (
+        {wifiSetupNeeded ? (
+          <>
+            <WifiSetupInstructions />
             <ControlCenterButton
-              aria-expanded={false}
               fullWidth
-              icon={<Monitor size={18} aria-hidden />}
-              label="Enter VibeTV IP"
-              onClick={() => setManualEntryOpen(true)}
+              icon={<RefreshCw size={18} aria-hidden />}
+              label="Scan WiFi again"
+              onClick={onSearch}
               size="large"
-              variant="secondary"
+              variant="primary"
             />
-          )
+          </>
         ) : null}
 
-        {wifiSetupNeeded ? <WifiSetupInstructions /> : null}
+        {manualEntryAvailable ? (
+          <div className="mx-auto grid w-full max-w-[560px] gap-3 text-left">
+            {manualEntryPrompt ? (
+              <p className="text-sm font-semibold leading-6 text-[#444933]">
+                {manualEntryPrompt}
+              </p>
+            ) : null}
+            <DeviceTargetForm
+              busy={manualConnecting}
+              buttonLabel="Connect VibeTV"
+              disabled={
+                Boolean(busyAction) &&
+                busyAction !== "search" &&
+                !manualConnecting
+              }
+              id="startup-device-target"
+              lastError={lastError}
+              minimal
+              onChange={onDeviceTargetChange}
+              onSubmit={onManualTarget}
+              searchingLabel="Connecting"
+              value={deviceTarget}
+            />
+          </div>
+        ) : null}
 
         {lastError && !searching ? (
           <div
@@ -191,24 +214,6 @@ export function DeviceStartupScreen({
               {lastError.message}
             </strong>
             <span>{lastError.nextAction}</span>
-          </div>
-        ) : null}
-
-        {searching || selecting || reconnecting || waiting ? (
-          <div
-            className="flex min-h-12 items-center justify-center gap-3 text-base font-semibold text-[#444933]"
-            role="status"
-          >
-            <Loader2 className="animate-spin" size={20} aria-hidden />
-            <span>
-              {selecting
-                ? "Connecting…"
-                : reconnecting
-                  ? "Reconnecting…"
-                  : waiting
-                    ? "Waiting for usage…"
-                    : "Searching…"}
-            </span>
           </div>
         ) : null}
 
@@ -238,16 +243,7 @@ export function DeviceStartupScreen({
               variant="secondary"
             />
           </div>
-        ) : wifiSetupNeeded ? (
-          <ControlCenterButton
-            fullWidth
-            icon={<Check size={18} aria-hidden />}
-            label="VibeTV is on WiFi"
-            onClick={onSearch}
-            size="large"
-            variant="primary"
-          />
-        ) : configuredDeviceNotFound ||
+        ) : wifiSetupNeeded ? null : configuredDeviceNotFound ||
           deviceSearchState === "failed" ||
           deviceSearchState === "repair-failed" ? (
           <div

--- a/apps/control-center/src/components/device-startup-screen.tsx
+++ b/apps/control-center/src/components/device-startup-screen.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { Check, Loader2, Monitor, RefreshCw } from "lucide-react";
+import { useState } from "react";
 import { ControlCenterButton } from "./control-center-button";
+import { DeviceTargetForm } from "./device-target-form";
 import type {
   ApiError,
   DeviceCandidate,
@@ -14,11 +16,14 @@ type Props = {
   busyAction?: string | null;
   deviceCandidates: DeviceCandidate[];
   deviceSearchState: DeviceSearchState;
+  deviceTarget: string;
   hasConfiguredDevice: boolean;
   lastError?: ApiError | null;
   diagnostics?: SupportDiagnostics | null;
   onCreateSupportReport?: () => void;
   onDecline: () => void;
+  onDeviceTargetChange: (target: string) => void;
+  onManualTarget: (target: string) => void;
   onSearch: () => void;
   onSelect: (candidate: DeviceCandidate) => void;
 };
@@ -27,15 +32,21 @@ export function DeviceStartupScreen({
   busyAction,
   deviceCandidates,
   deviceSearchState,
+  deviceTarget,
   hasConfiguredDevice,
   lastError,
   diagnostics,
   onCreateSupportReport,
   onDecline,
+  onDeviceTargetChange,
+  onManualTarget,
   onSearch,
   onSelect,
 }: Props) {
+  const [manualEntryOpen, setManualEntryOpen] = useState(false);
   const selecting = busyAction === "select";
+  const manualConnecting =
+    busyAction === "manual-target" || busyAction === "select";
   const reconnecting = busyAction === "repair";
   const searching =
     deviceSearchState === "searching" || busyAction === "search";
@@ -45,6 +56,13 @@ export function DeviceStartupScreen({
     deviceSearchState === "not-found" && !hasConfiguredDevice;
   const configuredDeviceNotFound =
     deviceSearchState === "not-found" && hasConfiguredDevice;
+  const manualEntryAvailable =
+    searching ||
+    multiple ||
+    wifiSetupNeeded ||
+    configuredDeviceNotFound ||
+    deviceSearchState === "failed" ||
+    deviceSearchState === "repair-failed";
 
   let title = "Reconnecting to your VibeTV";
   let detail = "Checking your last connected VibeTV and your WiFi.";
@@ -123,6 +141,43 @@ export function DeviceStartupScreen({
               </div>
             ))}
           </div>
+        ) : null}
+
+        {manualEntryAvailable ? (
+          manualEntryOpen ? (
+            <div className="grid gap-3 border border-[#747A60] bg-[#F9F9F9] p-4 text-left">
+              <p className="text-sm leading-6 text-[#444933]">
+                Enter the IP address shown on the VibeTV screen. You do not
+                need to wait for automatic search to finish.
+              </p>
+              <DeviceTargetForm
+                busy={manualConnecting}
+                buttonLabel="Connect VibeTV"
+                className="grid gap-4"
+                disabled={
+                  Boolean(busyAction) &&
+                  busyAction !== "search" &&
+                  !manualConnecting
+                }
+                id="startup-device-target"
+                lastError={lastError}
+                onChange={onDeviceTargetChange}
+                onSubmit={onManualTarget}
+                searchingLabel="Connecting"
+                value={deviceTarget}
+              />
+            </div>
+          ) : (
+            <ControlCenterButton
+              aria-expanded={false}
+              fullWidth
+              icon={<Monitor size={18} aria-hidden />}
+              label="Enter VibeTV IP"
+              onClick={() => setManualEntryOpen(true)}
+              size="large"
+              variant="secondary"
+            />
+          )
         ) : null}
 
         {wifiSetupNeeded ? <WifiSetupInstructions /> : null}

--- a/apps/control-center/src/components/device-target-copy.test.ts
+++ b/apps/control-center/src/components/device-target-copy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  deviceTargetHelpText,
+  normalizeManualDeviceTarget,
+} from "./device-target-copy";
+
+describe("VibeTV address input", () => {
+  it("normalizes a plain IPv4 address to the local HTTP target", () => {
+    expect(normalizeManualDeviceTarget(" 172.30.12.34 ")).toBe(
+      "http://172.30.12.34",
+    );
+    expect(normalizeManualDeviceTarget("HTTP://192.168.178.163")).toBe(
+      "http://192.168.178.163",
+    );
+  });
+
+  it.each([
+    "",
+    "vibetv.local",
+    "172.30.12",
+    "172.30.12.999",
+    "http://172.30.12.34/hello",
+    "172.30.12.34?token=secret",
+  ])("rejects invalid or unsafe input %j", (value) => {
+    expect(normalizeManualDeviceTarget(value)).toBeNull();
+  });
+
+  it("keeps unreachable and invalid input guidance customer-readable", () => {
+    expect(deviceTargetHelpText({ code: "device_not_found" })).toContain(
+      "did not answer",
+    );
+    expect(deviceTargetHelpText({ code: "invalid_device_target" })).toContain(
+      "only the IP address",
+    );
+  });
+});

--- a/apps/control-center/src/components/device-target-form.tsx
+++ b/apps/control-center/src/components/device-target-form.tsx
@@ -17,6 +17,7 @@ type DeviceTargetFormProps = {
   disabled?: boolean;
   id: string;
   lastError?: ApiError | null;
+  minimal?: boolean;
   onChange?: (target: string) => void;
   onSubmit?: (target: string) => void;
   searchingLabel?: string;
@@ -26,10 +27,11 @@ type DeviceTargetFormProps = {
 export function DeviceTargetForm({
   busy = false,
   buttonLabel = "Connect VibeTV",
-  className = "grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end",
+  className,
   disabled = false,
   id,
   lastError,
+  minimal = false,
   onChange,
   onSubmit,
   searchingLabel = "Searching",
@@ -37,6 +39,17 @@ export function DeviceTargetForm({
 }: DeviceTargetFormProps) {
   const formDisabled = disabled || busy;
   const [validationError, setValidationError] = useState("");
+  const formClassName =
+    className ||
+    (minimal
+      ? "grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start"
+      : "grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end");
+  const labelClassName = minimal
+    ? "sr-only"
+    : "text-sm font-bold text-[#1B1B1B]";
+  const inputClassName = minimal
+    ? "h-12 w-full border border-[#747A60] bg-[#F9F9F9] px-3 font-mono text-base text-[#1B1B1B] outline-none transition placeholder:text-[#747A60] focus:border-[#5E7200] disabled:cursor-not-allowed disabled:bg-[#EEEEEE] disabled:text-[#444933]"
+    : "mt-3 h-12 w-full border border-[#747A60] bg-[#F9F9F9] px-3 font-mono text-sm text-[#1B1B1B] outline-none transition placeholder:text-[#747A60] focus:border-[#5E7200] disabled:cursor-not-allowed disabled:bg-[#EEEEEE] disabled:text-[#444933]";
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -52,16 +65,18 @@ export function DeviceTargetForm({
   }
 
   return (
-    <form className={className} onSubmit={handleSubmit}>
+    <form className={formClassName} onSubmit={handleSubmit}>
       <div className="min-w-0">
-        <label className="text-sm font-bold text-[#1B1B1B]" htmlFor={id}>
+        <label className={labelClassName} htmlFor={id}>
           VibeTV address
         </label>
-        <p className="mt-1 max-w-[720px] text-sm leading-6 text-[#444933]">
-          {deviceTargetHelpText(lastError)}
-        </p>
+        {!minimal ? (
+          <p className="mt-1 max-w-[720px] text-sm leading-6 text-[#444933]">
+            {deviceTargetHelpText(lastError)}
+          </p>
+        ) : null}
         <input
-          className="mt-3 h-12 w-full border border-[#747A60] bg-[#F9F9F9] px-3 font-mono text-sm text-[#1B1B1B] outline-none transition placeholder:text-[#747A60] focus:border-[#5E7200] disabled:cursor-not-allowed disabled:bg-[#EEEEEE] disabled:text-[#444933]"
+          className={inputClassName}
           disabled={formDisabled}
           id={id}
           aria-invalid={Boolean(validationError)}

--- a/apps/control-center/src/components/setup-screen.tsx
+++ b/apps/control-center/src/components/setup-screen.tsx
@@ -540,17 +540,30 @@ function FinishSetupContent({
   onRepairConnection?: (targetOverride?: string) => void;
   setupComplete: boolean;
 }) {
+  const [manualEntryOpen, setManualEntryOpen] = useState(false);
+
   if (setupComplete) {
     return <StatusNote>VibeTV is ready.</StatusNote>;
   }
 
   if (deviceSearchState === "searching" || busyAction === "search") {
     return (
-      <StatusNote
-        icon={<Loader2 className="animate-spin" size={16} aria-hidden />}
-      >
-        Searching for VibeTVs on your WiFi...
-      </StatusNote>
+      <div className="grid gap-4">
+        <StatusNote
+          icon={<Loader2 className="animate-spin" size={16} aria-hidden />}
+        >
+          Searching for VibeTVs on your WiFi...
+        </StatusNote>
+        <ManualDeviceTargetOption
+          busyAction={busyAction}
+          deviceTarget={deviceTarget}
+          lastError={lastError}
+          onChange={onDeviceTargetChange}
+          onOpen={() => setManualEntryOpen(true)}
+          onSubmit={onRepairConnection}
+          open={manualEntryOpen}
+        />
+      </div>
     );
   }
 
@@ -599,6 +612,15 @@ function FinishSetupContent({
             size="large"
           />
         </div>
+        <ManualDeviceTargetOption
+          busyAction={busyAction}
+          deviceTarget={deviceTarget}
+          lastError={lastError}
+          onChange={onDeviceTargetChange}
+          onOpen={() => setManualEntryOpen(true)}
+          onSubmit={onRepairConnection}
+          open={manualEntryOpen}
+        />
       </div>
     );
   }
@@ -611,10 +633,15 @@ function FinishSetupContent({
           VibeTV screen.
         </p>
         <DeviceTargetForm
-          busy={busyAction === "repair"}
+          busy={busyAction === "manual-target" || busyAction === "select"}
           buttonLabel="Connect VibeTV"
           className="grid gap-4"
-          disabled={Boolean(busyAction)}
+          disabled={
+            Boolean(busyAction) &&
+            busyAction !== "search" &&
+            busyAction !== "manual-target" &&
+            busyAction !== "select"
+          }
           id="setup-device-target"
           lastError={lastError}
           onChange={onDeviceTargetChange}
@@ -640,6 +667,15 @@ function FinishSetupContent({
           onClick={onSearchDevices}
           size="large"
         />
+        <ManualDeviceTargetOption
+          busyAction={busyAction}
+          deviceTarget={deviceTarget}
+          lastError={lastError}
+          onChange={onDeviceTargetChange}
+          onOpen={() => setManualEntryOpen(true)}
+          onSubmit={onRepairConnection}
+          open={manualEntryOpen}
+        />
       </div>
     );
   }
@@ -657,6 +693,15 @@ function FinishSetupContent({
           label="Try again"
           onClick={onSearchDevices}
           size="large"
+        />
+        <ManualDeviceTargetOption
+          busyAction={busyAction}
+          deviceTarget={deviceTarget}
+          lastError={lastError}
+          onChange={onDeviceTargetChange}
+          onOpen={() => setManualEntryOpen(true)}
+          onSubmit={onRepairConnection}
+          open={manualEntryOpen}
         />
       </div>
     );
@@ -678,11 +723,77 @@ function FinishSetupContent({
   }
 
   return (
-    <StatusNote>
-      {deviceState === "offline"
-        ? "VibeTV is offline. Run setup again to search for it."
-        : "Waiting for automatic VibeTV search."}
-    </StatusNote>
+    <div className="grid gap-4">
+      <StatusNote>
+        {deviceState === "offline"
+          ? "VibeTV is offline. Run setup again to search for it."
+          : "Waiting for automatic VibeTV search."}
+      </StatusNote>
+      <ManualDeviceTargetOption
+        busyAction={busyAction}
+        deviceTarget={deviceTarget}
+        lastError={lastError}
+        onChange={onDeviceTargetChange}
+        onOpen={() => setManualEntryOpen(true)}
+        onSubmit={onRepairConnection}
+        open={manualEntryOpen}
+      />
+    </div>
+  );
+}
+
+function ManualDeviceTargetOption({
+  busyAction,
+  deviceTarget,
+  lastError,
+  onChange,
+  onOpen,
+  onSubmit,
+  open,
+}: {
+  busyAction?: string | null;
+  deviceTarget: string;
+  lastError?: ApiError | null;
+  onChange?: (target: string) => void;
+  onOpen: () => void;
+  onSubmit?: (targetOverride?: string) => void;
+  open: boolean;
+}) {
+  if (!open) {
+    return (
+      <ControlCenterButton
+        aria-expanded={false}
+        fullWidth
+        icon={<Monitor size={18} aria-hidden />}
+        label="Enter VibeTV IP"
+        onClick={onOpen}
+        size="large"
+        variant="secondary"
+      />
+    );
+  }
+
+  const connecting =
+    busyAction === "manual-target" || busyAction === "select";
+  return (
+    <div className="grid gap-3 border border-[#747A60] bg-[#F9F9F9] p-4">
+      <p className="text-sm leading-6 text-[#444933]">
+        Enter the IP address shown on the VibeTV screen. Automatic search can
+        keep running in the background.
+      </p>
+      <DeviceTargetForm
+        busy={connecting}
+        buttonLabel="Connect VibeTV"
+        className="grid gap-4"
+        disabled={Boolean(busyAction) && busyAction !== "search" && !connecting}
+        id="setup-device-target"
+        lastError={lastError}
+        onChange={onChange}
+        onSubmit={onSubmit}
+        searchingLabel="Connecting"
+        value={deviceTarget}
+      />
+    </div>
   );
 }
 

--- a/apps/control-center/src/components/setup-screen.tsx
+++ b/apps/control-center/src/components/setup-screen.tsx
@@ -330,7 +330,7 @@ export function SetupScreen({
                   <PrimaryButton
                     fullWidth
                     icon={<Check size={18} aria-hidden />}
-                    label="VibeTV is on WiFi"
+                    label="Scan WiFi again"
                     onClick={confirmWifi}
                     size="large"
                   />
@@ -540,8 +540,6 @@ function FinishSetupContent({
   onRepairConnection?: (targetOverride?: string) => void;
   setupComplete: boolean;
 }) {
-  const [manualEntryOpen, setManualEntryOpen] = useState(false);
-
   if (setupComplete) {
     return <StatusNote>VibeTV is ready.</StatusNote>;
   }
@@ -559,9 +557,7 @@ function FinishSetupContent({
           deviceTarget={deviceTarget}
           lastError={lastError}
           onChange={onDeviceTargetChange}
-          onOpen={() => setManualEntryOpen(true)}
           onSubmit={onRepairConnection}
-          open={manualEntryOpen}
         />
       </div>
     );
@@ -617,9 +613,7 @@ function FinishSetupContent({
           deviceTarget={deviceTarget}
           lastError={lastError}
           onChange={onDeviceTargetChange}
-          onOpen={() => setManualEntryOpen(true)}
           onSubmit={onRepairConnection}
-          open={manualEntryOpen}
         />
       </div>
     );
@@ -628,9 +622,9 @@ function FinishSetupContent({
   if (deviceSearchState === "not-found") {
     return (
       <div className="grid gap-5">
-        <p className="text-sm leading-6 text-[#444933]">
-          No VibeTV was found automatically. Enter the address shown on the
-          VibeTV screen.
+        <p className="text-sm font-semibold leading-6 text-[#444933]">
+          We couldn&apos;t find your VibeTV. Enter the IP address shown on your
+          VibeTV screen:
         </p>
         <DeviceTargetForm
           busy={busyAction === "manual-target" || busyAction === "select"}
@@ -644,6 +638,7 @@ function FinishSetupContent({
           }
           id="setup-device-target"
           lastError={lastError}
+          minimal
           onChange={onDeviceTargetChange}
           onSubmit={onRepairConnection}
           searchingLabel="Connecting"
@@ -656,25 +651,20 @@ function FinishSetupContent({
   if (deviceSearchState === "failed") {
     return (
       <div className="grid gap-4">
-        <p className="text-sm leading-6 text-[#444933]">
-          Automatic search could not finish. Make sure VibeTV and this Mac are
-          on the same WiFi, then try again.
-        </p>
+        <ManualDeviceTargetOption
+          busyAction={busyAction}
+          deviceTarget={deviceTarget}
+          lastError={lastError}
+          onChange={onDeviceTargetChange}
+          onSubmit={onRepairConnection}
+          prompt="We couldn't find your VibeTV. Enter the IP address shown on your VibeTV screen:"
+        />
         <PrimaryButton
           fullWidth
           icon={<RefreshCw size={18} aria-hidden />}
           label="Try again"
           onClick={onSearchDevices}
           size="large"
-        />
-        <ManualDeviceTargetOption
-          busyAction={busyAction}
-          deviceTarget={deviceTarget}
-          lastError={lastError}
-          onChange={onDeviceTargetChange}
-          onOpen={() => setManualEntryOpen(true)}
-          onSubmit={onRepairConnection}
-          open={manualEntryOpen}
         />
       </div>
     );
@@ -683,25 +673,20 @@ function FinishSetupContent({
   if (deviceSearchState === "repair-failed") {
     return (
       <div className="grid gap-4">
-        <p className="text-sm leading-6 text-[#444933]">
-          VibeTV could not reconnect automatically. Make sure it is on the same
-          WiFi as this Mac, then try again.
-        </p>
+        <ManualDeviceTargetOption
+          busyAction={busyAction}
+          deviceTarget={deviceTarget}
+          lastError={lastError}
+          onChange={onDeviceTargetChange}
+          onSubmit={onRepairConnection}
+          prompt="We couldn't reconnect your VibeTV. Enter the IP address shown on your VibeTV screen:"
+        />
         <PrimaryButton
           fullWidth
           icon={<RefreshCw size={18} aria-hidden />}
           label="Try again"
           onClick={onSearchDevices}
           size="large"
-        />
-        <ManualDeviceTargetOption
-          busyAction={busyAction}
-          deviceTarget={deviceTarget}
-          lastError={lastError}
-          onChange={onDeviceTargetChange}
-          onOpen={() => setManualEntryOpen(true)}
-          onSubmit={onRepairConnection}
-          open={manualEntryOpen}
         />
       </div>
     );
@@ -734,9 +719,7 @@ function FinishSetupContent({
         deviceTarget={deviceTarget}
         lastError={lastError}
         onChange={onDeviceTargetChange}
-        onOpen={() => setManualEntryOpen(true)}
         onSubmit={onRepairConnection}
-        open={manualEntryOpen}
       />
     </div>
   );
@@ -747,39 +730,22 @@ function ManualDeviceTargetOption({
   deviceTarget,
   lastError,
   onChange,
-  onOpen,
   onSubmit,
-  open,
+  prompt = "Or enter the IP address shown on your VibeTV screen:",
 }: {
   busyAction?: string | null;
   deviceTarget: string;
   lastError?: ApiError | null;
   onChange?: (target: string) => void;
-  onOpen: () => void;
   onSubmit?: (targetOverride?: string) => void;
-  open: boolean;
+  prompt?: string;
 }) {
-  if (!open) {
-    return (
-      <ControlCenterButton
-        aria-expanded={false}
-        fullWidth
-        icon={<Monitor size={18} aria-hidden />}
-        label="Enter VibeTV IP"
-        onClick={onOpen}
-        size="large"
-        variant="secondary"
-      />
-    );
-  }
-
   const connecting =
     busyAction === "manual-target" || busyAction === "select";
   return (
-    <div className="grid gap-3 border border-[#747A60] bg-[#F9F9F9] p-4">
-      <p className="text-sm leading-6 text-[#444933]">
-        Enter the IP address shown on the VibeTV screen. Automatic search can
-        keep running in the background.
+    <div className="grid gap-3">
+      <p className="text-sm font-semibold leading-6 text-[#444933]">
+        {prompt}
       </p>
       <DeviceTargetForm
         busy={connecting}
@@ -788,6 +754,7 @@ function ManualDeviceTargetOption({
         disabled={Boolean(busyAction) && busyAction !== "search" && !connecting}
         id="setup-device-target"
         lastError={lastError}
+        minimal
         onChange={onChange}
         onSubmit={onSubmit}
         searchingLabel="Connecting"

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -2299,6 +2299,11 @@ func (s *Server) handleDeviceSearch(w http.ResponseWriter, r *http.Request) {
 	}
 	devices, err := s.searchDevices(r.Context(), cfg, strings.TrimSpace(req.Target))
 	if err != nil {
+		var invalidTarget *invalidTargetError
+		if errors.As(err, &invalidTarget) {
+			writeInvalidDeviceTarget(w)
+			return
+		}
 		if errors.Is(err, errLocalNetworkAccessDenied) {
 			writeError(
 				w,
@@ -5234,6 +5239,17 @@ func (s *Server) discoverSubnet(ctx context.Context, cfg runtimeconfig.Config) (
 }
 
 func (s *Server) searchDevices(ctx context.Context, cfg runtimeconfig.Config, explicitTarget string) ([]deviceSearchEntry, error) {
+	explicitTarget = strings.TrimSpace(explicitTarget)
+	if explicitTarget != "" {
+		normalized, err := normalizeExplicitDeviceTarget(explicitTarget)
+		if err != nil {
+			return nil, err
+		}
+		// Manual entry is a deterministic fallback, not another LAN scan. Probe
+		// exactly the customer-provided address once through GET /hello.
+		return s.searchDevicesOnce(ctx, cfg, normalized)
+	}
+
 	searchCtx, cancel := context.WithTimeout(ctx, deviceSearchWindow)
 	defer cancel()
 
@@ -5277,19 +5293,22 @@ func (s *Server) searchDevices(ctx context.Context, cfg runtimeconfig.Config, ex
 func (s *Server) searchDevicesOnce(ctx context.Context, cfg runtimeconfig.Config, explicitTarget string) ([]deviceSearchEntry, error) {
 	candidates := []string{}
 	if explicitTarget != "" {
-		if target, err := normalizeExplicitDeviceTarget(explicitTarget); err == nil {
-			candidates = append(candidates, target)
+		target, err := normalizeExplicitDeviceTarget(explicitTarget)
+		if err != nil {
+			return nil, err
 		}
-	}
-	// Probe every remembered VibeTV before the subnet fan-out. This keeps known
-	// devices fast, including the case where more than one saved VibeTV is online.
-	candidates = append(candidates, cfg.DeviceTarget)
-	for _, known := range cfg.KnownDevices {
-		candidates = append(candidates, known.Target)
-	}
-	candidates = append(candidates, s.configuredDefaultWiFiTarget())
-	if s.subnetTargets != nil {
-		candidates = append(candidates, s.subnetTargets()...)
+		candidates = append(candidates, target)
+	} else {
+		// Probe every remembered VibeTV before the subnet fan-out. This keeps known
+		// devices fast, including the case where more than one saved VibeTV is online.
+		candidates = append(candidates, cfg.DeviceTarget)
+		for _, known := range cfg.KnownDevices {
+			candidates = append(candidates, known.Target)
+		}
+		candidates = append(candidates, s.configuredDefaultWiFiTarget())
+		if s.subnetTargets != nil {
+			candidates = append(candidates, s.subnetTargets()...)
+		}
 	}
 	candidates = uniqueStrings(candidates...)
 	if len(candidates) == 0 {

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -263,6 +263,8 @@ type repairStageError struct {
 	err   error
 }
 
+var errDeviceIdentityChanged = errors.New("VibeTV identity changed")
+
 type deviceHTTPError struct {
 	statusCode int
 	body       string
@@ -2718,7 +2720,7 @@ func (s *Server) selectDevice(
 	if !strings.EqualFold(expectedDeviceID, strings.TrimSpace(hello.DeviceID)) {
 		return deviceInfo{}, &repairStageError{
 			stage: "discovery",
-			err:   errors.New("selected VibeTV identity changed before pairing"),
+			err:   errDeviceIdentityChanged,
 		}
 	}
 
@@ -5506,13 +5508,13 @@ func validateRepairIdentity(
 	}
 	expectedDeviceID = strings.TrimSpace(expectedDeviceID)
 	if expectedDeviceID != "" && !strings.EqualFold(expectedDeviceID, strings.TrimSpace(hello.DeviceID)) {
-		return &repairStageError{stage: "discovery", err: errors.New("selected VibeTV identity changed before pairing")}
+		return &repairStageError{stage: "discovery", err: errDeviceIdentityChanged}
 	}
 	if explicit || strings.TrimSpace(cfg.DeviceID) == "" {
 		return nil
 	}
 	if !strings.EqualFold(strings.TrimSpace(cfg.DeviceID), strings.TrimSpace(hello.DeviceID)) {
-		return &repairStageError{stage: "discovery", err: errors.New("discovered VibeTV does not match the saved device identity")}
+		return &repairStageError{stage: "discovery", err: errDeviceIdentityChanged}
 	}
 	return nil
 }
@@ -6168,6 +6170,16 @@ func writeRepairError(w http.ResponseWriter, err error) {
 	var multiple *multipleDevicesError
 	if errors.As(err, &multiple) {
 		writeDiscoveryError(w, err)
+		return
+	}
+	if errors.Is(err, errDeviceIdentityChanged) {
+		writeError(
+			w,
+			http.StatusConflict,
+			"device_identity_changed",
+			"That address answered as a different VibeTV.",
+			"Check the IP on the VibeTV screen, then try again.",
+		)
 		return
 	}
 	var stageErr *repairStageError

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -864,8 +864,17 @@ func TestDeviceRepairRejectsIdentitySwapBetweenSearchAndPair(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	server.Handler().ServeHTTP(rec, req)
 
-	if rec.Code == http.StatusOK {
-		t.Fatalf("identity swap was accepted: %s", rec.Body.String())
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("identity swap status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var got errorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode identity swap response: %v", err)
+	}
+	if got.OK || got.Error.Code != "device_identity_changed" ||
+		got.Error.Message != "That address answered as a different VibeTV." ||
+		got.Error.NextAction != "Check the IP on the VibeTV screen, then try again." {
+		t.Fatalf("unexpected identity swap response: %+v", got)
 	}
 	if pairCalls.Load() != 0 {
 		t.Fatalf("identity swap triggered %d pairing writes", pairCalls.Load())
@@ -907,8 +916,17 @@ func TestDeviceSelectRejectsIdentitySwapBeforePairing(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	server.Handler().ServeHTTP(rec, req)
 
-	if rec.Code == http.StatusOK {
-		t.Fatalf("identity swap was accepted: %s", rec.Body.String())
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("identity swap status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var got errorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode identity swap response: %v", err)
+	}
+	if got.OK || got.Error.Code != "device_identity_changed" ||
+		got.Error.Message != "That address answered as a different VibeTV." ||
+		got.Error.NextAction != "Check the IP on the VibeTV screen, then try again." {
+		t.Fatalf("unexpected identity swap response: %+v", got)
 	}
 	if pairCalls.Load() != 0 {
 		t.Fatalf("identity swap triggered %d pairing writes", pairCalls.Load())

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -378,6 +378,82 @@ func TestDeviceSearchRetriesTransientKnownDeviceFailure(t *testing.T) {
 	}
 }
 
+func TestDeviceSearchExplicitTargetOnlyProbesThatAddress(t *testing.T) {
+	var explicitHelloCalls atomic.Int32
+	explicit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		explicitHelloCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":2,"board":"esp8266-smalltv-st7789","firmware":"1.0.37","deviceId":"manual-device","networkMode":"station","capabilities":{"transport":{"active":"wifi"}}}`))
+	}))
+	defer explicit.Close()
+
+	server := newTestServer(t, runtimeconfig.Config{
+		DeviceTarget: "http://192.0.2.10",
+		DeviceID:     "remembered-device",
+	})
+	server.defaultWiFiTarget = func() string {
+		t.Fatal("manual target validation must not probe the default target")
+		return ""
+	}
+	server.subnetTargets = func() []string {
+		t.Fatal("manual target validation must not scan the subnet")
+		return nil
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/device/search",
+		strings.NewReader(`{"target":`+strconv.Quote(explicit.URL)+`}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Devices []deviceSearchEntry `json:"devices"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Devices) != 1 || got.Devices[0].Target != explicit.URL || got.Devices[0].DeviceID != "manual-device" {
+		t.Fatalf("unexpected targeted search response: %+v", got.Devices)
+	}
+	if explicitHelloCalls.Load() != 1 {
+		t.Fatalf("manual target must receive one bounded hello probe, got %d", explicitHelloCalls.Load())
+	}
+}
+
+func TestDeviceSearchRejectsInvalidExplicitTargetWithoutSubnetScan(t *testing.T) {
+	server := newTestServer(t, runtimeconfig.Config{})
+	server.subnetTargets = func() []string {
+		t.Fatal("invalid manual target must not scan the subnet")
+		return nil
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/device/search",
+		strings.NewReader(`{"target":"http://192.0.2.10/hello"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var got errorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Error.Code != "invalid_device_target" {
+		t.Fatalf("unexpected invalid target response: %+v", got)
+	}
+}
+
 func TestDeviceSearchReportsDeniedLocalNetworkAccess(t *testing.T) {
 	server := newTestServer(t, runtimeconfig.Config{})
 	server.defaultWiFiTarget = func() string { return "" }

--- a/docs/control-center-customer-ui-approval.md
+++ b/docs/control-center-customer-ui-approval.md
@@ -154,3 +154,9 @@ issue scope, or release permission never implies UI permission.
 - User approval: After the security sweep described the visible recovery problem, the user explicitly answered `dann ... fixen` and approved implementing that customer-visible fix in the Codex task on 2026-07-21.
 - Approved customer-visible result: A closed pairing window or rejected saved token no longer tells the customer to check the same WiFi and retry. Control Center explains the three-restart recovery: interrupt early boot three times, connect VibeTV to WiFi again, then pair it again. A temporary pairing rate limit only asks the customer to wait briefly. When Mac App and VibeTV firmware updates are both available, the single Update action updates the Mac App first and exposes the firmware update only afterward.
 - Approved files: `control-center-types.ts`, `control-center-app.tsx`, `updates-screen.tsx`, `protocol/compatibility_matrix.json`, `docs/customer-setup.md`, and their customer-flow assertions.
+
+## 2026-07-22 — Manual IP alongside WiFi discovery
+
+- User approval: After reviewing the exact rendered automatic-search and no-result screens, the user explicitly ordered `mach PR` in the Codex task on 2026-07-22.
+- Approved customer-visible result: While Control Center searches WiFi, the search spinner appears before an always-visible minimal IP-address field introduced by `Or enter the IP address shown on your VibeTV screen:`. When no VibeTV is found, the screen shows `We couldn't find your VibeTV`, the seven WiFi setup steps, `Scan WiFi again`, and only then the same alternative IP-address entry. The former `Enter VibeTV IP` and `VibeTV is on WiFi` buttons do not appear.
+- Approved files: `device-startup-screen.tsx`, `device-target-form.tsx`, `setup-screen.tsx`, and their customer-flow assertions in `test-customer-flows.mjs`.

--- a/docs/control-center-ui-principles.md
+++ b/docs/control-center-ui-principles.md
@@ -24,13 +24,16 @@ This is the customer-facing design standard for VibeTV Control Center. The targe
 2. The installed Mac App never asks the customer to download itself during
    normal onboarding. A fresh setup searches the current WiFi for VibeTVs
    before showing setup instructions.
-3. If the initial search finds no VibeTV, the same full-screen startup gate
-   shows the VibeTV WiFi instructions and one `VibeTV is on WiFi` action. That
-   action starts a fresh device search. The Control Center shell and navigation
-   remain hidden. On a later app start, a saved but unavailable VibeTV uses a
-   separate reconnect screen without first-time WiFi instructions. It searches
-   only for the active saved identity and allows the customer to open Control
-   Center without replacing that identity.
+3. During the initial search, the same full-screen startup gate shows the active
+   search first and an always-visible alternative to enter the IP address shown
+   on the VibeTV screen. If the search finds no VibeTV, it shows `We couldn't
+   find your VibeTV`, followed by the VibeTV WiFi instructions and `Scan WiFi
+   again`. Below those steps, the manual alternative reads `Or enter the IP
+   address shown on your VibeTV screen:`. The Control Center shell and
+   navigation remain hidden. On a later app start, a saved but unavailable
+   VibeTV uses a separate reconnect screen without first-time WiFi instructions.
+   It searches only for the active saved identity and allows the customer to
+   open Control Center without replacing that identity.
 4. An existing healthy setup opens Overview without setup writes or extra
    confirmation. If VibeTV or the Mac App becomes unavailable after Control
    Center was entered, the current tab and navigation remain visible. Overview

--- a/firmware_esp8266/src/connected_setup_policy.h
+++ b/firmware_esp8266/src/connected_setup_policy.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstdint>
+
+namespace codexbar_display {
+namespace esp8266 {
+
+class ConnectedSetupPolicy {
+ public:
+  static bool IsStationIPv4(const char* value) {
+    if (value == nullptr || *value == '\0') {
+      return false;
+    }
+
+    uint16_t octets[4] = {0, 0, 0, 0};
+    uint8_t octetIndex = 0;
+    uint8_t digits = 0;
+    for (const char* cursor = value;; ++cursor) {
+      const char current = *cursor;
+      if (current >= '0' && current <= '9') {
+        if (digits >= 3) {
+          return false;
+        }
+        octets[octetIndex] = static_cast<uint16_t>(octets[octetIndex] * 10 + (current - '0'));
+        if (octets[octetIndex] > 255) {
+          return false;
+        }
+        ++digits;
+        continue;
+      }
+      if ((current == '.' || current == '\0') && digits > 0) {
+        if (current == '\0') {
+          if (octetIndex != 3) {
+            return false;
+          }
+          break;
+        }
+        if (octetIndex >= 3) {
+          return false;
+        }
+        ++octetIndex;
+        digits = 0;
+        continue;
+      }
+      return false;
+    }
+
+    // Never present unspecified, loopback, multicast, or the fixed setup-AP
+    // address as the reachable station address shown to the customer.
+    if (octets[0] == 0 || octets[0] == 127 || octets[0] >= 224) {
+      return false;
+    }
+    return !(octets[0] == 192 && octets[1] == 168 && octets[2] == 4 && octets[3] == 1);
+  }
+};
+
+}  // namespace esp8266
+}  // namespace codexbar_display

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -12,6 +12,7 @@
 #include "../../firmware_shared/theme_spec_renderer_core.h"
 #include "boot_recovery_policy.h"
 #include "asset_path_policy.h"
+#include "connected_setup_policy.h"
 #include "wifi_security_policy.h"
 #include "gif_asset_validator_file.h"
 #include "renderer_esp8266.h"
@@ -189,6 +190,7 @@ bool setupMode = false;
 bool physicalSetupAuthorized = false;
 String setupAuthorizationToken;
 bool waitStatusRendered = false;
+String lastConnectedSetupIp;
 bool otaUploadSucceeded = false;
 bool otaUploadInProgress = false;
 bool otaUploadNeedsReboot = false;
@@ -694,9 +696,15 @@ void applyFrameUpdateState() {
 }
 
 void drawWaitingForCompanionStatus() {
+  String stationIp = WiFi.localIP().toString();
+  if (WiFi.status() != WL_CONNECTED ||
+      !codexbar_display::esp8266::ConnectedSetupPolicy::IsStationIPv4(stationIp.c_str())) {
+    stationIp = "";
+  }
   const unsigned long renderStartUs = micros();
-  renderer.DrawConnectedSetupInstructions(runtimeCtx, kCustomerAppHost, WiFi.localIP().toString());
+  renderer.DrawConnectedSetupInstructions(runtimeCtx, kCustomerAppHost, stationIp);
   recordRenderFull("connected_setup", micros() - renderStartUs);
+  lastConnectedSetupIp = stationIp;
   waitStatusRendered = true;
 }
 
@@ -2741,6 +2749,15 @@ void maintainWifiConnection() {
     if (wifiDisconnectedAtMs != 0) {
       Serial.printf("wifi_reconnected ip=%s\n", WiFi.localIP().toString().c_str());
       drawWaitingForCompanionStatus();
+    } else if (waitStatusRendered) {
+      String stationIp = WiFi.localIP().toString();
+      if (!codexbar_display::esp8266::ConnectedSetupPolicy::IsStationIPv4(stationIp.c_str())) {
+        stationIp = "";
+      }
+      if (stationIp != lastConnectedSetupIp) {
+        Serial.printf("wifi_station_ip_changed ip=%s\n", stationIp.c_str());
+        drawWaitingForCompanionStatus();
+      }
     }
     resetWifiReconnectState();
     return;

--- a/firmware_esp8266/src/renderer_esp8266.cpp
+++ b/firmware_esp8266/src/renderer_esp8266.cpp
@@ -1,5 +1,7 @@
 #include "renderer_esp8266.h"
 
+#include "connected_setup_policy.h"
+
 #ifndef CODEXBAR_DISPLAY_PROBE_ONLY
 #include "renderer_esp8266_display_state.h"
 #else
@@ -355,19 +357,21 @@ void RendererESP8266::DrawConnectedSetupInstructions(
   tft.setTextWrap(false);
   tft.setTextFont(1);
 
-  (void)host;
-  (void)fallbackIp;
   const char* title = "WiFi connected!";
   const char* action = "Now go to:";
-  const char* detail = "app.vibetv.shop";
+  const String detail = host.length() > 0 ? host : "app.vibetv.shop";
+  const bool hasFallbackIp = ConnectedSetupPolicy::IsStationIPv4(fallbackIp.c_str());
+  const String ipLine = hasFallbackIp ? String("IP: ") + fallbackIp : String("IP unavailable");
   const int titleSize = display::ChooseTextSizeToFit(title, 3, 2, tft.width() - 8);
   const int actionSize = display::ChooseTextSizeToFit(action, 2, 1, tft.width() - 14);
-  const int detailSize = display::ChooseTextSizeToFit(detail, 2, 1, tft.width() - 14);
+  const int detailSize = display::ChooseTextSizeToFit(detail.c_str(), 2, 1, tft.width() - 14);
+  const int ipSize = display::ChooseTextSizeToFit(ipLine.c_str(), 2, 1, tft.width() - 14);
 
   const int totalH =
       display::TextPixelHeight(titleSize) + 12 +
       display::TextPixelHeight(actionSize) + 10 +
-      display::TextPixelHeight(detailSize);
+      display::TextPixelHeight(detailSize) + 14 +
+      display::TextPixelHeight(ipSize);
   int y = (tft.height() - totalH) / 2;
   if (y < 6) {
     y = 6;
@@ -387,8 +391,14 @@ void RendererESP8266::DrawConnectedSetupInstructions(
   y += display::TextPixelHeight(actionSize) + 10;
   display::SetTextSize(detailSize);
   tft.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
-  tft.setCursor(display::CenteredTextX(detail, detailSize), y);
+  tft.setCursor(display::CenteredTextX(detail.c_str(), detailSize), y);
   tft.print(detail);
+
+  y += display::TextPixelHeight(detailSize) + 14;
+  display::SetTextSize(ipSize);
+  tft.setTextColor(hasFallbackIp ? TFT_WHITE : TFT_LIGHTGREY, TFT_BLACK);
+  tft.setCursor(display::CenteredTextX(ipLine.c_str(), ipSize), y);
+  tft.print(ipLine);
 
   ctx.lastRenderedSecs = -1;
   ctx.lastRenderedMinuteBucket = -1;

--- a/firmware_esp8266/tests/gif_core_policy_test.cpp
+++ b/firmware_esp8266/tests/gif_core_policy_test.cpp
@@ -7,6 +7,7 @@
 #include "../src/gif_core_policy.h"
 #include "../src/boot_recovery_policy.h"
 #include "../src/asset_path_policy.h"
+#include "../src/connected_setup_policy.h"
 #include "../src/theme_spec_runtime_policy.h"
 #include "../src/wifi_security_policy.h"
 
@@ -18,6 +19,7 @@ using codexbar_display::esp8266::BootRecoveryPolicy;
 using codexbar_display::esp8266::ThemeSpecRuntimePolicy;
 using codexbar_display::esp8266::AssetPathPolicy;
 using codexbar_display::esp8266::WifiSecurityPolicy;
+using codexbar_display::esp8266::ConnectedSetupPolicy;
 
 std::string readFile(const char* path);
 
@@ -635,6 +637,36 @@ bool testFirmwareUsesIPDiscoveryInsteadOfMdns(const char* mainPath) {
       "firmware must expose setup and station endpoints by IP without mDNS");
 }
 
+bool testConnectedSetupAddressPolicy() {
+  return expect(
+             ConnectedSetupPolicy::IsStationIPv4("172.30.12.34") &&
+                 ConnectedSetupPolicy::IsStationIPv4("192.168.178.163"),
+             "connected setup must accept readable station IPv4 addresses") &&
+         expect(
+             !ConnectedSetupPolicy::IsStationIPv4("") &&
+                 !ConnectedSetupPolicy::IsStationIPv4("0.0.0.0") &&
+                 !ConnectedSetupPolicy::IsStationIPv4("192.168.4.1") &&
+                 !ConnectedSetupPolicy::IsStationIPv4("999.1.2.3") &&
+                 !ConnectedSetupPolicy::IsStationIPv4("not-an-ip"),
+             "connected setup must hide unavailable, AP-mode, and invalid IPv4 values");
+}
+
+bool testConnectedSetupRendererShowsSafeIpFallback(const char* rendererPath) {
+  const std::string renderer = readFile(rendererPath);
+  const std::size_t start = renderer.find("void RendererESP8266::DrawConnectedSetupInstructions(");
+  const std::size_t end = renderer.find("\n}\n\n#ifndef CODEXBAR_DISPLAY_PROBE_ONLY", start);
+  if (!expect(start != std::string::npos && end != std::string::npos, "connected setup renderer must remain testable")) {
+    return false;
+  }
+  const std::string function = renderer.substr(start, end - start);
+  return expect(
+      function.find("ConnectedSetupPolicy::IsStationIPv4") != std::string::npos &&
+          function.find("IP: ") != std::string::npos &&
+          function.find("IP unavailable") != std::string::npos &&
+          function.find("tft.print(ipLine)") != std::string::npos,
+      "connected setup renderer must display a validated IP line and an unavailable state");
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -705,6 +737,12 @@ int main(int argc, char** argv) {
     return 1;
   }
   if (!testFirmwareUsesIPDiscoveryInsteadOfMdns(argv[3])) {
+    return 1;
+  }
+  if (!testConnectedSetupAddressPolicy()) {
+    return 1;
+  }
+  if (!testConnectedSetupRendererShowsSafeIpFallback(argv[4])) {
     return 1;
   }
 


### PR DESCRIPTION
## Summary

- show the current station IPv4 address on every connected VibeTV setup/waiting screen while rejecting unavailable, AP-mode, and stale addresses
- keep bounded automatic discovery unchanged and expose manual IP entry immediately while WiFi search is running
- validate manual targets through the existing bounded read-only hello identity checks before the existing pairing and device-selection path persists them
- simplify the Control Center UI so the spinner precedes the always-visible IP field
- after an unsuccessful search, show the WiFi setup steps first, then `Scan WiFi again`, then the alternative manual IP field

## Why

Automatic discovery intentionally avoids scanning complete large office subnets such as a `/18` or `/16`. Previously, customers could wait for a bounded scan that could not reach their VibeTV, while the VibeTV screen did not show the address needed for the manual fallback.

## Customer impact

Normal home-network discovery continues to work as before. Customers on large, isolated, or filtered networks can read the VibeTV address from its screen and connect directly without waiting for discovery to time out.

## Validation

- `./scripts/check-gif-core-policy-tests.sh`
- `cd companion && go test ./...`
- `cd apps/control-center && npm run test:unit` — 69 tests passed
- `cd apps/control-center && npm run lint`
- `cd apps/control-center && npm run check:customer-ui-copy`
- `cd apps/control-center && npm run check:ui-review`
- `cd apps/control-center && npm run test:customer-flows`

## Physical QA

- flashed the issue firmware by USB to VibeTV device `14799300`
- user visually confirmed that station IP `172.30.0.31` is readable on the physical waiting screen
- exercised the real Mac App `Connect VibeTV` action against that displayed IP
- observed the targeted request `POST /v1/device/search` with `target=http://172.30.0.31`
- observed `POST /v1/device/select` with `expectedDeviceId=14799300`
- read back `target=http://172.30.0.31`, `deviceId=14799300`, `connected=true`, `paired=true`, `ready=true`, and a healthy running display stream
- the final follow-up commit only changes the presentation/order of the already-tested form and leaves this connection handler unchanged

Closes #227