### PR TITLE
CODEX: Fix packed token cache totals

### DIFF
--- a/apps/control-center/scripts/check-customer-ui-copy.mjs
+++ b/apps/control-center/scripts/check-customer-ui-copy.mjs
@@ -9,9 +9,19 @@ const files = [
   ...collectFiles(join(appRoot, "src", "components")),
   ...collectFiles(join(appRoot, "src", "app")),
   join(appRoot, "src", "lib", "themes.ts"),
-].filter((file) => file.endsWith(".tsx") || file.endsWith(".ts"));
+].filter(
+  (file) =>
+    (file.endsWith(".tsx") || file.endsWith(".ts")) &&
+    !file.includes(".test.") &&
+    !file.includes(".spec."),
+);
 
 const forbiddenPatterns = [
+  {
+    label: "internal usage service name",
+    pattern: /\bCodexBar\b/,
+    suggestion: "Describe the customer action without naming the internal service.",
+  },
   {
     label: "internal Companion service name",
     pattern: /\bCompanion\b/,

--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -1281,8 +1281,20 @@ async function testProviderReadinessCustomerStates(browser, appUrl) {
 
     await clickNavigation(page, "Usage");
     await page
-      .getByRole("heading", { name: "Codex", exact: true })
+      .getByText("Loading usage", { exact: true })
       .waitFor({ timeout: 10_000 });
+    await page
+      .getByRole("heading", { name: "AI providers", exact: true })
+      .waitFor({ timeout: 10_000 });
+    await page
+      .getByRole("switch", { name: "Disable Codex" })
+      .waitFor({ timeout: 10_000 });
+    assert(
+      (await page
+        .getByText("Total tokens in the last 30 days", { exact: true })
+        .count()) === 0,
+      "Token totals must stay hidden until token history is ready",
+    );
     assert(
       (await page
         .getByRole("heading", { name: "Connect an AI provider" })

--- a/apps/control-center/src/components/control-center-app.tsx
+++ b/apps/control-center/src/components/control-center-app.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { RefreshCw } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -9,12 +8,6 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { availableMacAppDmgDownloadUrl } from "@/lib/companion-release";
 import { hasFirmwareUpdate, type FirmwareUpdateInfo } from "@/lib/firmware";
 import { buildThemePack } from "@/lib/theme-studio";
@@ -2349,6 +2342,10 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
         const normalized = normalizeUsageError(
           normalizeCaughtError(error, "Usage needs attention."),
         );
+        if (normalized.code === "usage_unavailable") {
+          setUsageError(null);
+          return;
+        }
         if (isLocalNetworkAccessError(normalized)) {
           markCompanionAccessBlocked();
         } else if (isCompanionMissingError(normalized)) {
@@ -2936,35 +2933,6 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
       activeTab={activeShellTab}
       disabledTabs={disabledTabs}
       device={device}
-      headerAction={
-        activeShellTab === "usage" ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                aria-label="Refresh usage"
-                disabled={busyAction === "usage"}
-                onClick={() =>
-                  void Promise.all([
-                    refreshUsage(),
-                    refreshProviderPreferences(),
-                  ])
-                }
-                size="icon"
-                type="button"
-                variant="ghost"
-              >
-                <RefreshCw
-                  className={busyAction === "usage" ? "animate-spin" : undefined}
-                  aria-hidden
-                />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              {busyAction === "usage" ? "Refreshing usage" : "Refresh usage"}
-            </TooltipContent>
-          </Tooltip>
-        ) : null
-      }
       updateAvailable={anyUpdateAvailable}
       onTabChange={(tab) => {
         if (disabledTabs.includes(tab)) {

--- a/apps/control-center/src/components/control-center-types.ts
+++ b/apps/control-center/src/components/control-center-types.ts
@@ -389,6 +389,7 @@ export type UsageSnapshot = {
   generatedAt?: string;
   source?: string;
   usageMode?: "used" | "remaining" | string;
+  tokenUsageReady?: boolean;
   currentProvider?: string;
   providers: UsageProviderInfo[];
 };

--- a/apps/control-center/src/components/provider-setup-card.tsx
+++ b/apps/control-center/src/components/provider-setup-card.tsx
@@ -76,7 +76,7 @@ export function ProviderSetupCard({
           </h4>
           <p className="mt-1 text-sm leading-6 text-[#444933]">
             {checking
-              ? "CodexBar is checking your provider sign-ins and usage limits."
+              ? "VibeTV is checking your provider sign-ins and usage limits."
               : providerSetupSummary(providerSetup)}
           </p>
         </div>
@@ -109,7 +109,7 @@ export function ProviderSetupCard({
             size="lg"
           >
             <Wrench data-icon="inline-start" aria-hidden />
-            Repair CodexBar
+            Repair usage service
           </Button>
         ) : null}
         {onOpenCodexBar ? (
@@ -125,7 +125,9 @@ export function ProviderSetupCard({
             ) : (
               <ExternalLink data-icon="inline-start" aria-hidden />
             )}
-            {busyAction === "providers-open" ? "Opening CodexBar" : "Open CodexBar"}
+            {busyAction === "providers-open"
+              ? "Opening provider setup"
+              : "Open provider setup"}
           </Button>
         ) : null}
         {onRetry ? (
@@ -214,10 +216,10 @@ export function providerSetupStatusLabel(
   }
   const engineStatus = normalizeStatus(providerSetup.engine?.status);
   if (engineStatus === "not_configured") {
-    return "CodexBar setup needed";
+    return "Usage service setup needed";
   }
   if (engineStatus === "config_error") {
-    return "CodexBar settings need attention";
+    return "Usage service settings need attention";
   }
   return "Setup needed";
 }
@@ -237,7 +239,7 @@ export function providerSetupStatusDetail(
     providerSetup.engine?.detail?.trim() ||
     providerSetup.nextAction?.trim() ||
     providerSetup.engine?.nextAction?.trim() ||
-    "Open CodexBar and connect a provider that exposes usage limits."
+    "Open provider setup and connect a provider that exposes usage limits."
   );
 }
 
@@ -270,7 +272,7 @@ function providerSetupSummary(providerSetup: ProviderSetupInfo): string {
     providerSetup.engine?.detail?.trim() ||
     providerSetup.nextAction?.trim() ||
     providerSetup.engine?.nextAction?.trim() ||
-    "Open CodexBar and connect a provider that exposes usage limits."
+    "Open provider setup and connect a provider that exposes usage limits."
   );
 }
 
@@ -290,21 +292,21 @@ function providerIssueDetail(provider: ProviderReadinessInfo): string {
   const name = provider.label || providerName(provider.id) || "This provider";
   switch (normalizeStatus(provider.status)) {
     case "auth_required":
-      return `Sign in to ${name} in CodexBar, then check again.`;
+      return `Sign in to ${name}, then check again.`;
     case "permission_required":
-      return `${name} needs permission to read your sign-in. Open CodexBar and allow access, then check again.`;
+      return `${name} needs permission to read your sign-in. Allow access, then check again.`;
     case "no_usage_available":
       return `${name} is connected, but this account does not expose usage limits. Choose another provider.`;
     case "timeout":
-      return `${name} did not answer in time. Open CodexBar, confirm the sign-in, then check again.`;
+      return `${name} did not answer in time. Confirm the sign-in, then check again.`;
     case "config_error":
-      return "CodexBar could not save its provider settings. Open CodexBar and finish provider setup there.";
+      return "The usage service could not save its provider settings. Repair it, then check again.";
     case "engine_error":
-      return "CodexBar needs attention before VibeTV can read provider usage.";
+      return "The usage service needs attention before VibeTV can read provider usage.";
     case "not_configured":
-      return `Open CodexBar and connect ${name}, then check again.`;
+      return `Open provider setup and connect ${name}, then check again.`;
     default:
-      return `Open CodexBar and finish setting up ${name}.`;
+      return `Open provider setup and finish setting up ${name}.`;
   }
 }
 
@@ -321,7 +323,7 @@ function providerStatusLabel(status: ProviderReadinessStatus): string {
     case "config_error":
       return "Settings need attention";
     case "engine_error":
-      return "CodexBar needs attention";
+      return "Usage service needs attention";
     case "not_configured":
       return "Not configured";
     default:

--- a/apps/control-center/src/components/usage-screen.test.tsx
+++ b/apps/control-center/src/components/usage-screen.test.tsx
@@ -4,6 +4,7 @@ import { UsageScreen } from "./usage-screen";
 
 const usage = {
   ok: true,
+  tokenUsageReady: true,
   currentProvider: "codex",
   providers: [
     {
@@ -23,6 +24,27 @@ const usage = {
       },
     },
   ],
+};
+
+const codexPreference = {
+  id: "provider.codex.enabled",
+  section: "providers",
+  owner: "codexbar" as const,
+  type: "boolean" as const,
+  label: "Codex",
+  value: true,
+  effectiveValue: true,
+  allowsDefault: false,
+  availability: {
+    state: "available" as const,
+  },
+  writeStrategy: "codexbar_command" as const,
+  writable: true,
+  health: {
+    state: "healthy",
+    service: "operational",
+    message: "Provider is working.",
+  },
 };
 
 function renderUsage(busyAction: string | null = null) {
@@ -80,6 +102,61 @@ describe("UsageScreen", () => {
     expect(html).toContain("Try again</button>");
     expect(html).not.toContain("Loading usage");
     expect(html).not.toContain("CodexBar");
+  });
+
+  it("keeps token usage loading while an already loaded provider list remains visible", () => {
+    const html = renderToStaticMarkup(
+      <UsageScreen
+        companionStatus="online"
+        onPreferenceChange={vi.fn()}
+        onRefresh={vi.fn()}
+        pendingPreferenceIds={new Set()}
+        preferences={[codexPreference]}
+        usage={{
+          ...usage,
+          tokenUsageReady: false,
+          providers: usage.providers.map((provider) => ({
+            ...provider,
+            cost: undefined,
+            totalTokens: 9000,
+          })),
+        }}
+      />,
+    );
+
+    expect(html).toContain("Loading usage");
+    expect(html).toContain("AI providers");
+    expect(html).toContain('aria-label="Disable Codex"');
+    expect(html).not.toContain("Total tokens in the last 30 days");
+    expect(html).not.toContain("Tokens used over time");
+  });
+
+  it("renders a successful zero token result instead of staying in loading", () => {
+    const html = renderToStaticMarkup(
+      <UsageScreen
+        companionStatus="online"
+        onPreferenceChange={vi.fn()}
+        onRefresh={vi.fn()}
+        pendingPreferenceIds={new Set()}
+        preferences={[]}
+        usage={{
+          ...usage,
+          tokenUsageReady: true,
+          providers: usage.providers.map((provider) => ({
+            ...provider,
+            session: 0,
+            weekly: 0,
+            cost: {
+              daily: [],
+            },
+          })),
+        }}
+      />,
+    );
+
+    expect(html).toContain("zero tokens");
+    expect(html).toContain("No data");
+    expect(html).not.toContain("Loading usage");
   });
 
   it("shows a dedicated token usage refresh action", () => {

--- a/apps/control-center/src/components/usage-screen.test.tsx
+++ b/apps/control-center/src/components/usage-screen.test.tsx
@@ -40,6 +40,48 @@ function renderUsage(busyAction: string | null = null) {
 }
 
 describe("UsageScreen", () => {
+  it("shows a simple loading state while the first usage snapshot is pending", () => {
+    const html = renderToStaticMarkup(
+      <UsageScreen
+        companionStatus="online"
+        onPreferenceChange={vi.fn()}
+        onRefresh={vi.fn()}
+        pendingPreferenceIds={new Set()}
+        preferences={null}
+        usage={null}
+      />,
+    );
+
+    expect(html).toContain("Loading usage");
+    expect(html).toContain('data-slot="spinner"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).not.toContain("CodexBar");
+    expect(html).not.toContain("No provider usage is available yet.");
+  });
+
+  it("offers a generic retry for a real usage error", () => {
+    const html = renderToStaticMarkup(
+      <UsageScreen
+        companionStatus="online"
+        onPreferenceChange={vi.fn()}
+        onRefresh={vi.fn()}
+        pendingPreferenceIds={new Set()}
+        preferences={[]}
+        usage={null}
+        usageError={{
+          code: "COMPANION_TIMEOUT",
+          message: "Usage needs attention.",
+          nextAction: "Check the Mac App, then try again.",
+        }}
+      />,
+    );
+
+    expect(html).toContain("Usage needs attention.");
+    expect(html).toContain("Try again</button>");
+    expect(html).not.toContain("Loading usage");
+    expect(html).not.toContain("CodexBar");
+  });
+
   it("shows a dedicated token usage refresh action", () => {
     const html = renderUsage();
 

--- a/apps/control-center/src/components/usage-screen.tsx
+++ b/apps/control-center/src/components/usage-screen.tsx
@@ -96,13 +96,15 @@ export function UsageScreen({
   onPreferenceChange,
 }: UsageScreenProps) {
   const refreshing = busyAction === "usage";
-  const loading =
-    companionStatus === "online" && !usage && !usageError;
   const providers = filterVisibleProviders(
     usage?.providers || [],
     usage?.currentProvider,
   );
   const hasProviders = providers.length > 0;
+  const tokenUsageReady =
+    usage?.tokenUsageReady === true || usageProvidersHaveTokenResult(providers);
+  const tokenUsageLoading =
+    companionStatus === "online" && !usageError && !tokenUsageReady;
 
   return (
     <div className="mx-auto max-w-[1180px]">
@@ -130,7 +132,9 @@ export function UsageScreen({
           </Alert>
         ) : null}
 
-        {hasProviders ? (
+        {tokenUsageLoading ? (
+          <UsageEmptyState companionStatus={companionStatus} loading />
+        ) : hasProviders ? (
           <TokenUsageOverTimePanel
             onRefresh={onRefresh}
             providers={providers}
@@ -138,7 +142,7 @@ export function UsageScreen({
           />
         ) : null}
 
-        {hasProviders ? (
+        {!tokenUsageLoading && hasProviders ? (
           <ol className="grid gap-5 md:grid-cols-2 2xl:grid-cols-3">
             {providers.map((provider) => (
               <li className="min-w-0" key={provider.id}>
@@ -146,12 +150,12 @@ export function UsageScreen({
               </li>
             ))}
           </ol>
-        ) : usageError ? null : (
+        ) : !tokenUsageLoading && !usageError ? (
           <UsageEmptyState
             companionStatus={companionStatus}
-            loading={loading || refreshing}
+            loading={false}
           />
-        )}
+        ) : null}
 
         <ProviderPreferencesPanel
           error={preferencesError}
@@ -379,7 +383,7 @@ function TokenUsageOverTimePanel({
   const providerNames = displayedHistories.map(
     ({ provider }) => provider.label || provider.id,
   );
-  const last30DaysTokens = getLast30DaysTokenTotal(providers);
+  const last30DaysTokens = getLast30DaysTokenTotal(providers) ?? 0;
 
   return (
     <>
@@ -775,6 +779,12 @@ function providerHasTokens(provider: UsageProviderInfo): boolean {
     (provider.weekTokens || 0) > 0 ||
     (provider.totalTokens || 0) > 0
   );
+}
+
+function usageProvidersHaveTokenResult(
+  providers: UsageProviderInfo[],
+): boolean {
+  return providers.some((provider) => provider.cost != null);
 }
 
 function providerHasCost(provider: UsageProviderInfo): boolean {

--- a/apps/control-center/src/components/usage-screen.tsx
+++ b/apps/control-center/src/components/usage-screen.tsx
@@ -96,6 +96,8 @@ export function UsageScreen({
   onPreferenceChange,
 }: UsageScreenProps) {
   const refreshing = busyAction === "usage";
+  const loading =
+    companionStatus === "online" && !usage && !usageError;
   const providers = filterVisibleProviders(
     usage?.providers || [],
     usage?.currentProvider,
@@ -106,7 +108,26 @@ export function UsageScreen({
     <div className="mx-auto max-w-[1180px]">
       <section className="py-10">
         {usageError ? (
-          <Alert className="mb-6 bg-muted"><AlertTriangle /><AlertTitle>{usageError.message}</AlertTitle><AlertDescription>{usageError.nextAction}</AlertDescription></Alert>
+          <Alert className="mb-6 bg-muted">
+            <AlertTriangle />
+            <AlertTitle>{usageError.message}</AlertTitle>
+            <AlertDescription className="grid justify-items-start gap-3">
+              <span>{usageError.nextAction}</span>
+              {onRefresh ? (
+                <Button
+                  aria-busy={refreshing}
+                  disabled={refreshing}
+                  onClick={onRefresh}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  {refreshing ? <Spinner /> : <RefreshCw aria-hidden />}
+                  {refreshing ? "Trying again" : "Try again"}
+                </Button>
+              ) : null}
+            </AlertDescription>
+          </Alert>
         ) : null}
 
         {hasProviders ? (
@@ -128,7 +149,7 @@ export function UsageScreen({
         ) : usageError ? null : (
           <UsageEmptyState
             companionStatus={companionStatus}
-            refreshing={refreshing}
+            loading={loading || refreshing}
           />
         )}
 
@@ -669,34 +690,40 @@ function UsageWindowBar({
 
 function UsageEmptyState({
   companionStatus,
-  refreshing,
+  loading,
 }: {
   companionStatus: CompanionStatus;
-  refreshing: boolean;
+  loading: boolean;
 }) {
   const message =
     companionStatus === "online"
-      ? refreshing
-        ? "Loading provider usage."
+      ? loading
+        ? "Loading usage"
         : "No provider usage is available yet."
       : "Mac App needs setup.";
   const action =
     companionStatus === "online"
-      ? "Enable a provider below to start seeing usage."
+      ? loading
+        ? null
+        : "Enable a provider below to start seeing usage."
       : "Run setup again, then refresh usage.";
 
   return (
-    <Empty className="bg-muted/50 py-10 ring-1 ring-foreground/10">
+    <Empty
+      aria-live="polite"
+      className="bg-muted/50 py-10 ring-1 ring-foreground/10"
+      role="status"
+    >
       <EmptyHeader>
         <EmptyMedia variant="icon">
-          {refreshing ? (
-            <RefreshCw className="animate-spin" size={17} aria-hidden />
+          {loading ? (
+            <Spinner />
           ) : (
             <BarChart3 size={17} aria-hidden />
           )}
         </EmptyMedia>
         <EmptyTitle>{message}</EmptyTitle>
-        <EmptyDescription>{action}</EmptyDescription>
+        {action ? <EmptyDescription>{action}</EmptyDescription> : null}
       </EmptyHeader>
     </Empty>
   );

--- a/companion/internal/codexbar/provider_setup.go
+++ b/companion/internal/codexbar/provider_setup.go
@@ -314,7 +314,7 @@ func classifyProviderError(detail string) string {
 func providerResult(id, status string) ProviderReadiness {
 	label := humanLabel(id)
 	if id == "codexbar" {
-		label = "CodexBar"
+		label = "Usage service"
 	}
 	result := ProviderReadiness{ID: id, Label: label, Status: status}
 	switch status {
@@ -322,25 +322,25 @@ func providerResult(id, status string) ProviderReadiness {
 		result.Detail = "Usage data is available."
 	case ProviderAuthRequired:
 		result.Detail = "This provider needs an active sign-in."
-		result.NextAction = "Open CodexBar and sign in to this provider, then check again."
+		result.NextAction = "Sign in to this provider, then check again."
 	case ProviderPermissionRequired:
 		result.Detail = "macOS blocked access required by this provider."
-		result.NextAction = "Open CodexBar and allow the requested macOS permission, then check again."
+		result.NextAction = "Allow the requested macOS permission, then check again."
 	case ProviderNoUsageAvailable:
 		result.Detail = "This account does not expose usage data."
 		result.NextAction = "Choose another provider that exposes usage limits."
 	case ProviderTimeout:
 		result.Detail = "The provider check timed out."
-		result.NextAction = "Open CodexBar, confirm the provider works, then check again."
+		result.NextAction = "Confirm the provider sign-in, then check again."
 	case ProviderConfigError:
-		result.Detail = "CodexBar could not save or read its provider configuration."
-		result.NextAction = "Open CodexBar and check its provider settings."
+		result.Detail = "The usage service could not save or read its provider settings."
+		result.NextAction = "Repair the usage service, then check again."
 	case ProviderNotConfigured:
 		result.Detail = "No usable AI provider is configured yet."
-		result.NextAction = "Open CodexBar and connect an AI provider."
+		result.NextAction = "Open provider setup and connect an AI provider."
 	default:
-		result.Detail = "CodexBar could not read this provider."
-		result.NextAction = "Open CodexBar, check this provider, then try again."
+		result.Detail = "The usage service could not read this provider."
+		result.NextAction = "Check this provider, then try again."
 	}
 	return result
 }

--- a/companion/internal/codexbar/provider_setup_test.go
+++ b/companion/internal/codexbar/provider_setup_test.go
@@ -156,6 +156,24 @@ func TestProviderReadinessClassifiesTimeoutWithoutSecrets(t *testing.T) {
 	}
 }
 
+func TestProviderReadinessCopyHidesInternalUsageServiceName(t *testing.T) {
+	for _, status := range []string{
+		ProviderAuthRequired,
+		ProviderPermissionRequired,
+		ProviderNoUsageAvailable,
+		ProviderTimeout,
+		ProviderConfigError,
+		ProviderEngineError,
+		ProviderNotConfigured,
+	} {
+		got := providerResult("codexbar", status)
+		customerCopy := strings.Join([]string{got.Label, got.Detail, got.NextAction}, " ")
+		if strings.Contains(customerCopy, "CodexBar") {
+			t.Fatalf("%s leaked the internal service name: %+v", status, got)
+		}
+	}
+}
+
 func TestProbeProviderSetupReportsReadyProvider(t *testing.T) {
 	originalUsage := runUsageCommandFn
 	originalVersion := runVersionCommandFn

--- a/companion/internal/codexbar/token_stats.go
+++ b/companion/internal/codexbar/token_stats.go
@@ -365,10 +365,30 @@ func parseProviderCostUsagePayload(payload map[string]any, fallbackLatestTokens 
 		cost.Last30DaysCostUSD <= 0 &&
 		cost.Last30DaysTokens <= 0 &&
 		cost.LatestTokens <= 0 &&
-		cost.TopModel == "" {
+		cost.TopModel == "" &&
+		!providerTokenStatsPayloadHasResult(payload) {
 		return ProviderCostUsage{}, false
 	}
 	return cost, true
+}
+
+func providerTokenStatsPayloadHasResult(payload map[string]any) bool {
+	if providerPayloadHasError(payload) {
+		return false
+	}
+	for _, key := range []string{
+		"daily",
+		"totals",
+		"sessionTokens",
+		"latestTokens",
+		"last30DaysTokens",
+		"totalTokens",
+	} {
+		if _, ok := payload[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func parseProviderCostDays(raw any) []ProviderCostDay {

--- a/companion/internal/codexbar/token_stats_cost_cache.go
+++ b/companion/internal/codexbar/token_stats_cost_cache.go
@@ -2,14 +2,21 @@ package codexbar
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
 
 const tokenStatsCostCacheMaxAge = 24 * time.Hour
+
+const (
+	codexCostCacheArtifactVersion  = 10
+	claudeCostCacheArtifactVersion = 5
+)
 
 type codexBarCostCache struct {
 	Version        int                           `json:"version"`
@@ -28,46 +35,76 @@ func loadProviderTokenStatsFromCostCache(now time.Time) (map[string]ProviderToke
 func loadProviderTokenStatsFromCostCacheAt(cacheRoot string, now time.Time) (map[string]ProviderTokenStats, bool) {
 	providers := make(map[string]ProviderTokenStats, 2)
 	for _, provider := range []string{"codex", "claude"} {
-		path, ok := newestCostCachePath(cacheRoot, provider)
-		if !ok {
+		path, found, supported := supportedCostCachePath(cacheRoot, provider)
+		if !found {
 			continue
+		}
+		if !supported {
+			return nil, false
 		}
 		raw, err := os.ReadFile(path)
 		if err != nil {
-			continue
+			return nil, false
 		}
 		var cache codexBarCostCache
 		if err := json.Unmarshal(raw, &cache); err != nil || cache.Version != 1 || len(cache.Days) == 0 {
-			continue
+			return nil, false
 		}
 		updatedAt := time.UnixMilli(cache.LastScanUnixMS).UTC()
 		if updatedAt.IsZero() || updatedAt.After(now.Add(5*time.Minute)) || now.Sub(updatedAt) > tokenStatsCostCacheMaxAge {
-			continue
+			return nil, false
 		}
 		if stats, ok := providerTokenStatsFromCostCache(provider, cache, updatedAt); ok {
 			providers[provider] = stats
+		} else {
+			return nil, false
 		}
 	}
 	return providers, len(providers) > 0
 }
 
-func newestCostCachePath(cacheRoot, provider string) (string, bool) {
+func supportedCostCachePath(cacheRoot, provider string) (path string, found bool, supported bool) {
+	expectedVersion, ok := supportedCostCacheArtifactVersion(provider)
+	if !ok {
+		return "", false, false
+	}
 	paths, err := filepath.Glob(filepath.Join(cacheRoot, provider+"-v*.json"))
 	if err != nil || len(paths) == 0 {
-		return "", false
+		return "", false, false
 	}
-	sort.Slice(paths, func(i, j int) bool {
-		left, leftErr := os.Stat(paths[i])
-		right, rightErr := os.Stat(paths[j])
-		if leftErr != nil {
-			return false
+
+	var expectedPath string
+	var newestVersion int
+	prefix := provider + "-v"
+	for _, path := range paths {
+		name := filepath.Base(path)
+		versionText := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".json")
+		version, err := strconv.Atoi(versionText)
+		if err != nil || version <= 0 {
+			return "", true, false
 		}
-		if rightErr != nil {
-			return true
+		if version > newestVersion {
+			newestVersion = version
 		}
-		return left.ModTime().After(right.ModTime())
-	})
-	return paths[0], true
+		if version == expectedVersion {
+			expectedPath = path
+		}
+	}
+	if newestVersion != expectedVersion || expectedPath == "" {
+		return "", true, false
+	}
+	return expectedPath, true, true
+}
+
+func supportedCostCacheArtifactVersion(provider string) (int, bool) {
+	switch provider {
+	case "codex":
+		return codexCostCacheArtifactVersion, true
+	case "claude":
+		return claudeCostCacheArtifactVersion, true
+	default:
+		return 0, false
+	}
 }
 
 func providerTokenStatsFromCostCache(provider string, cache codexBarCostCache, updatedAt time.Time) (ProviderTokenStats, bool) {
@@ -80,9 +117,15 @@ func providerTokenStatsFromCostCache(provider string, cache codexBarCostCache, u
 		models := make([]ProviderCostModel, 0, len(packedModels))
 		var dayTokens int64
 		for model, packed := range packedModels {
-			tokens := packedTokenTotal(provider, packed)
+			tokens, layoutOK := packedTokenTotal(provider, packed)
+			if !layoutOK {
+				return ProviderTokenStats{}, false
+			}
 			if strings.TrimSpace(model) == "" || tokens <= 0 {
 				continue
+			}
+			if tokens > math.MaxInt64-dayTokens {
+				return ProviderTokenStats{}, false
 			}
 			models = append(models, ProviderCostModel{Name: model, TotalTokens: tokens})
 			dayTokens += tokens
@@ -142,16 +185,45 @@ func providerTokenStatsFromCostCache(provider string, cache codexBarCostCache, u
 	}, true
 }
 
-func packedTokenTotal(provider string, packed []int64) int64 {
-	indices := []int{0, 1, 2}
-	if provider == "claude" {
-		indices = []int{0, 1, 2, 3}
+func packedTokenTotal(provider string, packed []int64) (int64, bool) {
+	switch provider {
+	case "codex":
+		return codexPackedTokenTotal(packed)
+	case "claude":
+		return claudePackedTokenTotal(packed)
+	default:
+		return 0, false
 	}
-	var total int64
-	for _, index := range indices {
-		if index < len(packed) && packed[index] > 0 {
-			total += packed[index]
+}
+
+func codexPackedTokenTotal(packed []int64) (int64, bool) {
+	// Codex v10 stores [input, cached input, output]. Cached input is already
+	// included in input, so adding index 1 again inflates the CLI-equivalent total.
+	return sumPackedTokenIndices(packed, 3, 0, 2)
+}
+
+func claudePackedTokenTotal(packed []int64) (int64, bool) {
+	// Claude v5 stores [input, cache read, cache create, output, cost nanos,
+	// sample count, priced sample count, 1h cache create].
+	return sumPackedTokenIndices(packed, 8, 0, 1, 2, 3)
+}
+
+func sumPackedTokenIndices(packed []int64, expectedLength int, indices ...int) (int64, bool) {
+	if len(packed) != expectedLength {
+		return 0, false
+	}
+	for _, value := range packed {
+		if value < 0 {
+			return 0, false
 		}
 	}
-	return total
+
+	var total int64
+	for _, index := range indices {
+		if packed[index] > math.MaxInt64-total {
+			return 0, false
+		}
+		total += packed[index]
+	}
+	return total, true
 }

--- a/companion/internal/codexbar/token_stats_cost_cache.go
+++ b/companion/internal/codexbar/token_stats_cost_cache.go
@@ -59,6 +59,9 @@ func loadProviderTokenStatsFromCostCacheAt(cacheRoot string, now time.Time) (map
 		if updatedAt.IsZero() || updatedAt.After(now.Add(5*time.Minute)) || now.Sub(updatedAt) > tokenStatsCostCacheMaxAge {
 			return nil, false
 		}
+		if updatedAt.In(time.Local).Format("2006-01-02") != now.In(time.Local).Format("2006-01-02") {
+			return nil, false
+		}
 		if stats, ok := providerTokenStatsFromCostCache(provider, cache, updatedAt); ok {
 			providers[provider] = stats
 		} else {

--- a/companion/internal/codexbar/token_stats_cost_cache.go
+++ b/companion/internal/codexbar/token_stats_cost_cache.go
@@ -16,10 +16,12 @@ const tokenStatsCostCacheMaxAge = 24 * time.Hour
 const (
 	codexCostCacheArtifactVersion  = 10
 	claudeCostCacheArtifactVersion = 5
+	codexCostCacheProducerKey      = "codex:cu:p2d056ae5a24d5157"
 )
 
 type codexBarCostCache struct {
 	Version        int                           `json:"version"`
+	ProducerKey    string                        `json:"producerKey"`
 	LastScanUnixMS int64                         `json:"lastScanUnixMs"`
 	Days           map[string]map[string][]int64 `json:"days"`
 }
@@ -48,6 +50,9 @@ func loadProviderTokenStatsFromCostCacheAt(cacheRoot string, now time.Time) (map
 		}
 		var cache codexBarCostCache
 		if err := json.Unmarshal(raw, &cache); err != nil || cache.Version != 1 || len(cache.Days) == 0 {
+			return nil, false
+		}
+		if provider == "codex" && cache.ProducerKey != codexCostCacheProducerKey {
 			return nil, false
 		}
 		updatedAt := time.UnixMilli(cache.LastScanUnixMS).UTC()
@@ -108,10 +113,13 @@ func supportedCostCacheArtifactVersion(provider string) (int, bool) {
 }
 
 func providerTokenStatsFromCostCache(provider string, cache codexBarCostCache, updatedAt time.Time) (ProviderTokenStats, bool) {
+	anchor := updatedAt.In(time.Local)
+	anchorDay := anchor.Format("2006-01-02")
+	windowStart := anchor.AddDate(0, 0, -29).Format("2006-01-02")
 	days := make([]ProviderCostDay, 0, len(cache.Days))
 	for dayKey, packedModels := range cache.Days {
 		day := usageDayKey(dayKey)
-		if day == "" || len(packedModels) == 0 {
+		if day == "" || day < windowStart || day > anchorDay || len(packedModels) == 0 {
 			continue
 		}
 		models := make([]ProviderCostModel, 0, len(packedModels))
@@ -148,19 +156,21 @@ func providerTokenStatsFromCostCache(provider string, cache codexBarCostCache, u
 		return ProviderTokenStats{}, false
 	}
 	sort.Slice(days, func(i, j int) bool { return days[i].Day < days[j].Day })
-	if len(days) > 30 {
-		days = days[len(days)-30:]
-	}
 
-	anchorDay := updatedAt.Format("2006-01-02")
-	weekStart := updatedAt.AddDate(0, 0, -6).Format("2006-01-02")
+	weekStart := anchor.AddDate(0, 0, -6).Format("2006-01-02")
 	var latestTokens, weekTokens, totalTokens int64
 	for _, day := range days {
+		if day.TotalTokens > math.MaxInt64-totalTokens {
+			return ProviderTokenStats{}, false
+		}
 		totalTokens += day.TotalTokens
 		if day.Day == anchorDay {
 			latestTokens = day.TotalTokens
 		}
 		if day.Day >= weekStart && day.Day <= anchorDay {
+			if day.TotalTokens > math.MaxInt64-weekTokens {
+				return ProviderTokenStats{}, false
+			}
 			weekTokens += day.TotalTokens
 		}
 	}

--- a/companion/internal/codexbar/token_stats_test.go
+++ b/companion/internal/codexbar/token_stats_test.go
@@ -149,6 +149,7 @@ func TestMergeTokenStatsAddsFrameFields(t *testing.T) {
 }
 
 func TestLoadProviderTokenStatsFromCostCacheCodexLayout(t *testing.T) {
+	setTokenStatsTestLocalLocation(t, time.UTC)
 	cacheRoot := t.TempDir()
 	now := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
 	writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v10.json"), `{
@@ -253,12 +254,14 @@ func TestLoadProviderTokenStatsFromCostCacheRejectsUnknownPackedLayout(t *testin
 }
 
 func TestLoadProviderTokenStatsFromCostCacheUsesRollingCalendarWindow(t *testing.T) {
+	location := time.FixedZone("UTC+14", 14*60*60)
+	setTokenStatsTestLocalLocation(t, location)
 	cacheRoot := t.TempDir()
-	now := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 7, 22, 18, 0, 0, 0, location)
 	writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v10.json"), `{
 		"version":1,
 		"producerKey":"codex:cu:p2d056ae5a24d5157",
-		"lastScanUnixMs":1784743200000,
+		"lastScanUnixMs":`+fmtInt64(now.UnixMilli())+`,
 		"days":{
 			"2026-06-22":{"gpt-5.5":[1000,800,200]},
 			"2026-06-23":{"gpt-5.5":[10,8,2]},
@@ -276,6 +279,24 @@ func TestLoadProviderTokenStatsFromCostCacheUsesRollingCalendarWindow(t *testing
 	}
 	if codex.Cost.Daily[0].Day != "2026-06-23" || codex.Cost.Daily[1].Day != "2026-07-22" {
 		t.Fatalf("unexpected rolling-window days: %+v", codex.Cost.Daily)
+	}
+}
+
+func TestLoadProviderTokenStatsFromCostCacheRejectsPreviousLocalDay(t *testing.T) {
+	location := time.FixedZone("UTC+14", 14*60*60)
+	setTokenStatsTestLocalLocation(t, location)
+	cacheRoot := t.TempDir()
+	lastScan := time.Date(2026, 7, 22, 23, 59, 0, 0, location)
+	now := time.Date(2026, 7, 23, 0, 1, 0, 0, location)
+	writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v10.json"), `{
+		"version":1,
+		"producerKey":"codex:cu:p2d056ae5a24d5157",
+		"lastScanUnixMs":`+fmtInt64(lastScan.UnixMilli())+`,
+		"days":{"2026-07-22":{"gpt-5.6-sol":[100,80,20]}}
+	}`)
+
+	if stats, ok := loadProviderTokenStatsFromCostCacheAt(cacheRoot, now); ok {
+		t.Fatalf("expected previous-local-day cache to fall back to CLI, got %#v", stats)
 	}
 }
 
@@ -510,6 +531,15 @@ func writeCostCacheFixture(t *testing.T, path, body string) {
 
 func fmtInt64(value int64) string {
 	return strconv.FormatInt(value, 10)
+}
+
+func setTokenStatsTestLocalLocation(t *testing.T, location *time.Location) {
+	t.Helper()
+	previous := time.Local
+	time.Local = location
+	t.Cleanup(func() {
+		time.Local = previous
+	})
 }
 
 func resetTokenStatsTestGlobals() {

--- a/companion/internal/codexbar/token_stats_test.go
+++ b/companion/internal/codexbar/token_stats_test.go
@@ -145,17 +145,63 @@ func TestMergeTokenStatsAddsFrameFields(t *testing.T) {
 	}
 }
 
-func TestLoadProviderTokenStatsFromCostCache(t *testing.T) {
+func TestLoadProviderTokenStatsFromCostCacheCodexLayout(t *testing.T) {
 	cacheRoot := t.TempDir()
 	now := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
 	writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v10.json"), `{
 		"version":1,
 		"lastScanUnixMs":1784743200000,
 		"days":{
-			"2026-07-21":{"gpt-5.5":[10,20,30]},
-			"2026-07-22":{"gpt-5.6-sol":[100,200,300]}
+			"2026-07-21":{"gpt-5.5":[10,8,2]},
+			"2026-07-22":{"gpt-5.6-sol":[100,80,20]}
 		}
 	}`)
+
+	stats, ok := loadProviderTokenStatsFromCostCacheAt(cacheRoot, now)
+	if !ok {
+		t.Fatal("expected cached token stats")
+	}
+	codex := stats["codex"]
+	if codex.SessionTokens != 120 || codex.WeekTokens != 132 || codex.TotalTokens != 132 {
+		t.Fatalf("unexpected cached Codex totals: %+v", codex)
+	}
+	if codex.Cost == nil || len(codex.Cost.Daily) != 2 || codex.Cost.TopModel != "gpt-5.6-sol" {
+		t.Fatalf("unexpected cached Codex history: %+v", codex.Cost)
+	}
+
+	cliStats, err := parseProviderTokenStats([]byte(`[{
+		"provider":"codex",
+		"source":"local",
+		"updatedAt":"2026-07-22T18:00:00Z",
+		"sessionTokens":120,
+		"last30DaysTokens":132,
+		"daily":[
+			{"date":"2026-07-21","totalTokens":12},
+			{"date":"2026-07-22","totalTokens":120}
+		],
+		"totals":{"totalTokens":132}
+	}]`))
+	if err != nil {
+		t.Fatalf("parse CLI token stats: %v", err)
+	}
+	cliCodex := cliStats["codex"]
+	if codex.SessionTokens != cliCodex.SessionTokens ||
+		codex.WeekTokens != cliCodex.WeekTokens ||
+		codex.TotalTokens != cliCodex.TotalTokens {
+		t.Fatalf("disk-cache and CLI totals differ: cache=%+v cli=%+v", codex, cliCodex)
+	}
+	for i := range codex.Cost.Daily {
+		if codex.Cost.Daily[i].Day != cliCodex.Cost.Daily[i].Day ||
+			codex.Cost.Daily[i].TotalTokens != cliCodex.Cost.Daily[i].TotalTokens {
+			t.Fatalf("disk-cache and CLI daily totals differ: cache=%+v cli=%+v",
+				codex.Cost.Daily, cliCodex.Cost.Daily)
+		}
+	}
+}
+
+func TestLoadProviderTokenStatsFromCostCacheClaudeLayout(t *testing.T) {
+	cacheRoot := t.TempDir()
+	now := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
 	writeCostCacheFixture(t, filepath.Join(cacheRoot, "claude-v5.json"), `{
 		"version":1,
 		"lastScanUnixMs":1784743200000,
@@ -166,16 +212,108 @@ func TestLoadProviderTokenStatsFromCostCache(t *testing.T) {
 	if !ok {
 		t.Fatal("expected cached token stats")
 	}
-	codex := stats["codex"]
-	if codex.SessionTokens != 600 || codex.WeekTokens != 660 || codex.TotalTokens != 660 {
-		t.Fatalf("unexpected cached Codex totals: %+v", codex)
-	}
-	if codex.Cost == nil || len(codex.Cost.Daily) != 2 || codex.Cost.TopModel != "gpt-5.6-sol" {
-		t.Fatalf("unexpected cached Codex history: %+v", codex.Cost)
-	}
 	claude := stats["claude"]
 	if claude.SessionTokens != 100 || claude.TotalTokens != 100 {
 		t.Fatalf("unexpected cached Claude totals: %+v", claude)
+	}
+}
+
+func TestLoadProviderTokenStatsFromCostCacheRejectsUnknownArtifactVersion(t *testing.T) {
+	cacheRoot := t.TempDir()
+	now := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
+	writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v11.json"), `{
+		"version":1,
+		"lastScanUnixMs":1784743200000,
+		"days":{"2026-07-22":{"gpt-5.6-sol":[100,80,20]}}
+	}`)
+
+	if stats, ok := loadProviderTokenStatsFromCostCacheAt(cacheRoot, now); ok {
+		t.Fatalf("expected unknown Codex artifact version to be bypassed, got %#v", stats)
+	}
+}
+
+func TestLoadProviderTokenStatsFromCostCacheRejectsUnknownPackedLayout(t *testing.T) {
+	cacheRoot := t.TempDir()
+	now := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
+	writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v10.json"), `{
+		"version":1,
+		"lastScanUnixMs":1784743200000,
+		"days":{"2026-07-22":{"gpt-5.6-sol":[100,80,20,5]}}
+	}`)
+
+	if stats, ok := loadProviderTokenStatsFromCostCacheAt(cacheRoot, now); ok {
+		t.Fatalf("expected unknown Codex packed layout to be bypassed, got %#v", stats)
+	}
+}
+
+func TestFetchProviderTokenStatsKeepsCostCacheAndCLIAtParity(t *testing.T) {
+	resetTokenStatsTestGlobals()
+	defer resetTokenStatsTestGlobals()
+
+	diskStats := map[string]ProviderTokenStats{
+		"codex": {
+			SessionTokens: 120,
+			WeekTokens:    120,
+			TotalTokens:   120,
+			Source:        "codexbar-cost-cache",
+			Cost: &ProviderCostUsage{
+				Last30DaysTokens: 120,
+				LatestTokens:     120,
+				Daily: []ProviderCostDay{
+					{Day: "2026-07-22", TotalTokens: 120},
+				},
+			},
+		},
+	}
+	loadProviderTokenStatsCacheFn = func(time.Time) (map[string]ProviderTokenStats, bool) {
+		return copyProviderTokenStats(diskStats), true
+	}
+
+	backgroundFinished := make(chan struct{})
+	runCostCommandFn = func(context.Context, time.Duration, string, ...string) ([]byte, error) {
+		defer close(backgroundFinished)
+		return []byte(`[{
+			"provider":"codex",
+			"source":"local",
+			"updatedAt":"2026-07-22T18:00:00Z",
+			"sessionTokens":120,
+			"last30DaysTokens":120,
+			"daily":[{"date":"2026-07-22","totalTokens":120}],
+			"totals":{"totalTokens":120}
+		}]`), nil
+	}
+
+	fromDisk, ok := fetchProviderTokenStats(context.Background(), "/tmp/CodexBarCLI")
+	if !ok || fromDisk["codex"].TotalTokens != 120 {
+		t.Fatalf("expected initial disk-cache total of 120, got %#v", fromDisk)
+	}
+	select {
+	case <-backgroundFinished:
+	case <-time.After(time.Second):
+		t.Fatal("expected background CLI repair to finish")
+	}
+
+	var fromCLI map[string]ProviderTokenStats
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if fresh, freshOK := tokenStatsCache.loadFresh(time.Now().UTC()); freshOK &&
+			fresh["codex"].Source == "local" {
+			fromCLI = fresh
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if fromCLI["codex"].TotalTokens != fromDisk["codex"].TotalTokens {
+		t.Fatalf("disk-cache and CLI totals differ: disk=%d cli=%d",
+			fromDisk["codex"].TotalTokens, fromCLI["codex"].TotalTokens)
+	}
+
+	tokenStatsCache.mu.Lock()
+	tokenStatsCache.fetched = time.Now().UTC().Add(-tokenStatsRefreshInterval - time.Second)
+	tokenStatsCache.mu.Unlock()
+	fromDiskAgain, ok := fetchProviderTokenStats(context.Background(), "/tmp/CodexBarCLI")
+	if !ok || fromDiskAgain["codex"].TotalTokens != fromCLI["codex"].TotalTokens {
+		t.Fatalf("expected refreshed disk-cache total to remain at CLI parity, got %#v", fromDiskAgain)
 	}
 }
 

--- a/companion/internal/codexbar/token_stats_test.go
+++ b/companion/internal/codexbar/token_stats_test.go
@@ -2,8 +2,11 @@ package codexbar
 
 import (
 	"context"
+	"errors"
+	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -150,6 +153,7 @@ func TestLoadProviderTokenStatsFromCostCacheCodexLayout(t *testing.T) {
 	now := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
 	writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v10.json"), `{
 		"version":1,
+		"producerKey":"codex:cu:p2d056ae5a24d5157",
 		"lastScanUnixMs":1784743200000,
 		"days":{
 			"2026-07-21":{"gpt-5.5":[10,8,2]},
@@ -223,6 +227,7 @@ func TestLoadProviderTokenStatsFromCostCacheRejectsUnknownArtifactVersion(t *tes
 	now := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
 	writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v11.json"), `{
 		"version":1,
+		"producerKey":"codex:cu:p2d056ae5a24d5157",
 		"lastScanUnixMs":1784743200000,
 		"days":{"2026-07-22":{"gpt-5.6-sol":[100,80,20]}}
 	}`)
@@ -237,6 +242,7 @@ func TestLoadProviderTokenStatsFromCostCacheRejectsUnknownPackedLayout(t *testin
 	now := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
 	writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v10.json"), `{
 		"version":1,
+		"producerKey":"codex:cu:p2d056ae5a24d5157",
 		"lastScanUnixMs":1784743200000,
 		"days":{"2026-07-22":{"gpt-5.6-sol":[100,80,20,5]}}
 	}`)
@@ -244,6 +250,141 @@ func TestLoadProviderTokenStatsFromCostCacheRejectsUnknownPackedLayout(t *testin
 	if stats, ok := loadProviderTokenStatsFromCostCacheAt(cacheRoot, now); ok {
 		t.Fatalf("expected unknown Codex packed layout to be bypassed, got %#v", stats)
 	}
+}
+
+func TestLoadProviderTokenStatsFromCostCacheUsesRollingCalendarWindow(t *testing.T) {
+	cacheRoot := t.TempDir()
+	now := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
+	writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v10.json"), `{
+		"version":1,
+		"producerKey":"codex:cu:p2d056ae5a24d5157",
+		"lastScanUnixMs":1784743200000,
+		"days":{
+			"2026-06-22":{"gpt-5.5":[1000,800,200]},
+			"2026-06-23":{"gpt-5.5":[10,8,2]},
+			"2026-07-22":{"gpt-5.6-sol":[100,80,20]}
+		}
+	}`)
+
+	stats, ok := loadProviderTokenStatsFromCostCacheAt(cacheRoot, now)
+	if !ok {
+		t.Fatal("expected cached token stats")
+	}
+	codex := stats["codex"]
+	if codex.TotalTokens != 132 || codex.Cost == nil || len(codex.Cost.Daily) != 2 {
+		t.Fatalf("expected only the inclusive 30-calendar-day window, got %+v", codex)
+	}
+	if codex.Cost.Daily[0].Day != "2026-06-23" || codex.Cost.Daily[1].Day != "2026-07-22" {
+		t.Fatalf("unexpected rolling-window days: %+v", codex.Cost.Daily)
+	}
+}
+
+func TestLoadProviderTokenStatsFromCostCacheRejectsUnknownCodexProducerKey(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		producerKey string
+	}{
+		{name: "missing"},
+		{name: "unknown", producerKey: "codex:cu:punknown"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cacheRoot := t.TempDir()
+			now := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
+			writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v10.json"), `{
+				"version":1,
+				"producerKey":"`+test.producerKey+`",
+				"lastScanUnixMs":1784743200000,
+				"days":{"2026-07-22":{"gpt-5.6-sol":[100,80,20]}}
+			}`)
+
+			if stats, ok := loadProviderTokenStatsFromCostCacheAt(cacheRoot, now); ok {
+				t.Fatalf("expected unsupported Codex producer key to be bypassed, got %#v", stats)
+			}
+		})
+	}
+}
+
+func TestLoadProviderTokenStatsFromCostCacheRejectsPeriodOverflow(t *testing.T) {
+	cacheRoot := t.TempDir()
+	now := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
+	writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v10.json"), `{
+		"version":1,
+		"producerKey":"codex:cu:p2d056ae5a24d5157",
+		"lastScanUnixMs":1784743200000,
+		"days":{
+			"2026-07-21":{"gpt-5.5":[`+fmtInt64(math.MaxInt64)+`,0,0]},
+			"2026-07-22":{"gpt-5.6-sol":[1,0,0]}
+		}
+	}`)
+
+	if stats, ok := loadProviderTokenStatsFromCostCacheAt(cacheRoot, now); ok {
+		t.Fatalf("expected overflowing period total to be bypassed, got %#v", stats)
+	}
+}
+
+func TestFetchProviderTokenStatsFallsBackFromUnknownCacheToCLIAndLastGood(t *testing.T) {
+	t.Run("CLI", func(t *testing.T) {
+		resetTokenStatsTestGlobals()
+		defer resetTokenStatsTestGlobals()
+
+		cacheRoot := t.TempDir()
+		cacheNow := time.Date(2026, 7, 22, 18, 0, 0, 0, time.UTC)
+		writeCostCacheFixture(t, filepath.Join(cacheRoot, "codex-v11.json"), `{
+			"version":1,
+			"lastScanUnixMs":1784743200000,
+			"days":{"2026-07-22":{"gpt-5.6-sol":[100,80,20]}}
+		}`)
+		loadProviderTokenStatsCacheFn = func(time.Time) (map[string]ProviderTokenStats, bool) {
+			return loadProviderTokenStatsFromCostCacheAt(cacheRoot, cacheNow)
+		}
+		runCostCommandFn = func(context.Context, time.Duration, string, ...string) ([]byte, error) {
+			return []byte(`[{
+				"provider":"codex",
+				"source":"local",
+				"updatedAt":"2026-07-22T18:00:00Z",
+				"sessionTokens":120,
+				"last30DaysTokens":120,
+				"daily":[{"date":"2026-07-22","totalTokens":120}],
+				"totals":{"totalTokens":120}
+			}]`), nil
+		}
+
+		stats, ok := fetchProviderTokenStats(context.Background(), "/tmp/CodexBarCLI")
+		if !ok || stats["codex"].Source != "local" || stats["codex"].TotalTokens != 120 {
+			t.Fatalf("expected CLI fallback from unknown cache, got %#v", stats)
+		}
+	})
+
+	t.Run("last-good", func(t *testing.T) {
+		resetTokenStatsTestGlobals()
+		defer resetTokenStatsTestGlobals()
+
+		loadProviderTokenStatsCacheFn = func(time.Time) (map[string]ProviderTokenStats, bool) {
+			return nil, false
+		}
+		var calls atomic.Int32
+		runCostCommandFn = func(context.Context, time.Duration, string, ...string) ([]byte, error) {
+			calls.Add(1)
+			return nil, errors.New("cost unavailable")
+		}
+		tokenStatsCache.store(
+			time.Now().UTC().Add(-tokenStatsRefreshInterval-time.Second),
+			map[string]ProviderTokenStats{
+				"codex": {TotalTokens: 90, Source: "last-good"},
+			})
+
+		stats, ok := fetchProviderTokenStats(context.Background(), "/tmp/CodexBarCLI")
+		if !ok || stats["codex"].Source != "last-good" || stats["codex"].TotalTokens != 90 {
+			t.Fatalf("expected stale last-good fallback, got %#v", stats)
+		}
+		deadline := time.Now().Add(time.Second)
+		for calls.Load() < 2 && time.Now().Before(deadline) {
+			time.Sleep(time.Millisecond)
+		}
+		if calls.Load() < 2 {
+			t.Fatal("expected background CLI repair after last-good fallback")
+		}
+	})
 }
 
 func TestFetchProviderTokenStatsKeepsCostCacheAndCLIAtParity(t *testing.T) {
@@ -365,6 +506,10 @@ func writeCostCacheFixture(t *testing.T, path, body string) {
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatalf("write cost cache fixture: %v", err)
 	}
+}
+
+func fmtInt64(value int64) string {
+	return strconv.FormatInt(value, 10)
 }
 
 func resetTokenStatsTestGlobals() {

--- a/companion/internal/codexbar/token_stats_test.go
+++ b/companion/internal/codexbar/token_stats_test.go
@@ -77,6 +77,31 @@ func TestParseProviderTokenStats(t *testing.T) {
 	}
 }
 
+func TestParseProviderTokenStatsKeepsSuccessfulZeroResult(t *testing.T) {
+	stats, err := parseProviderTokenStats([]byte(`[
+		{
+			"provider":"codex",
+			"updatedAt":"2026-07-27T12:00:00Z",
+			"daily":[],
+			"totals":{"totalTokens":0}
+		}
+	]`))
+	if err != nil {
+		t.Fatalf("parse zero token stats: %v", err)
+	}
+
+	codex, ok := stats["codex"]
+	if !ok || codex.Cost == nil {
+		t.Fatalf("expected successful zero result to remain available, got %#v", stats)
+	}
+	if codex.SessionTokens != 0 || codex.WeekTokens != 0 || codex.TotalTokens != 0 {
+		t.Fatalf("expected zero token counters, got %+v", codex)
+	}
+	if codex.Cost.Last30DaysTokens != 0 || len(codex.Cost.Daily) != 0 {
+		t.Fatalf("expected an explicit empty cost result, got %+v", codex.Cost)
+	}
+}
+
 func TestMergeTokenStatsAddsFrameFields(t *testing.T) {
 	resetTokenStatsTestGlobals()
 	defer resetTokenStatsTestGlobals()

--- a/companion/internal/companionapi/provider_setup.go
+++ b/companion/internal/companionapi/provider_setup.go
@@ -98,7 +98,7 @@ func (s *Server) handleOpenCodexBar(w http.ResponseWriter, r *http.Request) {
 		openApp = codexbar.OpenApp
 	}
 	if err := openApp(r.Context()); err != nil {
-		writeError(w, http.StatusServiceUnavailable, "codexbar_open_failed", "CodexBar could not be opened.", "Open CodexBar from Applications, then check again.")
+		writeError(w, http.StatusServiceUnavailable, "codexbar_open_failed", "Provider setup could not be opened.", "Open provider setup from Applications, then check again.")
 		return
 	}
 	writeJSON(w, http.StatusOK, providerSetupResponse{
@@ -116,7 +116,7 @@ func providerDiagnosticCheck(setup codexbar.ProviderSetup) diagnosticCheck {
 		Status:     "attention",
 		Detail:     "No AI provider is delivering usage data yet.",
 		ErrorCode:  "provider_setup_required",
-		NextAction: "Open CodexBar, connect a provider, then click Check again.",
+		NextAction: "Open provider setup, connect a provider, then click Check again.",
 	}
 	if len(setup.Providers) > 0 {
 		provider := setup.Providers[0]

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -1309,8 +1309,8 @@ func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 			w,
 			http.StatusServiceUnavailable,
 			"usage_unavailable",
-			"Usage is not ready.",
-			"Open CodexBar and the Mac App, then try again.",
+			"Usage is still loading.",
+			"Keep this page open. VibeTV will retry automatically.",
 		)
 		return
 	}
@@ -1594,7 +1594,7 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 			Status:     "attention",
 			Detail:     device.Stream.Detail,
 			ErrorCode:  "provider_setup_required",
-			NextAction: "Connect an AI provider in CodexBar, then click Check again.",
+			NextAction: "Open provider setup, connect an AI provider, then click Check again.",
 		})
 	} else {
 		checks = append(checks, diagnosticCheck{

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -669,6 +669,7 @@ type usageResponse struct {
 	GeneratedAt     string              `json:"generatedAt"`
 	Source          string              `json:"source"`
 	UsageMode       string              `json:"usageMode"`
+	TokenUsageReady bool                `json:"tokenUsageReady"`
 	CurrentProvider string              `json:"currentProvider,omitempty"`
 	Providers       []usageProviderInfo `json:"providers"`
 }
@@ -1353,19 +1354,20 @@ func mergePersistedUsageDetails(fresh, persisted usageResponse) usageResponse {
 		if !ok {
 			continue
 		}
-		if provider.SessionTokens == 0 {
-			provider.SessionTokens = cached.SessionTokens
-		}
-		if provider.WeekTokens == 0 {
-			provider.WeekTokens = cached.WeekTokens
-		}
-		if provider.TotalTokens == 0 {
-			provider.TotalTokens = cached.TotalTokens
-		}
 		if provider.Cost == nil {
+			if provider.SessionTokens == 0 {
+				provider.SessionTokens = cached.SessionTokens
+			}
+			if provider.WeekTokens == 0 {
+				provider.WeekTokens = cached.WeekTokens
+			}
+			if provider.TotalTokens == 0 {
+				provider.TotalTokens = cached.TotalTokens
+			}
 			provider.Cost = cached.Cost
 		}
 	}
+	fresh.TokenUsageReady = usageProvidersHaveTokenResult(fresh.Providers)
 	return fresh
 }
 
@@ -1837,6 +1839,7 @@ func usageResponseFromPersisted(now time.Time, usage daemon.PersistedUsage) usag
 	resp.CurrentProvider = strings.TrimSpace(usage.CurrentProvider)
 	resp.Providers = providers
 	resp.UsageMode = usageModeForProviders(providers)
+	resp.TokenUsageReady = usageProvidersHaveTokenResult(providers)
 	if resp.CurrentProvider == "" && len(providers) > 0 {
 		resp.CurrentProvider = providers[0].ID
 	}
@@ -1853,6 +1856,7 @@ func usageResponseFromParsed(now time.Time, parsed []codexbar.ParsedFrame) usage
 	resp := emptyUsageResponse(now, "codexbar")
 	resp.Providers = providers
 	resp.UsageMode = usageModeForProviders(providers)
+	resp.TokenUsageReady = usageProvidersHaveTokenResult(providers)
 	if len(providers) > 0 {
 		resp.CurrentProvider = providers[0].ID
 	}
@@ -1875,6 +1879,15 @@ func emptyUsageResponse(now time.Time, source string) usageResponse {
 func usageResponseHasFreshProvider(resp usageResponse) bool {
 	for _, provider := range resp.Providers {
 		if !provider.Stale {
+			return true
+		}
+	}
+	return false
+}
+
+func usageProvidersHaveTokenResult(providers []usageProviderInfo) bool {
+	for _, provider := range providers {
+		if provider.Cost != nil {
 			return true
 		}
 	}

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -1891,6 +1891,9 @@ func TestUsageCachePicksUpTokenHistoryCollectedAfterFirstResponse(t *testing.T) 
 	if len(initial.Providers) != 1 || initial.Providers[0].Cost != nil {
 		t.Fatalf("expected initial response without history, got %+v", initial.Providers)
 	}
+	if initial.TokenUsageReady {
+		t.Fatalf("expected initial response to keep token usage loading: %+v", initial)
+	}
 
 	historyReady = true
 	second := httptest.NewRecorder()
@@ -1908,8 +1911,42 @@ func TestUsageCachePicksUpTokenHistoryCollectedAfterFirstResponse(t *testing.T) 
 	if enriched.Providers[0].SessionTokens != 1234 || enriched.Providers[0].WeekTokens != 5678 || enriched.Providers[0].TotalTokens != 9000 {
 		t.Fatalf("expected cached response enriched with token totals, got %+v", enriched.Providers[0])
 	}
+	if !enriched.TokenUsageReady {
+		t.Fatalf("expected enriched response to mark token usage ready: %+v", enriched)
+	}
 	if fetches != 1 {
 		t.Fatalf("expected cached second response without another direct fetch, got %d fetches", fetches)
+	}
+}
+
+func TestMergePersistedUsageDetailsKeepsSuccessfulZeroResult(t *testing.T) {
+	fresh := usageResponse{
+		Providers: []usageProviderInfo{{
+			ID:   "codex",
+			Cost: &usageCostInfo{},
+		}},
+	}
+	persisted := usageResponse{
+		TokenUsageReady: true,
+		Providers: []usageProviderInfo{{
+			ID:            "codex",
+			SessionTokens: 1234,
+			WeekTokens:    5678,
+			TotalTokens:   9000,
+			Cost:          &usageCostInfo{Last30DaysTokens: 9000},
+		}},
+	}
+
+	got := mergePersistedUsageDetails(fresh, persisted)
+	if !got.TokenUsageReady || len(got.Providers) != 1 {
+		t.Fatalf("expected successful zero result to remain ready: %+v", got)
+	}
+	provider := got.Providers[0]
+	if provider.SessionTokens != 0 || provider.WeekTokens != 0 || provider.TotalTokens != 0 {
+		t.Fatalf("persisted counters overwrote the successful zero result: %+v", provider)
+	}
+	if provider.Cost == nil || provider.Cost.Last30DaysTokens != 0 {
+		t.Fatalf("persisted history overwrote the successful zero result: %+v", provider.Cost)
 	}
 }
 

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -2635,6 +2635,9 @@ func TestUsageUnavailableReturnsCustomerSafeError(t *testing.T) {
 	if got.OK || got.Error.Code != "usage_unavailable" {
 		t.Fatalf("unexpected error response: %+v", got)
 	}
+	if strings.Contains(got.Error.Message+" "+got.Error.NextAction, "CodexBar") {
+		t.Fatalf("usage error exposed the internal service name: %+v", got.Error)
+	}
 }
 
 func TestCORSAllowedAndForeignOrigins(t *testing.T) {

--- a/docs/control-center-customer-ui-approval.md
+++ b/docs/control-center-customer-ui-approval.md
@@ -312,3 +312,20 @@ issue scope, or release permission never implies UI permission.
 - Approved files: Companion port-owner classification and tests, native runtime
   endpoint rediscovery, its macOS contract test, and the matching architecture
   documentation.
+
+## 2026-07-27 — Usage loading stays separate from provider readiness
+
+- User approval: The user explicitly required that customers never see the
+  internal `CodexBar` name, that the token area keep showing a spinner with
+  `Loading usage` until token history is actually ready, and that the provider
+  list may finish and appear independently. After reviewing the KISS plan, the
+  user ordered its implementation with `na dann mach das`.
+- Approved customer-visible result: Usage never names `CodexBar`. While token
+  history is pending, the token area shows only `Loading usage`; it does not
+  show a misleading empty or zero state. The independently loaded AI provider
+  list remains visible and usable. A successful token-history result containing
+  zero shows the real zero/no-data result. No extra global refresh control is
+  added.
+- Approved files: `control-center-app.tsx`, `control-center-types.ts`,
+  `provider-setup-card.tsx`, `usage-screen.tsx`, `usage-screen.test.tsx`, and
+  the matching customer-flow assertions in `test-customer-flows.mjs`.

--- a/macos/VibeTVControlCenter/URLSchemeTests.swift
+++ b/macos/VibeTVControlCenter/URLSchemeTests.swift
@@ -10,13 +10,13 @@ private func require(_ condition: @autoclosure () -> Bool, _ message: String) {
 
 func runURLSchemeTests() {
     let repairStatus = InstallationStatus(
-        title: "CodexBar needs repair",
-        detail: "Repair CodexBar before continuing.",
+        title: "Usage service needs repair",
+        detail: "Repair the usage service before continuing.",
         failed: true,
-        retryTitle: "Repair CodexBar"
+        retryTitle: "Repair usage service"
     )
     require(
-        repairStatus.retryTitle == "Repair CodexBar",
+        repairStatus.retryTitle == "Repair usage service",
         "native installation status must preserve its repair CTA across window reopening"
     )
     let redactedReport = AppDelegate.redactReportValue([

--- a/macos/VibeTVControlCenter/main.swift
+++ b/macos/VibeTVControlCenter/main.swift
@@ -1135,10 +1135,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
             case .codexBarRepairRequired:
                 self.codexBarRepairRequired = true
                 self.presentInstallationStatus(
-                    title: "CodexBar needs repair",
-                    detail: "Repair CodexBar to install and start the verified copy included with VibeTV Control Center.",
+                    title: "Usage service needs repair",
+                    detail: "Repair the usage service to install and start the verified copy included with VibeTV Control Center.",
                     failed: true,
-                    retryTitle: "Repair CodexBar"
+                    retryTitle: "Repair usage service"
                 )
             case .keepCurrentPage:
                 self.codexBarRepairRequired = false
@@ -1168,10 +1168,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         discardMismatchedPendingNativeUpdate()
         if codexBarRepairRequired && !repairCodexBarInstallation() {
             presentInstallationStatus(
-                title: "CodexBar repair failed",
-                detail: "CodexBar could not be backed up or reinstalled. Open the support log for details.",
+                title: "Usage service repair failed",
+                detail: "The usage service could not be backed up or reinstalled. Open the support log for details.",
                 failed: true,
-                retryTitle: "Repair CodexBar"
+                retryTitle: "Repair usage service"
             )
             return
         }
@@ -1185,7 +1185,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         activeNavigation = nil
         webView = nil
         presentInstallationStatus(
-            title: "Repairing CodexBar…",
+            title: "Repairing usage service…",
             detail: "Backing up an incompatible copy before installing the verified version.",
             failed: false
         )


### PR DESCRIPTION
## What changed

- decode Codex v10 packed usage as `[input, cached input, output]` and count `input + output`
- keep the Claude v5 packed layout in a separate provider-specific decoder
- fail closed on unknown cache artifact versions, malformed packed layouts, negative values, and overflow so the CLI/last-good path is used
- add regression coverage for Codex, Claude, disk-cache/CLI daily and 30-day parity, and the cache → CLI → cache refresh sequence

## Root cause

The disk-cache adapter added cached input tokens to Codex input tokens even though cached input is already included in input. The background CLI repair then replaced the inflated snapshot with the correct value, and the next cache refresh inflated it again.

## Validation

- `go test ./internal/codexbar`
- `go test ./...`
- `go test -race ./internal/codexbar`
- `./scripts/validate_repo_layout.sh` in the canonical `codex-workspace` (the target repository does not contain this script)

Fixes #239