### PR TITLE
Fix Mac runtime startup when the preferred port is occupied

### DIFF
--- a/apps/control-center/src/components/companion-installer-actions.tsx
+++ b/apps/control-center/src/components/companion-installer-actions.tsx
@@ -6,6 +6,7 @@ import {
   companionReleaseApiUrl,
   currentControlCenterOrigin,
 } from "./mac-app-install-command";
+import { isNativeControlCenterApp } from "./control-center-runtime";
 
 type UseCompanionReleaseOptions = {
   enabled?: boolean;
@@ -31,7 +32,10 @@ export function useCompanionRelease(
         params.set("version", companionVersion);
       }
       const suffix = params.toString() ? `?${params.toString()}` : "";
-      const endpoint = companionReleaseApiUrl(currentControlCenterOrigin());
+      const endpoint = companionReleaseApiUrl(
+        currentControlCenterOrigin(),
+        isNativeControlCenterApp(),
+      );
       const response = await fetch(`${endpoint}${suffix}`, {
         cache: "no-store",
       });

--- a/apps/control-center/src/components/mac-app-install-command.test.ts
+++ b/apps/control-center/src/components/mac-app-install-command.test.ts
@@ -7,13 +7,13 @@ import {
 } from "./mac-app-install-command";
 
 describe("companionReleaseApiUrl", () => {
-  it("uses the hosted release API from any loopback runtime port", () => {
+  it("uses the hosted release source from any native runtime port", () => {
     expect(companionReleaseApiUrl("http://127.0.0.1:54321", true)).toBe(
       `${DEFAULT_CONTROL_CENTER_ORIGIN}${COMPANION_RELEASE_API_PATH}`,
     );
   });
 
-  it("keeps the relative API route on the hosted app", () => {
+  it("keeps the relative release path on the hosted app", () => {
     expect(companionReleaseApiUrl(DEFAULT_CONTROL_CENTER_ORIGIN)).toBe(
       COMPANION_RELEASE_API_PATH,
     );

--- a/apps/control-center/src/components/mac-app-install-command.test.ts
+++ b/apps/control-center/src/components/mac-app-install-command.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COMPANION_RELEASE_API_PATH,
+  DEFAULT_CONTROL_CENTER_ORIGIN,
+  companionReleaseApiUrl,
+} from "./mac-app-install-command";
+
+describe("companionReleaseApiUrl", () => {
+  it("uses the hosted release API from any loopback runtime port", () => {
+    expect(companionReleaseApiUrl("http://127.0.0.1:54321", true)).toBe(
+      `${DEFAULT_CONTROL_CENTER_ORIGIN}${COMPANION_RELEASE_API_PATH}`,
+    );
+  });
+
+  it("keeps the relative API route on the hosted app", () => {
+    expect(companionReleaseApiUrl(DEFAULT_CONTROL_CENTER_ORIGIN)).toBe(
+      COMPANION_RELEASE_API_PATH,
+    );
+  });
+});

--- a/apps/control-center/src/components/mac-app-install-command.ts
+++ b/apps/control-center/src/components/mac-app-install-command.ts
@@ -31,8 +31,11 @@ export function currentControlCenterOrigin() {
     : window.location.origin;
 }
 
-export function companionReleaseApiUrl(origin: string) {
-  return isLocalCompanionOrigin(origin)
+export function companionReleaseApiUrl(
+  origin: string,
+  nativeRuntime = false,
+) {
+  return nativeRuntime || isLocalCompanionOrigin(origin)
     ? `${DEFAULT_CONTROL_CENTER_ORIGIN}${COMPANION_RELEASE_API_PATH}`
     : COMPANION_RELEASE_API_PATH;
 }

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -17,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/codexbar"
@@ -256,6 +259,7 @@ type daemonCommandOptions struct {
 	Daemon       daemon.Options
 	APIAddr      string
 	APIDevOrigin string
+	APIFallback  bool
 }
 
 func parseDaemonOptions(args []string) (daemon.Options, error) {
@@ -273,6 +277,7 @@ func parseDaemonCommandOptions(args []string) (daemonCommandOptions, error) {
 	theme := fs.String("theme", "", "optional runtime theme override: classic|crt|mini")
 	apiAddr := fs.String("api-addr", "", "optional local companion API bind address")
 	apiDevOrigin := fs.String("api-dev-origin", "http://localhost:3000", "additional allowed local dev origin for --api-addr")
+	apiFallback := fs.Bool("api-fallback", false, "fall back to a free loopback port when --api-addr is in use")
 	if err := fs.Parse(args); err != nil {
 		return daemonCommandOptions{}, err
 	}
@@ -296,7 +301,74 @@ func parseDaemonCommandOptions(args []string) (daemonCommandOptions, error) {
 		},
 		APIAddr:      strings.TrimSpace(*apiAddr),
 		APIDevOrigin: strings.TrimSpace(*apiDevOrigin),
+		APIFallback:  *apiFallback,
 	}, nil
+}
+
+type runtimeEndpoint struct {
+	Origin string `json:"origin"`
+	PID    int    `json:"pid"`
+}
+
+func listenCompanionAPI(addr string, allowFallback bool) (net.Listener, error) {
+	listener, err := net.Listen("tcp", addr)
+	if err == nil || !allowFallback || !errors.Is(err, syscall.EADDRINUSE) {
+		return listener, err
+	}
+	return net.Listen("tcp", "127.0.0.1:0")
+}
+
+func runtimeEndpointPath(home string) string {
+	return filepath.Join(
+		home,
+		"Library",
+		"Application Support",
+		"codexbar-display",
+		"run",
+		"runtime-endpoint.json",
+	)
+}
+
+func writeRuntimeEndpoint(path string, endpoint runtimeEndpoint) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	if err := os.Chmod(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(endpoint)
+	if err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".runtime-endpoint-*")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return err
+	}
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, path)
+}
+
+func removeRuntimeEndpoint(path string, pid int) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	var endpoint runtimeEndpoint
+	if json.Unmarshal(data, &endpoint) == nil && endpoint.PID == pid {
+		_ = os.Remove(path)
+	}
 }
 
 func runDaemonWithCompanionAPI(ctx context.Context, opts daemonCommandOptions) error {
@@ -321,8 +393,30 @@ func runDaemonWithCompanionAPI(ctx context.Context, opts daemonCommandOptions) e
 		default:
 		}
 	}
+	listener, err := listenCompanionAPI(opts.APIAddr, opts.APIFallback)
+	if err != nil {
+		return err
+	}
+	actualAddr := listener.Addr().String()
+	if opts.APIFallback {
+		endpointPath := runtimeEndpointPath(home)
+		endpoint := runtimeEndpoint{
+			Origin: "http://" + actualAddr,
+			PID:    os.Getpid(),
+		}
+		if err := writeRuntimeEndpoint(endpointPath, endpoint); err != nil {
+			if actualAddr != opts.APIAddr {
+				listener.Close()
+				return fmt.Errorf("write runtime endpoint: %w", err)
+			}
+			logf("VibeTV companion API kept the default endpoint because runtime discovery could not be written: %v", err)
+		} else {
+			defer removeRuntimeEndpoint(endpointPath, endpoint.PID)
+		}
+	}
+
 	server, err := companionapi.New(companionapi.Options{
-		Addr:           opts.APIAddr,
+		Addr:           actualAddr,
 		AllowedOrigins: []string{opts.APIDevOrigin},
 		RefreshDisplayStream: func(context.Context, string) error {
 			wakeDisplayWorker()
@@ -332,6 +426,7 @@ func runDaemonWithCompanionAPI(ctx context.Context, opts daemonCommandOptions) e
 		WakeDisplayStream:  wakeDisplayWorker,
 	})
 	if err != nil {
+		listener.Close()
 		return err
 	}
 
@@ -345,14 +440,14 @@ func runDaemonWithCompanionAPI(ctx context.Context, opts daemonCommandOptions) e
 
 	errc := make(chan error, 1)
 	go func() {
-		errc <- server.ListenAndServe(ctx)
+		errc <- server.Serve(ctx, listener)
 	}()
 	workerRun := func(ctx context.Context, opts daemon.Options) error {
 		return daemon.RunWithLogger(ctx, opts, logf)
 	}
 	go superviseDisplayWorker(ctx, daemonOpts, workerRun, time.After, logf)
 
-	logf("VibeTV companion API listening on http://%s", opts.APIAddr)
+	logf("VibeTV companion API listening on http://%s", actualAddr)
 	err = <-errc
 	cancel()
 	return err

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -310,10 +310,58 @@ type runtimeEndpoint struct {
 	PID    int    `json:"pid"`
 }
 
+func addressHostsVibeTVService(addr string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	statusURL := url.URL{
+		Scheme: "http",
+		Host:   addr,
+		Path:   "/v1/status",
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		statusURL.String(),
+		nil,
+	)
+	if err != nil {
+		return false
+	}
+	client := &http.Client{
+		Timeout: time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return false
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return false
+	}
+
+	var status map[string]json.RawMessage
+	if err := json.NewDecoder(io.LimitReader(response.Body, 64<<10)).Decode(&status); err != nil {
+		return false
+	}
+	companion := strings.TrimSpace(string(status["companion"]))
+	return companion != "" && companion != "null" && companion != "{}"
+}
+
 func listenCompanionAPI(addr string, allowFallback bool) (net.Listener, error) {
 	listener, err := net.Listen("tcp", addr)
 	if err == nil || !allowFallback || !errors.Is(err, syscall.EADDRINUSE) {
 		return listener, err
+	}
+	if addressHostsVibeTVService(addr) {
+		return nil, fmt.Errorf(
+			"another VibeTV service already owns %s: %w",
+			addr,
+			err,
+		)
 	}
 	return net.Listen("tcp", "127.0.0.1:0")
 }

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -310,17 +310,15 @@ type runtimeEndpoint struct {
 	PID    int    `json:"pid"`
 }
 
-func addressHostsVibeTVService(addr string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+const vibeTVServiceProbeTimeout = 12 * time.Second
 
+func addressHostsVibeTVService(addr string) bool {
 	statusURL := url.URL{
 		Scheme: "http",
 		Host:   addr,
 		Path:   "/v1/status",
 	}
-	request, err := http.NewRequestWithContext(
-		ctx,
+	request, err := http.NewRequest(
 		http.MethodGet,
 		statusURL.String(),
 		nil,
@@ -329,7 +327,7 @@ func addressHostsVibeTVService(addr string) bool {
 		return false
 	}
 	client := &http.Client{
-		Timeout: time.Second,
+		Timeout: vibeTVServiceProbeTimeout,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
@@ -343,12 +341,17 @@ func addressHostsVibeTVService(addr string) bool {
 		return false
 	}
 
-	var status map[string]json.RawMessage
+	var status struct {
+		Companion struct {
+			Status  string `json:"status"`
+			Version string `json:"version"`
+		} `json:"companion"`
+	}
 	if err := json.NewDecoder(io.LimitReader(response.Body, 64<<10)).Decode(&status); err != nil {
 		return false
 	}
-	companion := strings.TrimSpace(string(status["companion"]))
-	return companion != "" && companion != "null" && companion != "{}"
+	return strings.TrimSpace(status.Companion.Status) != "" &&
+		strings.TrimSpace(status.Companion.Version) != ""
 }
 
 func listenCompanionAPI(addr string, allowFallback bool) (net.Listener, error) {

--- a/companion/cmd/codexbar-display/main_test.go
+++ b/companion/cmd/codexbar-display/main_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -68,6 +69,85 @@ func TestParseDaemonOptionsWiFiTarget(t *testing.T) {
 	}
 	if !opts.Once {
 		t.Fatalf("expected once option")
+	}
+}
+
+func TestParseDaemonCommandOptionsAllowsAPIFallback(t *testing.T) {
+	opts, err := parseDaemonCommandOptions([]string{
+		"--transport", "wifi",
+		"--api-addr", "127.0.0.1:47832",
+		"--api-fallback",
+	})
+	if err != nil {
+		t.Fatalf("parseDaemonCommandOptions returned error: %v", err)
+	}
+	if !opts.APIFallback {
+		t.Fatal("expected API fallback to be enabled")
+	}
+}
+
+func TestListenCompanionAPIFallsBackWithoutStoppingForeignListener(t *testing.T) {
+	foreign, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen foreign: %v", err)
+	}
+	defer foreign.Close()
+
+	listener, err := listenCompanionAPI(foreign.Addr().String(), true)
+	if err != nil {
+		t.Fatalf("listen fallback: %v", err)
+	}
+	defer listener.Close()
+
+	if listener.Addr().String() == foreign.Addr().String() {
+		t.Fatalf("fallback reused occupied address %s", listener.Addr())
+	}
+	conn, err := net.DialTimeout("tcp", foreign.Addr().String(), time.Second)
+	if err != nil {
+		t.Fatalf("foreign listener was disturbed: %v", err)
+	}
+	conn.Close()
+}
+
+func TestRuntimeEndpointWriteIsPrivateAndAtomic(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run", "runtime-endpoint.json")
+	want := runtimeEndpoint{Origin: "http://127.0.0.1:54321", PID: 42}
+	if err := writeRuntimeEndpoint(path, want); err != nil {
+		t.Fatalf("writeRuntimeEndpoint: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read endpoint: %v", err)
+	}
+	var got runtimeEndpoint
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("decode endpoint: %v", err)
+	}
+	if got != want {
+		t.Fatalf("endpoint=%+v want %+v", got, want)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat endpoint: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("endpoint mode=%#o want 0600", info.Mode().Perm())
+	}
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("stat endpoint dir: %v", err)
+	}
+	if dirInfo.Mode().Perm() != 0o700 {
+		t.Fatalf("endpoint dir mode=%#o want 0700", dirInfo.Mode().Perm())
+	}
+
+	removeRuntimeEndpoint(path, 7)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("wrong pid removed endpoint: %v", err)
+	}
+	removeRuntimeEndpoint(path, want.PID)
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("matching pid did not remove endpoint: %v", err)
 	}
 }
 

--- a/companion/cmd/codexbar-display/main_test.go
+++ b/companion/cmd/codexbar-display/main_test.go
@@ -89,7 +89,8 @@ func TestParseDaemonCommandOptionsAllowsAPIFallback(t *testing.T) {
 
 func TestListenCompanionAPIFallsBackWithoutStoppingForeignListener(t *testing.T) {
 	foreign := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"companion":"unrelated"}`)
 	}))
 	defer foreign.Close()
 	foreignAddr := foreign.Listener.Addr().String()
@@ -116,6 +117,7 @@ func TestListenCompanionAPIRejectsSecondVibeTVService(t *testing.T) {
 			http.NotFound(w, request)
 			return
 		}
+		time.Sleep(1100 * time.Millisecond)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(
 			w,

--- a/companion/cmd/codexbar-display/main_test.go
+++ b/companion/cmd/codexbar-display/main_test.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -87,26 +88,50 @@ func TestParseDaemonCommandOptionsAllowsAPIFallback(t *testing.T) {
 }
 
 func TestListenCompanionAPIFallsBackWithoutStoppingForeignListener(t *testing.T) {
-	foreign, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen foreign: %v", err)
-	}
+	foreign := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
 	defer foreign.Close()
+	foreignAddr := foreign.Listener.Addr().String()
 
-	listener, err := listenCompanionAPI(foreign.Addr().String(), true)
+	listener, err := listenCompanionAPI(foreignAddr, true)
 	if err != nil {
 		t.Fatalf("listen fallback: %v", err)
 	}
 	defer listener.Close()
 
-	if listener.Addr().String() == foreign.Addr().String() {
+	if listener.Addr().String() == foreignAddr {
 		t.Fatalf("fallback reused occupied address %s", listener.Addr())
 	}
-	conn, err := net.DialTimeout("tcp", foreign.Addr().String(), time.Second)
+	conn, err := net.DialTimeout("tcp", foreignAddr, time.Second)
 	if err != nil {
 		t.Fatalf("foreign listener was disturbed: %v", err)
 	}
 	conn.Close()
+}
+
+func TestListenCompanionAPIRejectsSecondVibeTVService(t *testing.T) {
+	existing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v1/status" {
+			http.NotFound(w, request)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(
+			w,
+			`{"companion":{"status":"ready","version":"1.0.0","runtime":{"executable":"/private/tmp/vibetv-ai-theme-companion"}}}`,
+		)
+	}))
+	defer existing.Close()
+
+	listener, err := listenCompanionAPI(existing.Listener.Addr().String(), true)
+	if listener != nil {
+		listener.Close()
+		t.Fatal("second VibeTV service received a fallback listener")
+	}
+	if !errors.Is(err, syscall.EADDRINUSE) {
+		t.Fatalf("second VibeTV service error=%v want address-in-use", err)
+	}
 }
 
 func TestRuntimeEndpointWriteIsPrivateAndAtomic(t *testing.T) {

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -880,14 +880,21 @@ func New(opts Options) (*Server, error) {
 }
 
 func (s *Server) ListenAndServe(ctx context.Context) error {
+	listener, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return err
+	}
+	return s.Serve(ctx, listener)
+}
+
+func (s *Server) Serve(ctx context.Context, listener net.Listener) error {
 	server := &http.Server{
-		Addr:              s.addr,
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	errc := make(chan error, 1)
 	go func() {
-		err := server.ListenAndServe()
+		err := server.Serve(listener)
 		if errors.Is(err, http.ErrServerClosed) {
 			err = nil
 		}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,8 @@ VibeTV has four visible pieces:
 3. **VibeTV Mac App**: the local `codexbar-display` process on the customer's Mac.
 4. **Control Center**: the local browser app served by the Mac App. It prefers
    `http://127.0.0.1:47832/control-center` and automatically uses another
-   loopback port when that port belongs to another process.
+   loopback port when that port belongs to an unrelated process. It never
+   starts a second display writer beside another VibeTV service.
 
 The hosted page at `https://app.vibetv.shop` is the download entrypoint. It
 offers the verified Mac App DMG. After installation, the customer opens the Mac

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,8 +5,9 @@ VibeTV has four visible pieces:
 1. **VibeTV hardware**: the physical WiFi display on the desk.
 2. **CodexBar**: the upstream usage collector for AI providers.
 3. **VibeTV Mac App**: the local `codexbar-display` process on the customer's Mac.
-4. **Control Center**: the local browser app served by the Mac App at
-   `http://127.0.0.1:47832/control-center`.
+4. **Control Center**: the local browser app served by the Mac App. It prefers
+   `http://127.0.0.1:47832/control-center` and automatically uses another
+   loopback port when that port belongs to another process.
 
 The hosted page at `https://app.vibetv.shop` is the download entrypoint. It
 offers the verified Mac App DMG. After installation, the customer opens the Mac
@@ -26,7 +27,7 @@ CodexBar reads AI usage on the Mac
 ```text
 AI provider state
   -> CodexBar
-  -> VibeTV Mac App on 127.0.0.1:47832
+  -> VibeTV Mac App on a private loopback port
   -> browser running the local Control Center
   -> codexbar-display sends frames to VibeTV over LAN
   -> VibeTV screen

--- a/docs/control-center-customer-ui-approval.md
+++ b/docs/control-center-customer-ui-approval.md
@@ -280,3 +280,20 @@ issue scope, or release permission never implies UI permission.
   cannot collapse to zero width during a slow image load.
 - Approved files: `overview-screen.tsx` and the existing connected Overview
   customer-flow assertion in `test-customer-flows.mjs`.
+
+## 2026-07-23 — Automatic Mac runtime port fallback
+
+- User approval: After requiring the Mac App to use another port automatically,
+  the user reviewed the exact terminal-failure screenshot and explicitly
+  approved it with `ja` in the Codex task on 2026-07-23.
+- Approved customer-visible result: If another process uses VibeTV's preferred
+  local port, the Mac App starts on a free private loopback port without showing
+  an error screen. Only if automatic fallback also fails, the existing native
+  screen shows `VibeTV couldn’t start` and identifies the process name, PID, and
+  port followed by `Quit the app or stop the process, then click Try again.`
+  The existing `Try again`, `Create report`, and `Open support log` actions
+  remain unchanged.
+- Approved files: `companion-installer-actions.tsx`,
+  `mac-app-install-command.ts`, `mac-app-install-command.test.ts`, native
+  `main.swift`, `URLSchemeTests.swift`, runtime endpoint handling, and their
+  regression tests.

--- a/docs/control-center-customer-ui-approval.md
+++ b/docs/control-center-customer-ui-approval.md
@@ -297,3 +297,18 @@ issue scope, or release permission never implies UI permission.
   `mac-app-install-command.ts`, `mac-app-install-command.test.ts`, native
   `main.swift`, `URLSchemeTests.swift`, runtime endpoint handling, and their
   regression tests.
+
+## 2026-07-23 — Single-writer fallback safety
+
+- User approval: After the merge-risk review identified a possible second
+  display writer and stale fallback endpoint, the user explicitly ordered both
+  risks to be fixed in the Codex task on 2026-07-23.
+- Approved customer-visible result: An unrelated process on VibeTV's preferred
+  port still causes automatic background fallback without a new screen. If the
+  port belongs to another VibeTV service, the Mac App never starts a second
+  display writer and uses the already approved `VibeTV couldn’t start` screen.
+  After a fallback runtime restart, Control Center verifies the newly published
+  port before reloading. No copy, control, or layout changes.
+- Approved files: Companion port-owner classification and tests, native runtime
+  endpoint rediscovery, its macOS contract test, and the matching architecture
+  documentation.

--- a/docs/macos-dmg-distribution.md
+++ b/docs/macos-dmg-distribution.md
@@ -42,9 +42,10 @@ VibeTV Control Center.app/
   `vibetv://open-control-center` launcher
 
 The Swift shell prefers `http://127.0.0.1:47832/control-center` in `WKWebView`.
-If another process already owns that port, the bundled runtime binds an
+If an unrelated process already owns that port, the bundled runtime binds an
 OS-selected loopback port and publishes it in the private
-`runtime-endpoint.json` file for the Swift shell.
+`runtime-endpoint.json` file for the Swift shell. If the listener is another
+VibeTV service, startup stops instead of creating a second display writer.
 When a bundled `Contents/Helpers/codexbar-display` exists, the shell
 uses this migration order:
 
@@ -58,14 +59,18 @@ uses this migration order:
    do not restart an already-current service.
 4. Record which old user LaunchAgents are running and stop them without moving
    or deleting their plists. Start on `127.0.0.1:47832`, or automatically use a
-   free loopback port when another process still owns the preferred port.
+   free loopback port when an unrelated process still owns the preferred port.
+   Another VibeTV service remains the sole display writer until the customer
+   stops it and retries.
 5. Accept the new runtime only when the endpoint returns HTTP 2xx, JSON
    `ok: true`, `companion.version` exactly matches the DMG app version, and the
    PID reported for `shop.vibetv.control-center.runtime` by `launchctl` owns the
    discovered listener. A timeout or mismatch
    unregisters the new service and restores the previously running legacy
    agents; their plists and old app bundles remain in place. A known or unknown
-   process on the preferred port is never killed.
+   process on the preferred port is never killed. If a fallback runtime
+   restarts on a different port, the Swift shell verifies the new endpoint
+   before reloading Control Center.
 6. After that health gate, make the `/Applications` app the default `vibetv://`
    handler and move both old LaunchAgent plists and the old Terminal app copies
    from `~/Applications` or Application Support into

--- a/docs/macos-dmg-distribution.md
+++ b/docs/macos-dmg-distribution.md
@@ -41,7 +41,10 @@ VibeTV Control Center.app/
 - `CFBundleURLTypes`: registers `vibetv://`, including the hosted
   `vibetv://open-control-center` launcher
 
-The Swift shell loads `http://127.0.0.1:47832/control-center` in `WKWebView`.
+The Swift shell prefers `http://127.0.0.1:47832/control-center` in `WKWebView`.
+If another process already owns that port, the bundled runtime binds an
+OS-selected loopback port and publishes it in the private
+`runtime-endpoint.json` file for the Swift shell.
 When a bundled `Contents/Helpers/codexbar-display` exists, the shell
 uses this migration order:
 
@@ -53,15 +56,16 @@ uses this migration order:
 3. When a newer DMG has replaced the app bundle, unregister the previous
    service version and register the new bundle version once. Normal app opens
    do not restart an already-current service.
-4. Record which old user LaunchAgents are running, stop them without moving or
-   deleting their plists, then poll `http://127.0.0.1:47832/v1/status`.
+4. Record which old user LaunchAgents are running and stop them without moving
+   or deleting their plists. Start on `127.0.0.1:47832`, or automatically use a
+   free loopback port when another process still owns the preferred port.
 5. Accept the new runtime only when the endpoint returns HTTP 2xx, JSON
    `ok: true`, `companion.version` exactly matches the DMG app version, and the
    PID reported for `shop.vibetv.control-center.runtime` by `launchctl` owns the
-   listener on `127.0.0.1:47832`. A timeout, mismatch, or foreign listener
+   discovered listener. A timeout or mismatch
    unregisters the new service and restores the previously running legacy
    agents; their plists and old app bundles remain in place. A known or unknown
-   Terminal fallback is never killed speculatively.
+   process on the preferred port is never killed.
 6. After that health gate, make the `/Applications` app the default `vibetv://`
    handler and move both old LaunchAgent plists and the old Terminal app copies
    from `~/Applications` or Application Support into

--- a/macos/VibeTVControlCenter/URLSchemeTests.swift
+++ b/macos/VibeTVControlCenter/URLSchemeTests.swift
@@ -9,6 +9,46 @@ private func require(_ condition: @autoclosure () -> Bool, _ message: String) {
 }
 
 func runURLSchemeTests() {
+    let fallbackEndpoint = RuntimeEndpoint(
+        origin: "http://127.0.0.1:54321",
+        pid: 83979
+    )
+    require(
+        validatedRuntimeEndpointOrigin(fallbackEndpoint)?.port == 54321,
+        "a private loopback fallback endpoint must be accepted"
+    )
+    for invalid in [
+        RuntimeEndpoint(origin: "http://0.0.0.0:54321", pid: 83979),
+        RuntimeEndpoint(origin: "https://127.0.0.1:54321", pid: 83979),
+        RuntimeEndpoint(origin: "http://127.0.0.1:54321/path", pid: 83979),
+        RuntimeEndpoint(origin: "http://127.0.0.1:54321", pid: 0),
+    ] {
+        require(
+            validatedRuntimeEndpointOrigin(invalid) == nil,
+            "runtime endpoint discovery must reject non-private or malformed endpoints"
+        )
+    }
+    require(
+        parseLsofListenerProcesses(
+            """
+            p83979
+            cnode
+            p91234
+            cpython3
+            """
+        ) == [
+            PortListenerProcess(pid: 83979, name: "node"),
+            PortListenerProcess(pid: 91234, name: "python3"),
+        ],
+        "port diagnostics must preserve process names and pids"
+    )
+    require(
+        portConflictDetail(
+            process: PortListenerProcess(pid: 83979, name: "node"),
+            port: 47832
+        ) == "“node” (PID 83979) is using VibeTV’s local port 47832. VibeTV also couldn’t start on another free port.",
+        "the native failure screen must identify the blocking process and pid"
+    )
     let repairStatus = InstallationStatus(
         title: "CodexBar needs repair",
         detail: "Repair CodexBar before continuing.",

--- a/macos/VibeTVControlCenter/URLSchemeTests.swift
+++ b/macos/VibeTVControlCenter/URLSchemeTests.swift
@@ -46,7 +46,7 @@ func runURLSchemeTests() {
         portConflictDetail(
             process: PortListenerProcess(pid: 83979, name: "node"),
             port: 47832
-        ) == "“node” (PID 83979) is using VibeTV’s local port 47832. VibeTV also couldn’t start on another free port.",
+        ) == "“node” (PID 83979) is using VibeTV’s local port 47832. Quit the app or stop the process, then click Try again.",
         "the native failure screen must identify the blocking process and pid"
     )
     let repairStatus = InstallationStatus(

--- a/macos/VibeTVControlCenter/main.swift
+++ b/macos/VibeTVControlCenter/main.swift
@@ -893,7 +893,7 @@ func portConflictDetail(
     process: PortListenerProcess,
     port: Int
 ) -> String {
-    "“\(process.name)” (PID \(process.pid)) is using VibeTV’s local port \(port). VibeTV also couldn’t start on another free port."
+    "“\(process.name)” (PID \(process.pid)) is using VibeTV’s local port \(port). Quit the app or stop the process, then click Try again."
 }
 
 private struct NativeSupportReportSnapshot: Sendable {

--- a/macos/VibeTVControlCenter/main.swift
+++ b/macos/VibeTVControlCenter/main.swift
@@ -2895,6 +2895,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         return candidates
     }
 
+    private func rediscoverRuntimeOriginForNavigationRetry() async {
+        let expectedVersion = currentCompanionVersion()
+        guard !expectedVersion.isEmpty else {
+            return
+        }
+        _ = await waitForHealthyRuntime(
+            expectedVersion: expectedVersion,
+            timeout: runtimeInitialHealthTimeout
+        )
+    }
+
     private func runtimePortConflictDetail() -> String? {
         let listener = runCommandCapturingOutput(
             executable: "/usr/sbin/lsof",
@@ -3639,6 +3650,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 return
             }
             guard let self else {
+                return
+            }
+            await self.rediscoverRuntimeOriginForNavigationRetry()
+            guard !Task<Never, Never>.isCancelled else {
                 return
             }
             self.scheduledReload = nil

--- a/macos/VibeTVControlCenter/main.swift
+++ b/macos/VibeTVControlCenter/main.swift
@@ -8,8 +8,9 @@ import WebKit
 import Sparkle
 #endif
 
-private let controlCenterURLString = "http://127.0.0.1:47832/control-center"
-private let runtimeHealthURLString = "http://127.0.0.1:47832/v1/runtime-health"
+private let defaultRuntimeOriginString = "http://127.0.0.1:47832"
+private let defaultRuntimePort = 47832
+private let runtimeEndpointFileName = "runtime-endpoint.json"
 private let nativeControlCenterUserAgentPrefix = "VibeTVControlCenter/"
 private let controlCenterURLScheme = "vibetv"
 private let controlCenterURLHost = "open-control-center"
@@ -836,6 +837,65 @@ private func captureProcessOutput(
     }
 }
 
+struct RuntimeEndpoint: Codable, Equatable {
+    let origin: String
+    let pid: Int32
+}
+
+func validatedRuntimeEndpointOrigin(_ endpoint: RuntimeEndpoint) -> URL? {
+    guard endpoint.pid > 0,
+          let components = URLComponents(string: endpoint.origin),
+          components.scheme?.lowercased() == "http",
+          components.host == "127.0.0.1",
+          let port = components.port,
+          (1...65535).contains(port),
+          components.user == nil,
+          components.password == nil,
+          components.query == nil,
+          components.fragment == nil,
+          components.path.isEmpty || components.path == "/" else {
+        return nil
+    }
+    return components.url
+}
+
+struct PortListenerProcess: Equatable {
+    let pid: Int32
+    let name: String
+}
+
+func parseLsofListenerProcesses(_ output: String) -> [PortListenerProcess] {
+    var processes: [Int32: String] = [:]
+    var currentPID: Int32?
+    for line in output.split(whereSeparator: \Character.isNewline) {
+        guard let field = line.first else {
+            continue
+        }
+        let value = String(line.dropFirst())
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        switch field {
+        case "p":
+            currentPID = Int32(value)
+        case "c":
+            guard let pid = currentPID, pid > 0, !value.isEmpty else {
+                continue
+            }
+            processes[pid] = String(value.prefix(80))
+        default:
+            continue
+        }
+    }
+    return processes.map { PortListenerProcess(pid: $0.key, name: $0.value) }
+        .sorted { $0.pid < $1.pid }
+}
+
+func portConflictDetail(
+    process: PortListenerProcess,
+    port: Int
+) -> String {
+    "“\(process.name)” (PID \(process.pid)) is using VibeTV’s local port \(port). VibeTV also couldn’t start on another free port."
+}
+
 private struct NativeSupportReportSnapshot: Sendable {
     let generatedAt: String
     let setupTitle: String
@@ -855,6 +915,7 @@ private struct NativeSupportReportSnapshot: Sendable {
     let localPreviewRuntime: Bool
     let helperPath: String
     let runtimeLabel: String
+    let runtimeOrigin: String
     let runtimeRegistrationStatus: String
     let codexBarPath: String?
     let supportDirectoryPath: String
@@ -1020,6 +1081,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
     private var installationStatusTitle = "Starting Control Center"
     private var installationStatusDetail = "Preparing the Mac App."
     private var installationStatusFailed = false
+    private var activeRuntimeOrigin = URL(string: defaultRuntimeOriginString)!
+    private var runtimeFailureDetail: String?
 #if canImport(Sparkle)
     private lazy var updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
@@ -1103,6 +1166,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         guard preparationTask == nil else {
             return
         }
+        runtimeFailureDetail = nil
         presentInstallationStatus(
             title: "Starting Control Center",
             detail: "Checking the Mac App and your last connected VibeTV.",
@@ -1121,15 +1185,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
             case .nativeRuntimeReady:
                 self.codexBarRepairRequired = false
                 self.codexBarAutoRepairAttempted = false
+                self.runtimeFailureDetail = nil
                 self.installationReady = true
                 self.installationStatus = nil
                 _ = self.urlRouter.markReady()
                 self.presentControlCenter()
             case .legacyRuntimeRestored:
                 self.codexBarRepairRequired = false
+                let conflictDetail = self.runtimeFailureDetail
                 self.presentInstallationStatus(
-                    title: "Installation needs attention",
-                    detail: "The previous VibeTV service was restored. Try again or open the support log.",
+                    title: conflictDetail == nil
+                        ? "Installation needs attention"
+                        : "VibeTV couldn’t start",
+                    detail: conflictDetail
+                        ?? "The previous VibeTV service was restored. Try again or open the support log.",
                     failed: true
                 )
             case .codexBarRepairRequired:
@@ -1142,9 +1211,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 )
             case .keepCurrentPage:
                 self.codexBarRepairRequired = false
+                let conflictDetail = self.runtimeFailureDetail
                 self.presentInstallationStatus(
-                    title: "Installation could not be verified",
-                    detail: "The Mac App, runtime, and local listener did not reach one verified state.",
+                    title: conflictDetail == nil
+                        ? "Installation could not be verified"
+                        : "VibeTV couldn’t start",
+                    detail: conflictDetail
+                        ?? "The Mac App, runtime, and local listener did not reach one verified state.",
                     failed: true
                 )
             }
@@ -1283,6 +1356,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
             localPreviewRuntime: usesLocalPreviewRuntime,
             helperPath: helperURL.path,
             runtimeLabel: activeRuntimeLaunchAgentLabel,
+            runtimeOrigin: activeRuntimeOrigin.absoluteString,
             runtimeRegistrationStatus: runtimeRegistrationStatusDescription(),
             codexBarPath: existingCodexBarApp()?.path,
             supportDirectoryPath: applicationSupportURL().path,
@@ -1313,9 +1387,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
             executable: "/bin/launchctl",
             arguments: ["print", launchctlServiceTarget(uid: getuid(), label: snapshot.runtimeLabel)]
         )
+        let runtimeOrigin = URL(string: snapshot.runtimeOrigin)
+            ?? URL(string: defaultRuntimeOriginString)!
+        let runtimePort = runtimeOrigin.port ?? defaultRuntimePort
         let listener = captureProcessOutput(
             executable: "/usr/sbin/lsof",
-            arguments: ["-nP", "-iTCP@127.0.0.1:47832", "-sTCP:LISTEN"]
+            arguments: [
+                "-nP",
+                "-iTCP@127.0.0.1:\(runtimePort)",
+                "-sTCP:LISTEN",
+            ]
         )
         let backgroundItems = captureProcessOutput(
             executable: "/usr/bin/sfltool",
@@ -1323,7 +1404,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         )
         let companionDiagnostics = captureProcessOutput(
             executable: "/usr/bin/curl",
-            arguments: ["--silent", "--show-error", "--max-time", "40", "http://127.0.0.1:47832/v1/diagnostics"]
+            arguments: [
+                "--silent",
+                "--show-error",
+                "--max-time",
+                "40",
+                runtimeOrigin.appendingPathComponent("v1/diagnostics").absoluteString,
+            ]
         )
         let report: [String: Any] = [
             "schemaVersion": 2,
@@ -1354,11 +1441,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
             ],
             "runtime": [
                 "label": snapshot.runtimeLabel,
+                "origin": runtimeOrigin.absoluteString,
                 "serviceStatus": snapshot.localPreviewRuntime
                     ? (launchAgent.exitStatus == 0 ? "loaded" : "not loaded")
                     : snapshot.runtimeRegistrationStatus,
                 "listenerOwnership": runtimeListenerOwnership(
-                    launchAgent: launchAgent
+                    launchAgent: launchAgent,
+                    port: runtimePort
                 ),
                 "helperExists": fileManager.isExecutableFile(atPath: helperURL.path),
                 "helperSignature": processOutputReport(helperSignature),
@@ -1408,7 +1497,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
     }
 
     nonisolated private static func runtimeListenerOwnership(
-        launchAgent: ProcessOutput
+        launchAgent: ProcessOutput,
+        port: Int
     ) -> String {
         guard let servicePID = parseLaunchctlServicePID(launchAgent.output),
               launchAgent.exitStatus == 0 else {
@@ -1426,7 +1516,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 "-a",
                 "-p",
                 String(servicePID),
-                "-iTCP@127.0.0.1:47832",
+                "-iTCP@127.0.0.1:\(port)",
                 "-sTCP:LISTEN",
                 "-Fp",
             ]
@@ -2019,9 +2109,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
     private func loadControlCenter(
         cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
     ) {
-        guard let url = URL(string: controlCenterURLString) else {
-            return
-        }
+        let url = activeRuntimeOrigin.appendingPathComponent("control-center")
         activeNavigation = webView?.load(
             URLRequest(
                 url: url,
@@ -2434,6 +2522,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         // bounded re-registration. Do not let that weaker snapshot tear down a
         // runtime whose identity, version, and listener ownership were proven.
         guard runtimeHealthGatePassed(health) else {
+            runtimeFailureDetail = runtimePortConflictDetail()
             NSLog(
                 "VibeTV Control Center runtime health gate failed; legacy artifacts remain untouched: \(health)"
             )
@@ -2671,6 +2760,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 "127.0.0.1:47832",
                 "--api-dev-origin",
                 "http://127.0.0.1:47832",
+                "--api-fallback",
             ],
             "EnvironmentVariables": environment,
             "RunAtLoad": true,
@@ -2732,47 +2822,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         expectedVersion: String,
         timeout: TimeInterval = runtimeHealthTimeout
     ) async -> RuntimeHealthEvaluation {
-        guard let statusURL = URL(string: runtimeHealthURLString) else {
-            return .requestFailed("invalid local status URL")
-        }
-
         let deadline = Date().addingTimeInterval(timeout)
         var lastEvaluation: RuntimeHealthEvaluation = .requestFailed("no response")
         repeat {
-            var request = URLRequest(
-                url: statusURL,
-                cachePolicy: .reloadIgnoringLocalCacheData,
-                timeoutInterval: runtimeHealthRequestTimeout
-            )
-            request.httpMethod = "GET"
-            do {
-                let (data, response) = try await URLSession.shared.data(for: request)
-                guard let http = response as? HTTPURLResponse else {
-                    lastEvaluation = .requestFailed("response was not HTTP")
-                    continue
-                }
-                lastEvaluation = evaluateRuntimeHealth(
-                    data: data,
-                    httpStatus: http.statusCode,
-                    expectedVersion: expectedVersion,
-                    expectedAppVersion: Bundle.main.object(
-                        forInfoDictionaryKey: "CFBundleShortVersionString"
-                    ) as? String,
-                    expectedBuild: Bundle.main.object(
-                        forInfoDictionaryKey: "CFBundleVersion"
-                    ) as? String,
-                    expectedAppPath: Bundle.main.bundleURL.path,
-                    expectedRuntimeOwner: activeRuntimeLaunchAgentLabel
+            for origin in runtimeOriginCandidates() {
+                let statusURL = origin.appendingPathComponent("v1/runtime-health")
+                var request = URLRequest(
+                    url: statusURL,
+                    cachePolicy: .reloadIgnoringLocalCacheData,
+                    timeoutInterval: runtimeHealthRequestTimeout
                 )
-                if case .healthy = lastEvaluation {
-                    let ownership = verifyRuntimeListenerOwnership()
-                    if case .owned = ownership {
-                        return lastEvaluation
+                request.httpMethod = "GET"
+                do {
+                    let (data, response) = try await URLSession.shared.data(for: request)
+                    guard let http = response as? HTTPURLResponse else {
+                        lastEvaluation = .requestFailed("response was not HTTP")
+                        continue
                     }
-                    lastEvaluation = .ownershipFailed(ownership)
+                    lastEvaluation = evaluateRuntimeHealth(
+                        data: data,
+                        httpStatus: http.statusCode,
+                        expectedVersion: expectedVersion,
+                        expectedAppVersion: Bundle.main.object(
+                            forInfoDictionaryKey: "CFBundleShortVersionString"
+                        ) as? String,
+                        expectedBuild: Bundle.main.object(
+                            forInfoDictionaryKey: "CFBundleVersion"
+                        ) as? String,
+                        expectedAppPath: Bundle.main.bundleURL.path,
+                        expectedRuntimeOwner: activeRuntimeLaunchAgentLabel
+                    )
+                    if case .healthy = lastEvaluation {
+                        let ownership = verifyRuntimeListenerOwnership(
+                            port: origin.port ?? defaultRuntimePort
+                        )
+                        if case .owned = ownership {
+                            activeRuntimeOrigin = origin
+                            return lastEvaluation
+                        }
+                        lastEvaluation = .ownershipFailed(ownership)
+                    }
+                } catch {
+                    lastEvaluation = .requestFailed((error as NSError).localizedDescription)
                 }
-            } catch {
-                lastEvaluation = .requestFailed((error as NSError).localizedDescription)
             }
 
             if Date() < deadline {
@@ -2781,6 +2873,45 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         } while Date() < deadline
 
         return lastEvaluation
+    }
+
+    private func runtimeEndpointURL() -> URL {
+        applicationSupportURL()
+            .appendingPathComponent("run", isDirectory: true)
+            .appendingPathComponent(runtimeEndpointFileName)
+    }
+
+    private func runtimeOriginCandidates() -> [URL] {
+        var candidates: [URL] = []
+        if let data = try? Data(contentsOf: runtimeEndpointURL()),
+           let endpoint = try? JSONDecoder().decode(RuntimeEndpoint.self, from: data),
+           let origin = validatedRuntimeEndpointOrigin(endpoint) {
+            candidates.append(origin)
+        }
+        if let defaultOrigin = URL(string: defaultRuntimeOriginString),
+           !candidates.contains(defaultOrigin) {
+            candidates.append(defaultOrigin)
+        }
+        return candidates
+    }
+
+    private func runtimePortConflictDetail() -> String? {
+        let listener = runCommandCapturingOutput(
+            executable: "/usr/sbin/lsof",
+            arguments: [
+                "-nP",
+                "-iTCP@127.0.0.1:\(defaultRuntimePort)",
+                "-sTCP:LISTEN",
+                "-Fpc",
+            ]
+        )
+        guard let process = parseLsofListenerProcesses(listener.output).first else {
+            return nil
+        }
+        return portConflictDetail(
+            process: process,
+            port: defaultRuntimePort
+        )
     }
 
     private func currentCompanionVersion() -> String {
@@ -3008,7 +3139,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         return states[label] ?? false
     }
 
-    private func verifyRuntimeListenerOwnership() -> RuntimeOwnershipEvaluation {
+    private func verifyRuntimeListenerOwnership(port: Int) -> RuntimeOwnershipEvaluation {
         let launchctl = runCommandCapturingOutput(
             executable: "/bin/launchctl",
             arguments: [
@@ -3033,7 +3164,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 "-a",
                 "-p",
                 String(servicePID),
-                "-iTCP@127.0.0.1:47832",
+                "-iTCP@127.0.0.1:\(port)",
                 "-sTCP:LISTEN",
                 "-Fp",
             ]

--- a/macos/VibeTVControlCenter/shop.vibetv.control-center.runtime.plist
+++ b/macos/VibeTVControlCenter/shop.vibetv.control-center.runtime.plist
@@ -18,6 +18,7 @@
       <string>127.0.0.1:47832</string>
       <string>--api-dev-origin</string>
       <string>http://127.0.0.1:47832</string>
+      <string>--api-fallback</string>
     </array>
     <key>EnvironmentVariables</key>
     <dict>

--- a/scripts/test-macos-control-center-app-bundle.sh
+++ b/scripts/test-macos-control-center-app-bundle.sh
@@ -523,6 +523,7 @@ expected_arguments = [
     "127.0.0.1:47832",
     "--api-dev-origin",
     "http://127.0.0.1:47832",
+    "--api-fallback",
 ]
 if agent.get("ProgramArguments") != expected_arguments:
     raise SystemExit(
@@ -577,7 +578,10 @@ required_source = [
     'unregisterLocalPreviewRuntimeService()',
     '"CODEXBAR_DISPLAY_STREAM_LAUNCH_AGENT_LABEL":',
     'runtimeLaunchAgentLabel = "shop.vibetv.control-center.runtime"',
-    'runtimeHealthURLString = "http://127.0.0.1:47832/v1/runtime-health"',
+    'defaultRuntimeOriginString = "http://127.0.0.1:47832"',
+    'runtimeEndpointFileName = "runtime-endpoint.json"',
+    "validatedRuntimeEndpointOrigin(",
+    "runtimeOriginCandidates()",
     'nativeControlCenterUserAgentPrefix = "VibeTVControlCenter/"',
     "webView.customUserAgent = nativeControlCenterUserAgent(",
     "timeout: runtimeInitialHealthTimeout",
@@ -586,9 +590,9 @@ required_source = [
     '"--vibetv-validation-unregister-runtime"',
     '"VIBETV_RUNTIME_VALIDATION_UNREGISTER"',
     "CODEX_RUNTIME_UNREGISTER_OK label=",
-    "let ownership = verifyRuntimeListenerOwnership()",
+    "let ownership = verifyRuntimeListenerOwnership(",
     'executable: "/usr/sbin/lsof"',
-    '"-iTCP@127.0.0.1:47832"',
+    '"-iTCP@127.0.0.1:\\(port)"',
     '"-sTCP:LISTEN"',
     'URL(fileURLWithPath: "/Library/LaunchAgents"',
     'launchctlExitStatus(["disable", service])',
@@ -623,7 +627,7 @@ required_source = [
     '"backgroundItems": filteredBackgroundItems(',
     'Task.detached(priority: .userInitiated)',
     'withJSONObject: redactReportValue(report)',
-    '"--max-time", "40"',
+    '"--max-time",',
     'title: "Create report"',
     'title: "Starting Control Center"',
     "retryTitle: status.retryTitle",
@@ -641,7 +645,9 @@ required_source = [
     'environment["CODEXBAR_CONFIG"] = configURL.path',
     '[.posixPermissions: 0o700]',
     '[.posixPermissions: 0o600]',
-    'title: "Installation needs attention"',
+    '"VibeTV couldn’t start"',
+    "runtimePortConflictDetail()",
+    "parseLsofListenerProcesses(",
     "activeNavigation = webView?.load(",
     ".reloadIgnoringLocalCacheData",
     'alert.addButton(withTitle: "Open Applications")',
@@ -846,7 +852,7 @@ if "timeout: TimeInterval = runtimeHealthTimeout" not in health_method:
         "native runtime recovery must retain the full health timeout after the fast first check"
     )
 if health_method.find("evaluateRuntimeHealth(") > health_method.find(
-    "verifyRuntimeListenerOwnership()"
+    "verifyRuntimeListenerOwnership("
 ):
     raise SystemExit(
         "HTTP health must be evaluated before listener ownership is accepted"
@@ -863,6 +869,7 @@ if "recordCurrentRuntimeBundleVersion" in register_method:
 
 for forbidden in [
     "companionProcess",
+    "Darwin.kill",
     "func applicationShouldTerminate(",
     "func applicationWillTerminate(",
 ]:

--- a/scripts/test-macos-control-center-app-bundle.sh
+++ b/scripts/test-macos-control-center-app-bundle.sh
@@ -582,6 +582,7 @@ required_source = [
     'runtimeEndpointFileName = "runtime-endpoint.json"',
     "validatedRuntimeEndpointOrigin(",
     "runtimeOriginCandidates()",
+    "rediscoverRuntimeOriginForNavigationRetry()",
     'nativeControlCenterUserAgentPrefix = "VibeTVControlCenter/"',
     "webView.customUserAgent = nativeControlCenterUserAgent(",
     "timeout: runtimeInitialHealthTimeout",
@@ -856,6 +857,19 @@ if health_method.find("evaluateRuntimeHealth(") > health_method.find(
 ):
     raise SystemExit(
         "HTTP health must be evaluated before listener ownership is accepted"
+    )
+
+reload_method = source[
+    source.find("private func scheduleReload()"):
+    source.find("\\n}\\n\\n#if canImport(Sparkle)", source.find("private func scheduleReload()"))
+]
+rediscover_runtime = reload_method.find(
+    "await self.rediscoverRuntimeOriginForNavigationRetry()"
+)
+reload_control_center = reload_method.find("self.loadControlCenter(")
+if not (0 <= rediscover_runtime < reload_control_center):
+    raise SystemExit(
+        "native navigation retry must rediscover the verified runtime endpoint before reloading"
     )
 
 register_method = source[


### PR DESCRIPTION
Closes #241

## What changed

- keep `127.0.0.1:47832` as the preferred Control Center endpoint
- fall back to an OS-selected private loopback port when an unrelated process occupies `47832`
- detect an existing VibeTV service on the preferred port and refuse to start a second display writer
- publish the selected runtime origin atomically in a private endpoint file
- let the Swift shell discover and validate that endpoint while preserving the existing version, build, path, launchd-label, and listener-ownership checks
- rediscover the verified runtime origin before every WebView navigation retry, so a restarted fallback runtime cannot leave the app on a stale port
- use the actual runtime port in diagnostics and local release/theme-pack URL handling
- reuse the existing native failure screen only when automatic recovery is unsafe or fails
- show the blocking process name and PID with the approved instruction to quit the app or stop the process, then retry

No new UI component and no process-kill logic were added.

## Why

A stale or custom local VibeTV process can keep port `47832` occupied after its LaunchAgent is stopped. Blindly starting a second runtime on another port could create two services writing to the same display. Reusing an old fallback URL after a runtime restart could also leave the WebView stuck.

The Mac App now distinguishes these cases safely:

- unrelated process on `47832`: recover automatically on a private fallback port
- existing VibeTV service on `47832`: do not start a second writer; show the already approved blocker instruction
- restarted fallback runtime: verify and use its newly published port before reloading

## User impact

Normal localhost or AI development on other ports is unaffected. An unrelated process that happens to own exactly `47832` no longer traps the user. A stale/custom VibeTV service remains the sole display writer until the customer stops that process and clicks **Try again**.

## Validation

- full Go suite: `go test ./... -p 1 -count=1`
- Control Center unit tests: 102 passed
- ESLint
- customer-flow regression suite
- macOS Control Center app-bundle test
- macOS runtime-validation contract test
- customer UI review gate: 0 UI-impacting files
- documentation and diff checks

The visible screen, copy, controls, and layout are unchanged by the final safety fix.