### PR TITLE
Handle native installation recovery states

### DIFF
--- a/macos/VibeTVControlCenter/URLSchemeTests.swift
+++ b/macos/VibeTVControlCenter/URLSchemeTests.swift
@@ -53,11 +53,85 @@ func runURLSchemeTests() {
         title: "CodexBar needs repair",
         detail: "Repair CodexBar before continuing.",
         failed: true,
-        retryTitle: "Repair CodexBar"
+        retryTitle: "Repair CodexBar",
+        kind: .standard
     )
     require(
         repairStatus.retryTitle == "Repair CodexBar",
         "native installation status must preserve its repair CTA across window reopening"
+    )
+    let approvalStatus = InstallationFailure.backgroundApproval.installationStatus
+    require(
+        approvalStatus.title == "Allow VibeTV to run in the background"
+            && approvalStatus.detail
+                == "VibeTV needs permission to keep its local service running."
+            && approvalStatus.retryTitle == "Try again"
+            && approvalStatus.kind == .backgroundApproval,
+        "native installation status must preserve background approval across window reopening"
+    )
+    let serviceStatus = InstallationFailure.serviceStart.installationStatus
+    require(
+        serviceStatus.title == "VibeTV’s background service couldn’t start"
+            && serviceStatus.detail
+                == "Restart VibeTV’s local service to continue."
+            && serviceStatus.retryTitle == "Restart service"
+            && serviceStatus.kind == .serviceRestart,
+        "service startup failures must offer the focused restart recovery"
+    )
+    let updateStatus = InstallationFailure.updateMismatch.installationStatus
+    require(
+        updateStatus.title == "VibeTV update didn’t finish"
+            && updateStatus.detail
+                == "The app and its background service are on different versions."
+            && updateStatus.retryTitle == "Restart VibeTV"
+            && updateStatus.kind == .updateMismatch,
+        "version mismatches must explain the interrupted update"
+    )
+    let incompleteStatus = InstallationFailure.applicationIncomplete.installationStatus
+    require(
+        incompleteStatus.title == "VibeTV Control Center is incomplete"
+            && incompleteStatus.detail
+                == "Required application files are missing or damaged."
+            && incompleteStatus.retryTitle == "Download VibeTV again"
+            && incompleteStatus.kind == .applicationIncomplete,
+        "missing app resources must direct the customer to a fresh download"
+    )
+    let legacyStatus = InstallationFailure.legacyRepair.installationStatus
+    require(
+        legacyStatus.title == "Your previous VibeTV installation needs repair"
+            && legacyStatus.detail
+                == "VibeTV couldn’t safely replace the older background service."
+            && legacyStatus.retryTitle == "Repair installation"
+            && legacyStatus.kind == .legacyRepair,
+        "legacy migration failures must offer installation repair"
+    )
+    require(
+        installationPreviewFailure("background-approval") == .backgroundApproval
+            && installationPreviewFailure("service-start") == .serviceStart
+            && installationPreviewFailure("update-mismatch") == .updateMismatch
+            && installationPreviewFailure("application-incomplete")
+                == .applicationIncomplete
+            && installationPreviewFailure("legacy-repair") == .legacyRepair
+            && installationPreviewFailure("unknown") == nil,
+        "local preview must expose every approved recovery state and nothing else"
+    )
+    require(
+        installationFailure(
+            for: .versionMismatch(expected: "1.0.0", actual: "0.9.0")
+        ) == .updateMismatch
+            && installationFailure(for: .appMetadataMissing) == .updateMismatch
+            && installationFailure(for: .requestFailed("offline"))
+                == .serviceStart,
+        "runtime diagnostics must select a useful customer recovery state"
+    )
+    let backgroundApprovalSequence = [
+        runtimeServiceRegistrationOutcome(for: .requiresApproval),
+        runtimeServiceRegistrationOutcome(for: .enabled),
+        runtimeServiceRegistrationOutcome(for: .requiresApproval),
+    ]
+    require(
+        backgroundApprovalSequence == [.requiresApproval, .ready, .requiresApproval],
+        "background approval must recover after consent and return when consent is revoked"
     )
     let redactedReport = AppDelegate.redactReportValue([
         "token": "raw-token",
@@ -130,15 +204,17 @@ func runURLSchemeTests() {
         "healthy native runtime must refresh the WebView"
     )
     require(
-        !RuntimePreparationOutcome.legacyRuntimeRestored.shouldReloadControlCenter,
-        "a restored legacy runtime must keep the WebView closed until native installation succeeds"
-    )
-    require(
         !RuntimePreparationOutcome.codexBarRepairRequired.shouldReloadControlCenter,
         "a failed CodexBar installation must keep customer setup blocked"
     )
     require(
-        !RuntimePreparationOutcome.keepCurrentPage.shouldReloadControlCenter,
+        !RuntimePreparationOutcome.failure(.backgroundApproval)
+            .shouldReloadControlCenter,
+        "background approval must keep the WebView closed until the runtime is verified"
+    )
+    require(
+        !RuntimePreparationOutcome.failure(.legacyRepair)
+            .shouldReloadControlCenter,
         "uncertain runtime state must not force a misleading WebView refresh"
     )
     require(

--- a/macos/VibeTVControlCenter/main.swift
+++ b/macos/VibeTVControlCenter/main.swift
@@ -29,6 +29,8 @@ private let runtimeRegisteredVersionDefaultsKey =
     "shop.vibetv.control-center.runtime.registered-bundle-version"
 private let pendingNativeUpdateFileName = "pending-native-update.json"
 private let pendingNativeUpdateMaximumAge: TimeInterval = 30 * 60
+private let installationPreviewEnvironmentKey = "VIBETV_INSTALLATION_PREVIEW_STATE"
+private let hostedControlCenterURLString = "https://app.vibetv.shop"
 private let runtimeInitialHealthTimeout: TimeInterval = 8
 private let runtimeHealthTimeout: TimeInterval = 35
 private let runtimeHealthRequestTimeout: TimeInterval = 5
@@ -965,14 +967,81 @@ func pendingNativeUpdateBlocksBundle(
     )
 }
 
+enum InstallationFailure: Equatable {
+    case backgroundApproval
+    case serviceStart
+    case updateMismatch
+    case applicationIncomplete
+    case legacyRepair
+    case portConflict(String)
+}
+
+func installationFailure(
+    for health: RuntimeHealthEvaluation
+) -> InstallationFailure {
+    switch health {
+    case .expectedVersionMissing,
+         .versionMismatch,
+         .appMetadataMissing,
+         .appBuildMismatch,
+         .appPathMismatch,
+         .runtimeOwnerMismatch:
+        return .updateMismatch
+    case .healthy,
+         .httpStatus,
+         .invalidPayload,
+         .reportedUnhealthy,
+         .ownershipFailed,
+         .requestFailed:
+        return .serviceStart
+    }
+}
+
+func installationPreviewFailure(_ value: String) -> InstallationFailure? {
+    switch value {
+    case "background-approval":
+        return .backgroundApproval
+    case "service-start":
+        return .serviceStart
+    case "update-mismatch":
+        return .updateMismatch
+    case "application-incomplete":
+        return .applicationIncomplete
+    case "legacy-repair":
+        return .legacyRepair
+    default:
+        return nil
+    }
+}
+
 enum RuntimePreparationOutcome: Equatable {
     case nativeRuntimeReady
-    case legacyRuntimeRestored
     case codexBarRepairRequired
-    case keepCurrentPage
+    case failure(InstallationFailure)
 
     var shouldReloadControlCenter: Bool {
         self == .nativeRuntimeReady
+    }
+}
+
+enum RuntimeServiceRegistrationOutcome: Equatable {
+    case ready
+    case requiresApproval
+    case failed
+}
+
+func runtimeServiceRegistrationOutcome(
+    for status: SMAppService.Status
+) -> RuntimeServiceRegistrationOutcome {
+    switch status {
+    case .enabled:
+        return .ready
+    case .requiresApproval:
+        return .requiresApproval
+    case .notRegistered, .notFound:
+        return .failed
+    @unknown default:
+        return .failed
     }
 }
 
@@ -981,17 +1050,83 @@ func shouldRetryControlCenterNavigation(_ error: Error) -> Bool {
     return !(error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled)
 }
 
+enum InstallationStatusKind: Equatable {
+    case standard
+    case backgroundApproval
+    case serviceRestart
+    case updateMismatch
+    case applicationIncomplete
+    case legacyRepair
+}
+
 struct InstallationStatus {
     let title: String
     let detail: String
     let failed: Bool
     let retryTitle: String
+    let kind: InstallationStatusKind
+}
+
+extension InstallationFailure {
+    var installationStatus: InstallationStatus {
+        switch self {
+        case .backgroundApproval:
+            return InstallationStatus(
+                title: "Allow VibeTV to run in the background",
+                detail: "VibeTV needs permission to keep its local service running.",
+                failed: true,
+                retryTitle: "Try again",
+                kind: .backgroundApproval
+            )
+        case .serviceStart:
+            return InstallationStatus(
+                title: "VibeTV’s background service couldn’t start",
+                detail: "Restart VibeTV’s local service to continue.",
+                failed: true,
+                retryTitle: "Restart service",
+                kind: .serviceRestart
+            )
+        case .updateMismatch:
+            return InstallationStatus(
+                title: "VibeTV update didn’t finish",
+                detail: "The app and its background service are on different versions.",
+                failed: true,
+                retryTitle: "Restart VibeTV",
+                kind: .updateMismatch
+            )
+        case .applicationIncomplete:
+            return InstallationStatus(
+                title: "VibeTV Control Center is incomplete",
+                detail: "Required application files are missing or damaged.",
+                failed: true,
+                retryTitle: "Download VibeTV again",
+                kind: .applicationIncomplete
+            )
+        case .legacyRepair:
+            return InstallationStatus(
+                title: "Your previous VibeTV installation needs repair",
+                detail: "VibeTV couldn’t safely replace the older background service.",
+                failed: true,
+                retryTitle: "Repair installation",
+                kind: .legacyRepair
+            )
+        case .portConflict(let detail):
+            return InstallationStatus(
+                title: "VibeTV couldn’t start",
+                detail: detail,
+                failed: true,
+                retryTitle: "Try again",
+                kind: .standard
+            )
+        }
+    }
 }
 
 private enum NativeSetupButtonVariant {
     case primary
     case secondary
     case outline
+    case plain
 }
 
 @MainActor
@@ -1082,7 +1217,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
     private var installationStatusDetail = "Preparing the Mac App."
     private var installationStatusFailed = false
     private var activeRuntimeOrigin = URL(string: defaultRuntimeOriginString)!
-    private var runtimeFailureDetail: String?
 #if canImport(Sparkle)
     private lazy var updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
@@ -1107,6 +1241,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
         configureMenu()
+        if usesLocalPreviewRuntime,
+           let previewValue = ProcessInfo.processInfo.environment[
+               installationPreviewEnvironmentKey
+           ],
+           let failure = installationPreviewFailure(previewValue) {
+            presentInstallationFailure(failure)
+            return
+        }
         guard !installationRequired else {
             presentInstallationRequiredAlert()
             return
@@ -1153,7 +1295,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 title: status.title,
                 detail: status.detail,
                 failed: status.failed,
-                retryTitle: status.retryTitle
+                retryTitle: status.retryTitle,
+                kind: status.kind
             )
         } else {
             window?.makeKeyAndOrderFront(nil)
@@ -1166,12 +1309,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         guard preparationTask == nil else {
             return
         }
-        runtimeFailureDetail = nil
-        presentInstallationStatus(
-            title: "Starting Control Center",
-            detail: "Checking the Mac App and your last connected VibeTV.",
-            failed: false
-        )
+        let preserveBackgroundApprovalStatus =
+            installationStatus?.kind == .backgroundApproval
+        if !preserveBackgroundApprovalStatus {
+            presentInstallationStatus(
+                title: "Starting Control Center",
+                detail: "Checking the Mac App and your last connected VibeTV.",
+                failed: false
+            )
+        }
         Task { [weak self] in
             await self?.performLocalNetworkPrivacyPreflight()
         }
@@ -1185,22 +1331,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
             case .nativeRuntimeReady:
                 self.codexBarRepairRequired = false
                 self.codexBarAutoRepairAttempted = false
-                self.runtimeFailureDetail = nil
                 self.installationReady = true
                 self.installationStatus = nil
                 _ = self.urlRouter.markReady()
                 self.presentControlCenter()
-            case .legacyRuntimeRestored:
-                self.codexBarRepairRequired = false
-                let conflictDetail = self.runtimeFailureDetail
-                self.presentInstallationStatus(
-                    title: conflictDetail == nil
-                        ? "Installation needs attention"
-                        : "VibeTV couldn’t start",
-                    detail: conflictDetail
-                        ?? "The previous VibeTV service was restored. Try again or open the support log.",
-                    failed: true
-                )
             case .codexBarRepairRequired:
                 self.codexBarRepairRequired = true
                 self.presentInstallationStatus(
@@ -1209,19 +1343,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                     failed: true,
                     retryTitle: "Repair CodexBar"
                 )
-            case .keepCurrentPage:
+            case .failure(let failure):
                 self.codexBarRepairRequired = false
-                let conflictDetail = self.runtimeFailureDetail
-                self.presentInstallationStatus(
-                    title: conflictDetail == nil
-                        ? "Installation could not be verified"
-                        : "VibeTV couldn’t start",
-                    detail: conflictDetail
-                        ?? "The Mac App, runtime, and local listener did not reach one verified state.",
-                    failed: true
-                )
+                self.presentInstallationFailure(failure)
             }
         }
+    }
+
+    private func presentInstallationFailure(_ failure: InstallationFailure) {
+        let status = failure.installationStatus
+        presentInstallationStatus(
+            title: status.title,
+            detail: status.detail,
+            failed: status.failed,
+            retryTitle: status.retryTitle,
+            kind: status.kind
+        )
     }
 
     private func prepareCompanionWithAutomaticCodexBarRepair() async -> RuntimePreparationOutcome {
@@ -1250,6 +1387,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         }
         codexBarRepairRequired = false
         startRuntimePreparation()
+    }
+
+    @objc private func openSystemSettingsLoginItems() {
+        SMAppService.openSystemSettingsLoginItems()
+    }
+
+    @objc private func downloadVibeTVAgain() {
+        guard let url = URL(string: hostedControlCenterURLString) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    @objc private func restartControlCenterAfterFailedUpdate() {
+        discardMismatchedPendingNativeUpdate()
+        restartControlCenter()
     }
 
     private func beginCodexBarRepair() {
@@ -1730,7 +1883,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
 #endif
     }
 
-    private func restartControlCenter() {
+    @objc private func restartControlCenter() {
         let configuration = NSWorkspace.OpenConfiguration()
         configuration.activates = true
         configuration.addsToRecentItems = false
@@ -1883,6 +2036,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
     ) -> NSButton {
         let button = NSButton(title: title, target: self, action: action)
         button.isBordered = false
+        button.focusRingType = .none
         button.wantsLayer = true
         button.layer?.cornerRadius = 8
         button.layer?.masksToBounds = true
@@ -1920,12 +2074,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 alpha: 1
             ).cgColor
             button.layer?.borderWidth = 1
+        case .plain:
+            button.layer?.backgroundColor = NSColor.clear.cgColor
         }
 
         button.translatesAutoresizingMaskIntoConstraints = false
+        let shadcnButtonWidth = max(
+            132,
+            button.intrinsicContentSize.width + 32
+        )
         NSLayoutConstraint.activate([
             button.heightAnchor.constraint(equalToConstant: 44),
-            button.widthAnchor.constraint(greaterThanOrEqualToConstant: 132),
+            button.widthAnchor.constraint(equalToConstant: shadcnButtonWidth),
         ])
         return button
     }
@@ -1934,13 +2094,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         title: String,
         detail: String,
         failed: Bool,
-        retryTitle: String = "Try again"
+        retryTitle: String = "Try again",
+        kind: InstallationStatusKind = .standard
     ) {
         installationStatus = InstallationStatus(
             title: title,
             detail: detail,
             failed: failed,
-            retryTitle: retryTitle
+            retryTitle: retryTitle,
+            kind: kind
         )
         installationStatusTitle = title
         installationStatusDetail = detail
@@ -1986,41 +2148,132 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
             progress.startAnimation()
         }
 
-        let retry = makeNativeSetupButton(
-            title: retryTitle,
-            action: #selector(retryRuntimePreparation),
-            symbolName: "arrow.clockwise",
-            variant: .primary
-        )
-        retry.keyEquivalent = "\r"
-        retry.isHidden = !failed
-
+        let recoveryLayout = kind != .standard
         let support = makeNativeSetupButton(
             title: "Create report",
             action: #selector(createNativeSupportReport),
             symbolName: "doc.text",
-            variant: .secondary
+            variant: recoveryLayout ? .plain : .secondary
         )
-        support.isHidden = false
-
         let supportLog = makeNativeSetupButton(
             title: "Open support log",
             action: #selector(openSupportLog),
             symbolName: "doc.plaintext",
-            variant: .outline
+            variant: recoveryLayout ? .plain : .outline
         )
         supportLog.isHidden = !failed
 
-        let actions = NSStackView(views: [retry, support, supportLog])
-        actions.orientation = .horizontal
-        actions.alignment = .centerY
-        actions.spacing = 12
+        let actions: NSStackView
+        if recoveryLayout {
+            let recoveryButtons: [NSButton]
+            switch kind {
+            case .backgroundApproval:
+                recoveryButtons = [
+                    makeNativeSetupButton(
+                        title: "Open Login Items",
+                        action: #selector(openSystemSettingsLoginItems),
+                        symbolName: "slider.horizontal.3",
+                        variant: .primary
+                    ),
+                    makeNativeSetupButton(
+                        title: "Try again",
+                        action: #selector(retryRuntimePreparation),
+                        symbolName: "arrow.clockwise",
+                        variant: .secondary
+                    ),
+                ]
+            case .serviceRestart:
+                recoveryButtons = [
+                    makeNativeSetupButton(
+                        title: "Restart service",
+                        action: #selector(retryRuntimePreparation),
+                        symbolName: "arrow.clockwise",
+                        variant: .primary
+                    ),
+                ]
+            case .updateMismatch:
+                recoveryButtons = [
+                    makeNativeSetupButton(
+                        title: "Restart VibeTV",
+                        action: #selector(restartControlCenterAfterFailedUpdate),
+                        symbolName: "arrow.clockwise",
+                        variant: .primary
+                    ),
+                    makeNativeSetupButton(
+                        title: "Check for updates",
+                        action: #selector(checkForUpdates),
+                        symbolName: "arrow.triangle.2.circlepath",
+                        variant: .secondary
+                    ),
+                ]
+            case .applicationIncomplete:
+                recoveryButtons = [
+                    makeNativeSetupButton(
+                        title: "Download VibeTV again",
+                        action: #selector(downloadVibeTVAgain),
+                        symbolName: "arrow.down.circle",
+                        variant: .primary
+                    ),
+                ]
+            case .legacyRepair:
+                recoveryButtons = [
+                    makeNativeSetupButton(
+                        title: "Repair installation",
+                        action: #selector(retryRuntimePreparation),
+                        symbolName: "wrench.and.screwdriver",
+                        variant: .primary
+                    ),
+                    makeNativeSetupButton(
+                        title: "Try again",
+                        action: #selector(restartControlCenter),
+                        symbolName: "arrow.clockwise",
+                        variant: .secondary
+                    ),
+                ]
+            case .standard:
+                recoveryButtons = []
+            }
+            recoveryButtons.first?.keyEquivalent = "\r"
+
+            let primaryActions = NSStackView(views: recoveryButtons)
+            primaryActions.orientation = .vertical
+            primaryActions.alignment = .centerX
+            primaryActions.spacing = 12
+
+            let supportActions = NSStackView(views: [support, supportLog])
+            supportActions.orientation = .horizontal
+            supportActions.alignment = .centerY
+            supportActions.spacing = 24
+
+            actions = NSStackView(views: [primaryActions, supportActions])
+            actions.orientation = .vertical
+            actions.alignment = .centerX
+            actions.spacing = 18
+        } else {
+            let retry = makeNativeSetupButton(
+                title: retryTitle,
+                action: #selector(retryRuntimePreparation),
+                symbolName: "arrow.clockwise",
+                variant: .primary
+            )
+            retry.keyEquivalent = "\r"
+            retry.isHidden = !failed
+
+            actions = NSStackView(views: [retry, support, supportLog])
+            actions.orientation = .horizontal
+            actions.alignment = .centerY
+            actions.spacing = 12
+        }
 
         let stack = NSStackView(views: [brand, titleLabel, detailLabel, progress, actions])
         stack.orientation = .vertical
         stack.alignment = .centerX
         stack.spacing = 18
         stack.translatesAutoresizingMaskIntoConstraints = false
+        if recoveryLayout {
+            stack.setCustomSpacing(44, after: brand)
+            stack.setCustomSpacing(56, after: detailLabel)
+        }
         container.addSubview(stack)
         NSLayoutConstraint.activate([
             stack.centerXAnchor.constraint(equalTo: container.centerXAnchor),
@@ -2407,7 +2660,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
             NSLog(
                 "VibeTV Control Center runtime migration skipped: move the app to /Applications first"
             )
-            return .keepCurrentPage
+            return .failure(.applicationIncomplete)
         }
         if let pending = loadPendingNativeUpdate() {
             let shortVersion = Bundle.main.object(
@@ -2424,7 +2677,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 NSLog(
                     "VibeTV Control Center pending update mismatch expected=\(pending.version)+\(pending.build); Try again can discard the failed handoff"
                 )
-                return .keepCurrentPage
+                return .failure(.updateMismatch)
             }
             if !pendingNativeUpdateMatchesBundle(
                 pending,
@@ -2439,7 +2692,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         }
         guard bundledRuntimeResourcesAreValid() else {
             NSLog("VibeTV Control Center app-managed runtime resources are missing")
-            return .keepCurrentPage
+            return .failure(.applicationIncomplete)
         }
 
         guard await bootstrapCodexBar() else {
@@ -2449,14 +2702,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         let expectedVersion = currentCompanionVersion()
         guard !expectedVersion.isEmpty else {
             NSLog("VibeTV Control Center bundled Companion version is missing")
-            return .keepCurrentPage
+            return .failure(.applicationIncomplete)
         }
 
         guard let legacyStates = legacyLaunchAgentStates() else {
             NSLog(
                 "VibeTV Control Center kept legacy services and apps because their launchctl state could not be captured"
             )
-            return .keepCurrentPage
+            return .failure(.legacyRepair)
         }
         let legacyDescriptors = legacyStates.map(\.descriptor)
         let legacyApps = legacyTerminalAppURLs()
@@ -2469,19 +2722,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 NSLog(
                     "VibeTV Control Center could not stop the app-managed runtime before legacy migration"
                 )
-                return .keepCurrentPage
+                return .failure(.legacyRepair)
             }
         }
 
         if !stopLegacyLaunchAgents(legacyStates) {
             let reason = "one or more legacy LaunchAgents could not be stopped"
-            let restored = restoreLegacyAgents(legacyStates, reason: reason)
-            return restored ? .legacyRuntimeRestored : .keepCurrentPage
+            _ = restoreLegacyAgents(legacyStates, reason: reason)
+            return .failure(.legacyRepair)
         }
 
         // SMAppService.register() bootstraps a LaunchAgent immediately. Stop
         // every legacy writer first so migration never overlaps two streams.
-        guard await ensureBundledRuntimeServiceRegistered() else {
+        switch await ensureBundledRuntimeServiceRegistered() {
+        case .ready:
+            break
+        case .requiresApproval:
+            return .failure(.backgroundApproval)
+        case .failed:
             NSLog(
                 "VibeTV Control Center could not register the app-managed runtime after stopping legacy services"
             )
@@ -2493,9 +2751,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 } else {
                     restored = restoreLegacyAgents(legacyStates, reason: reason)
                 }
-                return restored ? .legacyRuntimeRestored : .keepCurrentPage
+                if !restored {
+                    NSLog(
+                        "VibeTV Control Center could not restore the previous background service"
+                    )
+                }
+                return .failure(.legacyRepair)
             }
-            return .keepCurrentPage
+            return .failure(.serviceStart)
         }
 
         // Detect a failed first runtime launch quickly, then use the existing
@@ -2512,8 +2775,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
             NSLog(
                 "VibeTV Control Center runtime did not become reachable; refreshing its Service Management registration once: \(health)"
             )
-            if await unregisterBundledRuntimeService(), registerBundledRuntimeService() {
-                health = await waitForHealthyRuntime(expectedVersion: expectedVersion)
+            if await unregisterBundledRuntimeService() {
+                switch registerBundledRuntimeService() {
+                case .ready:
+                    health = await waitForHealthyRuntime(expectedVersion: expectedVersion)
+                case .requiresApproval:
+                    return .failure(.backgroundApproval)
+                case .failed:
+                    break
+                }
             }
         }
         // A healthy result already proves that the expected Companion version
@@ -2522,7 +2792,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         // bounded re-registration. Do not let that weaker snapshot tear down a
         // runtime whose identity, version, and listener ownership were proven.
         guard runtimeHealthGatePassed(health) else {
-            runtimeFailureDetail = runtimePortConflictDetail()
+            let failure = runtimePortConflictDetail().map(
+                InstallationFailure.portConflict
+            ) ?? installationFailure(for: health)
             NSLog(
                 "VibeTV Control Center runtime health gate failed; legacy artifacts remain untouched: \(health)"
             )
@@ -2531,13 +2803,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                     legacyStates,
                     reason: health.description
                 )
-                return restored ? .legacyRuntimeRestored : .keepCurrentPage
+                if !restored {
+                    NSLog(
+                        "VibeTV Control Center could not restore the previous background service"
+                    )
+                }
             } else if !(await unregisterBundledRuntimeService()) {
                 NSLog(
                     "VibeTV Control Center could not unregister the failed app-managed runtime"
                 )
             }
-            return .keepCurrentPage
+            return .failure(failure)
         }
         clearPendingNativeUpdate()
 
@@ -2553,11 +2829,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         if !legacyApps.isEmpty {
             let registeredURLHandler = await registerCurrentAppAsURLHandler()
             if !registeredURLHandler {
-                let restored = await rollbackToLegacyAgents(
+                _ = await rollbackToLegacyAgents(
                     legacyStates,
                     reason: "the current app could not become the vibetv URL handler"
                 )
-                return restored ? .legacyRuntimeRestored : .keepCurrentPage
+                return .failure(.legacyRepair)
             }
         }
 
@@ -2568,11 +2844,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
             backupRoot: backupRoot
         )
         guard moveMigrationArtifacts(artifacts) != nil else {
-            let restored = await rollbackToLegacyAgents(
+            _ = await rollbackToLegacyAgents(
                 legacyStates,
                 reason: "legacy artifacts could not be moved into the migration backup"
             )
-            return restored ? .legacyRuntimeRestored : .keepCurrentPage
+            return .failure(.legacyRepair)
         }
 
         recordCurrentRuntimeBundleVersion()
@@ -2608,7 +2884,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         }
     }
 
-    private func ensureBundledRuntimeServiceRegistered() async -> Bool {
+    private func ensureBundledRuntimeServiceRegistered() async
+        -> RuntimeServiceRegistrationOutcome {
         if usesLocalPreviewRuntime {
             // An ad-hoc preview cannot satisfy the Developer ID launch
             // constraint retained by SMAppService from a production install.
@@ -2621,9 +2898,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 ),
             ])
             guard await unregisterLocalPreviewRuntimeService() else {
-                return false
+                return .failed
             }
-            return registerLocalPreviewRuntimeService()
+            return registerLocalPreviewRuntimeService() ? .ready : .failed
         }
         switch runtimeService.status {
         case .enabled:
@@ -2632,49 +2909,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
                 currentVersion: currentRuntimeBundleVersion()
             ) {
                 guard await unregisterBundledRuntimeService() else {
-                    return false
+                    return .failed
                 }
                 return registerBundledRuntimeService()
             }
-            return true
+            return .ready
         case .requiresApproval:
             NSLog(
                 "VibeTV Control Center runtime needs approval in System Settings > General > Login Items"
             )
-            return false
+            return .requiresApproval
         case .notRegistered, .notFound:
             return registerBundledRuntimeService()
         @unknown default:
             NSLog("VibeTV Control Center runtime has an unknown Service Management status")
-            return false
+            return .failed
         }
     }
 
-    private func registerBundledRuntimeService() -> Bool {
+    private func registerBundledRuntimeService() -> RuntimeServiceRegistrationOutcome {
         if usesLocalPreviewRuntime {
-            return registerLocalPreviewRuntimeService()
+            return registerLocalPreviewRuntimeService() ? .ready : .failed
         }
         do {
             try runtimeService.register()
         } catch {
             NSLog("VibeTV Control Center could not register its app-managed runtime: \(error)")
-            return runtimeService.status == .enabled
+            return runtimeServiceRegistrationOutcome(for: runtimeService.status)
         }
 
         switch runtimeService.status {
         case .enabled:
-            return true
+            return .ready
         case .requiresApproval:
             NSLog(
                 "VibeTV Control Center runtime was registered but needs approval in System Settings > General > Login Items"
             )
-            return false
+            return .requiresApproval
         case .notRegistered, .notFound:
             NSLog("VibeTV Control Center runtime registration did not become enabled")
-            return false
+            return .failed
         @unknown default:
             NSLog("VibeTV Control Center runtime has an unknown status after registration")
-            return false
+            return .failed
         }
     }
 

--- a/scripts/test-macos-control-center-app-bundle.sh
+++ b/scripts/test-macos-control-center-app-bundle.sh
@@ -617,6 +617,8 @@ required_source = [
     "requiresApplicationInstallation(Bundle.main.bundleURL)",
     "presentInstallationRequiredAlert()",
     "RuntimePreparationOutcome",
+    "RuntimeServiceRegistrationOutcome",
+    "runtimeServiceRegistrationOutcome(",
     "pendingNativeUpdateBlocksBundle(",
     "pendingNativeUpdateIsExpired(",
     "discardMismatchedPendingNativeUpdate()",
@@ -632,6 +634,41 @@ required_source = [
     'title: "Create report"',
     'title: "Starting Control Center"',
     "retryTitle: status.retryTitle",
+    "kind: status.kind",
+    "case .failure(let failure):",
+    "SMAppService.openSystemSettingsLoginItems()",
+    'installationPreviewEnvironmentKey = "VIBETV_INSTALLATION_PREVIEW_STATE"',
+    'title: "Allow VibeTV to run in the background"',
+    'detail: "VibeTV needs permission to keep its local service running."',
+    'title: "Open Login Items"',
+    "action: #selector(openSystemSettingsLoginItems)",
+    "kind: .backgroundApproval",
+    "installationStatus?.kind == .backgroundApproval",
+    'title: "VibeTV’s background service couldn’t start"',
+    'detail: "Restart VibeTV’s local service to continue."',
+    'title: "Restart service"',
+    "action: #selector(retryRuntimePreparation)",
+    "kind: .serviceRestart",
+    'title: "VibeTV update didn’t finish"',
+    'detail: "The app and its background service are on different versions."',
+    'title: "Restart VibeTV"',
+    "action: #selector(restartControlCenterAfterFailedUpdate)",
+    "@objc private func restartControlCenterAfterFailedUpdate()",
+    'title: "Check for updates"',
+    "action: #selector(checkForUpdates)",
+    "kind: .updateMismatch",
+    'title: "VibeTV Control Center is incomplete"',
+    'detail: "Required application files are missing or damaged."',
+    'title: "Download VibeTV again"',
+    "action: #selector(downloadVibeTVAgain)",
+    "kind: .applicationIncomplete",
+    'title: "Your previous VibeTV installation needs repair"',
+    'detail: "VibeTV couldn’t safely replace the older background service."',
+    'title: "Repair installation"',
+    "action: #selector(restartControlCenter)",
+    "kind: .legacyRepair",
+    "button.intrinsicContentSize.width + 32",
+    "button.widthAnchor.constraint(equalToConstant: shadcnButtonWidth)",
     'codexBarBundleIdentifier = "com.steipete.codexbar"',
     'codexBarPinnedVersion = "0.44.0"',
     'codexBarMinimumCompatibleVersion = "0.23.0"',
@@ -661,6 +698,14 @@ for snippet in required_source:
 
 if "support.isHidden = !failed" in source:
     raise SystemExit("Create report must remain visible on every native setup screen")
+if '"Background activity is off"' in source:
+    raise SystemExit("background approval UI must stay limited to headline, detail, and actions")
+if '"Installation could not be verified"' in source:
+    raise SystemExit("runtime failures must use a specific customer recovery state")
+if '"The Mac App, runtime, and local listener did not reach one verified state."' in source:
+    raise SystemExit("runtime failures must not expose the generic verification detail")
+if "equalToConstant: 660" in source:
+    raise SystemExit("recovery buttons must hug their content instead of stretching")
 
 launch_start = source.find("func applicationDidFinishLaunching(")
 launch_end = source.find("func application(_ application:", launch_start)
@@ -686,10 +731,10 @@ prepare_runtime = preparation_method.find(
 )
 native_case = preparation_method.find("case .nativeRuntimeReady:", prepare_runtime)
 webview_after_verify = preparation_method.find("self.presentControlCenter()", native_case)
-legacy_case = preparation_method.find("case .legacyRuntimeRestored:", native_case)
+failure_case = preparation_method.find("case .failure(let failure):", native_case)
 if not (
     0 <= status_start < preflight_call < preparation_task < prepare_runtime
-    < native_case < webview_after_verify < legacy_case
+    < native_case < webview_after_verify < failure_case
 ):
     raise SystemExit(
         "native app must keep the WebView closed until app, runtime, and listener verification succeeds"
@@ -744,7 +789,7 @@ if "loadControlCenter(cachePolicy: .reloadIgnoringLocalCacheData)" not in create
         "native app must bypass stale Control Center HTML on the first verified WebView load"
     )
 
-registration = source.find("guard await ensureBundledRuntimeServiceRegistered()")
+registration = source.find("switch await ensureBundledRuntimeServiceRegistered()")
 stop_legacy = source.find("if !stopLegacyLaunchAgents(legacyStates)")
 health_gate = source.find("var health = await waitForHealthyRuntime")
 legacy_app_migration = source.find(


### PR DESCRIPTION
## Summary
- replace the generic native installation failure with cause-specific recovery screens
- handle background approval, service startup, update mismatch, incomplete bundle, and legacy migration recovery
- keep all recovery actions in the existing native status view and match shadcn default button sizing
- add a local-preview-only state switch for deterministic macOS QA

## Root cause
The runtime preparation pipeline collapsed distinct failures into one generic “Installation could not be verified” screen. Customers could not tell whether they needed to approve a background item, restart the service, finish an update, redownload the app, or repair a legacy installation.

## Customer impact
Customers now get a specific explanation and the smallest relevant recovery action. `SMAppService.Status.requiresApproval` opens Login Items & Extensions directly.

## Validation
- `./scripts/test-macos-control-center-app-bundle.sh`
- `git diff --check`
- Quick Preview: all five recovery states rendered on macOS
- macOS accessibility integration checks for Login Items, retry/repair transitions, app restart, update handler, report save panel, and support log
- download destination and Sparkle appcast returned HTTP 200

Closes #244