### PR TITLE
Fix known Wi-Fi retry while setup portal remains available

### DIFF
--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -2774,15 +2774,16 @@ void loop() {
     markFrameAccepted(event, "usb");
   }
 
+  if (httpServerStarted) {
+    webServer.handleClient();
+  }
+  handleRawOtaClient();
   maintainWifiConnection();
   if (!otaUploadInProgress) {
     maintainFirmwareUpdateNotice();
   }
 
   if (otaUploadInProgress || assetUploadInProgress) {
-    if (httpServerStarted) {
-      webServer.handleClient();
-    }
     delay(1);
     return;
   }
@@ -2889,10 +2890,6 @@ void loop() {
   (void)renderDurationUs;
 #endif
 
-  if (httpServerStarted) {
-    webServer.handleClient();
-  }
-  handleRawOtaClient();
   if (captiveDnsStarted) {
     dnsServer.processNextRequest();
   }

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -15,6 +15,7 @@
 #include "wifi_security_policy.h"
 #include "gif_asset_validator_file.h"
 #include "renderer_esp8266.h"
+#include "wifi_recovery_policy.h"
 #include "wifi_setup_portal.h"
 
 #ifndef CODEXBAR_DISPLAY_BOARD_ID
@@ -188,6 +189,9 @@ File assetUploadFile;
 String activeThemeSpecPath;
 String activeThemeSpecHash;
 codexbar_display::esp8266::wifi_setup::State setupWifiState;
+WifiCredentials savedWifiCredentials;
+bool savedWifiCredentialsAvailable = false;
+codexbar_display::esp8266::wifi_recovery::State wifiSetupRecoveryState;
 bool rebootPending = false;
 unsigned long rebootAtMs = 0;
 unsigned long lastFrameAcceptedAtMs = 0;
@@ -209,6 +213,8 @@ String bootResetReasonJSON;
 uint32_t bootResetCounter = 0;
 
 void addCorsHeaders();
+void resetWifiReconnectState();
+void startHttpServer();
 
 #if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
 constexpr const char* kDefaultThemeSpecPath = "/themes/u/mini-cl-1-e4fe6b.json";
@@ -685,6 +691,59 @@ void drawUpdateStatus(const String& line2) {
 
 bool statusScreenLocked() {
   return otaUploadInProgress || rebootPending;
+}
+
+bool wifiSetupRecoveryBusy() {
+  return statusScreenLocked() || assetUploadInProgress || setupWifiState.scanInProgress;
+}
+
+void finishWifiSetupRecovery() {
+  if (captiveDnsStarted) {
+    dnsServer.stop();
+    captiveDnsStarted = false;
+    Serial.println("captive_dns_stopped reason=wifi_reconnected");
+  }
+  WiFi.softAPdisconnect(true);
+  WiFi.mode(WIFI_STA);
+  setupMode = false;
+  resetWifiReconnectState();
+  startHttpServer();
+  drawWaitingForCompanionStatus();
+  Serial.printf("wifi_setup_retry_connected ip=%s\n", WiFi.localIP().toString().c_str());
+}
+
+void maintainWifiSetupRecovery() {
+  const unsigned long nowMs = millis();
+  codexbar_display::esp8266::wifi_recovery::Inputs inputs;
+  inputs.nowMs = static_cast<uint32_t>(nowMs);
+  inputs.setupMode = setupMode;
+  inputs.credentialsAvailable = savedWifiCredentialsAvailable;
+  inputs.busy = wifiSetupRecoveryBusy();
+  inputs.connected = WiFi.status() == WL_CONNECTED;
+
+  const codexbar_display::esp8266::wifi_recovery::Action action =
+      codexbar_display::esp8266::wifi_recovery::Tick(wifiSetupRecoveryState, inputs);
+  switch (action) {
+    case codexbar_display::esp8266::wifi_recovery::Action::StartAttempt:
+      WiFi.mode(WIFI_AP_STA);
+      WiFi.begin(savedWifiCredentials.ssid, savedWifiCredentials.password);
+      Serial.printf("wifi_setup_retry_started ssid=%s\n", savedWifiCredentials.ssid);
+      break;
+    case codexbar_display::esp8266::wifi_recovery::Action::Timeout:
+      WiFi.disconnect(false);
+      WiFi.mode(WIFI_AP_STA);
+      WiFi.softAP(kSetupApSsid);
+      Serial.printf("wifi_setup_retry_failed status=%d next_retry_ms=%lu\n",
+                    static_cast<int>(WiFi.status()),
+                    static_cast<unsigned long>(
+                        codexbar_display::esp8266::wifi_recovery::kRetryIntervalMs));
+      break;
+    case codexbar_display::esp8266::wifi_recovery::Action::Connected:
+      finishWifiSetupRecovery();
+      break;
+    case codexbar_display::esp8266::wifi_recovery::Action::None:
+      break;
+  }
 }
 
 void resetWifiReconnectState() {
@@ -2523,10 +2582,13 @@ void startHttpServer() {
 void startSetupAccessPoint() {
   setupMode = true;
   resetWifiReconnectState();
+  codexbar_display::esp8266::wifi_recovery::EnterSetup(
+      wifiSetupRecoveryState,
+      static_cast<uint32_t>(millis()));
   codexbar_display::esp8266::wifi_setup::ClearConnectionError(setupWifiState);
   WiFi.setAutoReconnect(false);
   WiFi.disconnect(false);
-  WiFi.mode(WIFI_AP);
+  WiFi.mode(WIFI_AP_STA);
   WiFi.softAP(kSetupApSsid);
   Serial.printf("wifi_setup_ap ssid=VibeTV-Setup ip=%s\n", WiFi.softAPIP().toString().c_str());
   dnsServer.start(kDnsPort, "*", WiFi.softAPIP());
@@ -2540,7 +2602,11 @@ void startSetupAccessPoint() {
 }
 
 void maintainWifiConnection() {
-  if (setupMode || rebootPending) {
+  if (setupMode) {
+    maintainWifiSetupRecovery();
+    return;
+  }
+  if (rebootPending) {
     return;
   }
   if (WiFi.status() == WL_CONNECTED) {
@@ -2668,16 +2734,20 @@ void setup() {
 #endif
 
   bool wifiConnected = false;
-  WifiCredentials creds;
-  const bool hasSavedWifi = readWifiCredentials(creds);
+  const bool hasSavedWifi = readWifiCredentials(savedWifiCredentials);
+  savedWifiCredentialsAvailable = hasSavedWifi;
   if (hasSavedWifi) {
-    wifiConnected = connectToSavedWifi(creds);
+    wifiConnected = connectToSavedWifi(savedWifiCredentials);
   }
 
   // SDK credentials are a one-time legacy import only. Never let stale SDK
   // credentials replace a failed explicit VibeTV Wi-Fi configuration.
   if (!wifiConnected && !hasSavedWifi) {
     wifiConnected = connectToSdkWifiConfig();
+  }
+
+  if (wifiConnected && !hasSavedWifi) {
+    savedWifiCredentialsAvailable = readWifiCredentials(savedWifiCredentials);
   }
 
   if (wifiConnected) {

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -1667,6 +1667,12 @@ void handleAssetUpload() {
   HTTPUpload& upload = webServer.upload();
 
   if (upload.status == UPLOAD_FILE_START) {
+    if (otaUploadInProgress || assetUploadInProgress || rebootPending) {
+      assetUploadSucceeded = false;
+      assetUploadInProgress = true;
+      assetUploadError = "another upload is active";
+      return;
+    }
     assetUploadSucceeded = false;
     assetUploadInProgress = true;
     assetUploadError = "";
@@ -2148,6 +2154,13 @@ void handleOtaUpload(int command, const char* target) {
   HTTPUpload& upload = webServer.upload();
 
   if (upload.status == UPLOAD_FILE_START) {
+    if (assetUploadInProgress || otaUploadInProgress || rebootPending) {
+      otaUploadSucceeded = false;
+      otaUploadInProgress = true;
+      otaUploadNeedsReboot = false;
+      otaUploadError = "another upload is active";
+      return;
+    }
     otaUploadSucceeded = false;
     otaUploadInProgress = true;
     otaUploadNeedsReboot = false;
@@ -2308,7 +2321,7 @@ String rawRequestToken(const String& line) {
 }
 
 void handleRawOtaClient() {
-  if (!rawOtaServerStarted || otaUploadInProgress || rebootPending) {
+  if (!rawOtaServerStarted || otaUploadInProgress || assetUploadInProgress || rebootPending) {
     return;
   }
 

--- a/firmware_esp8266/src/wifi_recovery_policy.h
+++ b/firmware_esp8266/src/wifi_recovery_policy.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cstdint>
+
+namespace codexbar_display {
+namespace esp8266 {
+namespace wifi_recovery {
+
+constexpr uint32_t kRetryIntervalMs = 120000UL;
+constexpr uint32_t kAttemptTimeoutMs = 20000UL;
+
+enum class Action : uint8_t {
+  None,
+  StartAttempt,
+  Timeout,
+  Connected,
+};
+
+struct State {
+  bool attemptInProgress = false;
+  bool retryScheduled = false;
+  uint32_t attemptStartedAtMs = 0;
+  uint32_t retryDueAtMs = 0;
+};
+
+struct Inputs {
+  uint32_t nowMs = 0;
+  bool setupMode = false;
+  bool credentialsAvailable = false;
+  bool busy = false;
+  bool connected = false;
+};
+
+inline uint32_t elapsedMs(uint32_t nowMs, uint32_t startedAtMs) {
+  return nowMs - startedAtMs;
+}
+
+inline void EnterSetup(State& state, uint32_t nowMs) {
+  state = {};
+  state.retryScheduled = true;
+  state.retryDueAtMs = nowMs + kRetryIntervalMs;
+}
+
+inline Action Tick(State& state, const Inputs& inputs) {
+  if (!inputs.setupMode) {
+    state = {};
+    return Action::None;
+  }
+
+  if (inputs.busy) {
+    return Action::None;
+  }
+
+  if (inputs.connected) {
+    state = {};
+    return Action::Connected;
+  }
+
+  if (state.attemptInProgress) {
+    if (elapsedMs(inputs.nowMs, state.attemptStartedAtMs) < kAttemptTimeoutMs) {
+      return Action::None;
+    }
+    state.attemptInProgress = false;
+    state.retryScheduled = true;
+    state.retryDueAtMs = inputs.nowMs + kRetryIntervalMs;
+    return Action::Timeout;
+  }
+
+  if (!inputs.credentialsAvailable) {
+    return Action::None;
+  }
+
+  if (state.retryScheduled && elapsedMs(inputs.nowMs, state.retryDueAtMs) >= 0x80000000UL) {
+    return Action::None;
+  }
+
+  state.attemptInProgress = true;
+  state.retryScheduled = false;
+  state.attemptStartedAtMs = inputs.nowMs;
+  return Action::StartAttempt;
+}
+
+}  // namespace wifi_recovery
+}  // namespace esp8266
+}  // namespace codexbar_display

--- a/firmware_esp8266/src/wifi_recovery_policy.h
+++ b/firmware_esp8266/src/wifi_recovery_policy.h
@@ -6,7 +6,7 @@ namespace codexbar_display {
 namespace esp8266 {
 namespace wifi_recovery {
 
-constexpr uint32_t kRetryIntervalMs = 120000UL;
+constexpr uint32_t kRetryIntervalMs = 5000UL;
 constexpr uint32_t kAttemptTimeoutMs = 20000UL;
 
 enum class Action : uint8_t {

--- a/firmware_esp8266/test/test_native_wifi_setup/test_wifi_setup_portal.cpp
+++ b/firmware_esp8266/test/test_native_wifi_setup/test_wifi_setup_portal.cpp
@@ -4,13 +4,29 @@
 #include <cstdlib>
 
 #include "../../src/wifi_setup_portal.cpp"
+#include "../../src/wifi_recovery_policy.h"
 
 namespace {
 
 using namespace codexbar_display::esp8266::wifi_setup;
+namespace wifi_recovery = codexbar_display::esp8266::wifi_recovery;
 
 bool contains(const String& haystack, const char* needle) {
   return haystack.find(needle) != String::npos;
+}
+
+wifi_recovery::Inputs recoveryInputs(
+    uint32_t nowMs,
+    bool credentialsAvailable = true,
+    bool busy = false,
+    bool connected = false) {
+  wifi_recovery::Inputs inputs;
+  inputs.nowMs = nowMs;
+  inputs.setupMode = true;
+  inputs.credentialsAvailable = credentialsAvailable;
+  inputs.busy = busy;
+  inputs.connected = connected;
+  return inputs;
 }
 
 void test_scan_filters_deduplicates_and_sorts() {
@@ -159,6 +175,117 @@ void test_clean_automatic_fallback_does_not_render_or_prefill_old_ssid() {
   TEST_ASSERT_TRUE(contains(fallbackServer.output, "Search again"));
 }
 
+void test_recovery_waits_120_seconds_before_starting_once() {
+  wifi_recovery::State state;
+  wifi_recovery::EnterSetup(state, 0);
+
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::None),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(119999))));
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::StartAttempt),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120000))));
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::None),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120001))));
+}
+
+void test_recovery_scheduling_handles_millis_wraparound() {
+  wifi_recovery::State state;
+  const uint32_t setupAtMs = 0xFFFFFF00UL;
+  wifi_recovery::EnterSetup(state, setupAtMs);
+
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::None),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(0x0001D3BFUL))));
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::StartAttempt),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(0x0001D3C0UL))));
+}
+
+void test_recovery_does_not_retry_without_credentials() {
+  wifi_recovery::State state;
+  wifi_recovery::EnterSetup(state, 0);
+
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::None),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(0xFFFFFFFFUL, false))));
+  TEST_ASSERT_FALSE(state.attemptInProgress);
+}
+
+void test_recovery_busy_gate_defers_attempt() {
+  wifi_recovery::State state;
+  wifi_recovery::EnterSetup(state, 0);
+
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::None),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120000, true, true))));
+  TEST_ASSERT_FALSE(state.attemptInProgress);
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::StartAttempt),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120001))));
+}
+
+void test_recovery_busy_gate_defers_connected_transition() {
+  wifi_recovery::State state;
+  wifi_recovery::EnterSetup(state, 0);
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::StartAttempt),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120000))));
+
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::None),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(125000, true, true, true))));
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::Connected),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(125001, true, false, true))));
+}
+
+void test_recovery_does_not_begin_again_while_attempt_is_running() {
+  wifi_recovery::State state;
+  wifi_recovery::EnterSetup(state, 0);
+
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::StartAttempt),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120000))));
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::None),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120001))));
+}
+
+void test_recovery_timeout_stays_in_setup_and_schedules_next_attempt() {
+  wifi_recovery::State state;
+  wifi_recovery::EnterSetup(state, 0);
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::StartAttempt),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120000))));
+
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::Timeout),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(140000))));
+  TEST_ASSERT_FALSE(state.attemptInProgress);
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::None),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(140001))));
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::StartAttempt),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(260000))));
+}
+
+void test_recovery_connected_later_leaves_setup_state() {
+  wifi_recovery::State state;
+  wifi_recovery::EnterSetup(state, 0);
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::StartAttempt),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120000))));
+
+  TEST_ASSERT_EQUAL_INT(
+      static_cast<int>(wifi_recovery::Action::Connected),
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(125000, true, false, true))));
+  TEST_ASSERT_FALSE(state.attemptInProgress);
+  TEST_ASSERT_FALSE(state.retryScheduled);
+}
+
 }  // namespace
 
 void setUp() {}
@@ -187,5 +314,13 @@ int main(int, char**) {
   RUN_TEST(test_page_publishes_no_placeholder_without_support_url);
   RUN_TEST(test_automatic_setup_ap_renders_normal_writable_setup_page);
   RUN_TEST(test_clean_automatic_fallback_does_not_render_or_prefill_old_ssid);
+  RUN_TEST(test_recovery_waits_120_seconds_before_starting_once);
+  RUN_TEST(test_recovery_scheduling_handles_millis_wraparound);
+  RUN_TEST(test_recovery_does_not_retry_without_credentials);
+  RUN_TEST(test_recovery_busy_gate_defers_attempt);
+  RUN_TEST(test_recovery_busy_gate_defers_connected_transition);
+  RUN_TEST(test_recovery_does_not_begin_again_while_attempt_is_running);
+  RUN_TEST(test_recovery_timeout_stays_in_setup_and_schedules_next_attempt);
+  RUN_TEST(test_recovery_connected_later_leaves_setup_state);
   return UNITY_END();
 }

--- a/firmware_esp8266/test/test_native_wifi_setup/test_wifi_setup_portal.cpp
+++ b/firmware_esp8266/test/test_native_wifi_setup/test_wifi_setup_portal.cpp
@@ -175,19 +175,19 @@ void test_clean_automatic_fallback_does_not_render_or_prefill_old_ssid() {
   TEST_ASSERT_TRUE(contains(fallbackServer.output, "Search again"));
 }
 
-void test_recovery_waits_120_seconds_before_starting_once() {
+void test_recovery_waits_5_seconds_before_starting_once() {
   wifi_recovery::State state;
   wifi_recovery::EnterSetup(state, 0);
 
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::None),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(119999))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(4999))));
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::StartAttempt),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120000))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(5000))));
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::None),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120001))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(5001))));
 }
 
 void test_recovery_scheduling_handles_millis_wraparound() {
@@ -197,10 +197,10 @@ void test_recovery_scheduling_handles_millis_wraparound() {
 
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::None),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(0x0001D3BFUL))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(0x00001287UL))));
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::StartAttempt),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(0x0001D3C0UL))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(0x00001288UL))));
 }
 
 void test_recovery_does_not_retry_without_credentials() {
@@ -219,11 +219,11 @@ void test_recovery_busy_gate_defers_attempt() {
 
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::None),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120000, true, true))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(5000, true, true))));
   TEST_ASSERT_FALSE(state.attemptInProgress);
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::StartAttempt),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120001))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(5001))));
 }
 
 void test_recovery_busy_gate_defers_connected_transition() {
@@ -231,7 +231,7 @@ void test_recovery_busy_gate_defers_connected_transition() {
   wifi_recovery::EnterSetup(state, 0);
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::StartAttempt),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120000))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(5000))));
 
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::None),
@@ -247,10 +247,10 @@ void test_recovery_does_not_begin_again_while_attempt_is_running() {
 
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::StartAttempt),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120000))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(5000))));
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::None),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120001))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(5001))));
 }
 
 void test_recovery_timeout_stays_in_setup_and_schedules_next_attempt() {
@@ -258,18 +258,18 @@ void test_recovery_timeout_stays_in_setup_and_schedules_next_attempt() {
   wifi_recovery::EnterSetup(state, 0);
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::StartAttempt),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120000))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(5000))));
 
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::Timeout),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(140000))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(25000))));
   TEST_ASSERT_FALSE(state.attemptInProgress);
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::None),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(140001))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(25001))));
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::StartAttempt),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(260000))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(30000))));
 }
 
 void test_recovery_connected_later_leaves_setup_state() {
@@ -277,11 +277,11 @@ void test_recovery_connected_later_leaves_setup_state() {
   wifi_recovery::EnterSetup(state, 0);
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::StartAttempt),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(120000))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(5000))));
 
   TEST_ASSERT_EQUAL_INT(
       static_cast<int>(wifi_recovery::Action::Connected),
-      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(125000, true, false, true))));
+      static_cast<int>(wifi_recovery::Tick(state, recoveryInputs(10000, true, false, true))));
   TEST_ASSERT_FALSE(state.attemptInProgress);
   TEST_ASSERT_FALSE(state.retryScheduled);
 }
@@ -314,7 +314,7 @@ int main(int, char**) {
   RUN_TEST(test_page_publishes_no_placeholder_without_support_url);
   RUN_TEST(test_automatic_setup_ap_renders_normal_writable_setup_page);
   RUN_TEST(test_clean_automatic_fallback_does_not_render_or_prefill_old_ssid);
-  RUN_TEST(test_recovery_waits_120_seconds_before_starting_once);
+  RUN_TEST(test_recovery_waits_5_seconds_before_starting_once);
   RUN_TEST(test_recovery_scheduling_handles_millis_wraparound);
   RUN_TEST(test_recovery_does_not_retry_without_credentials);
   RUN_TEST(test_recovery_busy_gate_defers_attempt);

--- a/firmware_esp8266/tests/gif_core_policy_test.cpp
+++ b/firmware_esp8266/tests/gif_core_policy_test.cpp
@@ -29,6 +29,17 @@ bool expect(bool cond, const char* message) {
   return true;
 }
 
+std::size_t countOccurrences(const std::string& value, const char* needle) {
+  std::size_t count = 0;
+  std::size_t offset = 0;
+  const std::string target(needle);
+  while ((offset = value.find(target, offset)) != std::string::npos) {
+    ++count;
+    offset += target.size();
+  }
+  return count;
+}
+
 bool testBackoffThresholdAndExpiry() {
   GifFailureGuardState guard;
 
@@ -274,16 +285,79 @@ bool testSetupPortalIsReadyBeforeJoinInstructions(const char* mainPath) {
   const std::size_t clearError = body.find("ClearConnectionError(setupWifiState)");
   const std::size_t stopReconnect = body.find("WiFi.setAutoReconnect(false)");
   const std::size_t disconnect = body.find("WiFi.disconnect(false)");
-  const std::size_t apOnly = body.find("WiFi.mode(WIFI_AP)");
+  const std::size_t apSta = body.find("WiFi.mode(WIFI_AP_STA)");
   const std::size_t accessPoint = body.find("WiFi.softAP(kSetupApSsid)");
   const std::size_t dns = body.find("dnsServer.start(");
   const std::size_t http = body.find("startHttpServer()");
   const std::size_t joinInstructions = body.find("renderer.DrawSetupInstructions(");
   return expect(
-      clearError < stopReconnect && stopReconnect < disconnect && disconnect < apOnly &&
-          apOnly < accessPoint && accessPoint < dns && dns < http &&
-          http < joinInstructions && body.find("scanSetupNetworks()") == std::string::npos,
-      "setup display may invite joining only after the old STA attempt is stopped and AP, DNS, and HTTP are ready");
+      clearError < stopReconnect && stopReconnect < disconnect && disconnect < apSta &&
+          apSta < accessPoint && accessPoint < dns && dns < http &&
+          http < joinInstructions && body.find("WiFi.mode(WIFI_AP)") == std::string::npos &&
+          body.find("scanSetupNetworks()") == std::string::npos,
+      "setup display may invite joining only after the old STA attempt is stopped and AP_STA, DNS, and HTTP are ready");
+}
+
+bool testNetworkWorkPrecedesWifiRecovery(const char* mainPath) {
+  const std::string mainSource = readFile(mainPath);
+  const std::size_t loopStart = mainSource.find("void loop()");
+  if (!expect(loopStart != std::string::npos, "firmware loop must remain discoverable")) {
+    return false;
+  }
+  const std::string loop = mainSource.substr(loopStart);
+  const std::size_t http = loop.find("webServer.handleClient();");
+  const std::size_t rawOta = loop.find("handleRawOtaClient();");
+  const std::size_t recovery = loop.find("maintainWifiConnection();");
+  return expect(
+      http != std::string::npos && rawOta != std::string::npos && recovery != std::string::npos &&
+          http < recovery && rawOta < recovery && countOccurrences(loop, "webServer.handleClient();") == 1 &&
+          countOccurrences(loop, "handleRawOtaClient();") == 1,
+      "setup HTTP and raw OTA work must run once before WiFi recovery decides busy state");
+}
+
+bool testWifiRecoveryFirmwareWiring(const char* mainPath) {
+  const std::string mainSource = readFile(mainPath);
+  const std::size_t recoveryStart = mainSource.find("void maintainWifiSetupRecovery()");
+  const std::size_t recoveryEnd = mainSource.find("void resetWifiReconnectState()", recoveryStart);
+  const std::size_t finishStart = mainSource.find("void finishWifiSetupRecovery()");
+  const std::size_t finishEnd = mainSource.find("void maintainWifiSetupRecovery()", finishStart);
+  if (!expect(
+          recoveryStart != std::string::npos && recoveryEnd != std::string::npos &&
+              finishStart != std::string::npos && finishEnd != std::string::npos,
+          "WiFi setup recovery functions must remain discoverable")) {
+    return false;
+  }
+
+  const std::string recovery = mainSource.substr(recoveryStart, recoveryEnd - recoveryStart);
+  const std::string finish = mainSource.substr(finishStart, finishEnd - finishStart);
+  const std::size_t timeout = recovery.find("case codexbar_display::esp8266::wifi_recovery::Action::Timeout:");
+  const std::size_t timeoutDisconnect = recovery.find("WiFi.disconnect(false);", timeout);
+  const std::size_t timeoutApSta = recovery.find("WiFi.mode(WIFI_AP_STA);", timeoutDisconnect);
+  const std::size_t timeoutAp = recovery.find("WiFi.softAP(kSetupApSsid);", timeoutApSta);
+  const std::size_t connected = recovery.find("case codexbar_display::esp8266::wifi_recovery::Action::Connected:");
+  if (!expect(
+          timeout != std::string::npos && connected != std::string::npos && timeout < connected,
+          "setup recovery must keep distinct timeout and connected branches")) {
+    return false;
+  }
+  const std::string timeoutBlock = recovery.substr(timeout, connected - timeout);
+  const std::size_t dnsStop = finish.find("dnsServer.stop();");
+  const std::size_t apDisconnect = finish.find("WiFi.softAPdisconnect(true);");
+  const std::size_t sta = finish.find("WiFi.mode(WIFI_STA);");
+  const std::size_t leaveSetup = finish.find("setupMode = false;");
+  const std::size_t reset = finish.find("resetWifiReconnectState();");
+  const std::size_t server = finish.find("startHttpServer();");
+  const std::size_t connectedScreen = finish.find("drawWaitingForCompanionStatus();");
+  return expect(
+      countOccurrences(recovery, "WiFi.begin(") == 1 && timeout != std::string::npos &&
+          timeoutDisconnect != std::string::npos && timeoutApSta != std::string::npos &&
+          timeoutAp != std::string::npos && timeout < timeoutDisconnect && timeoutDisconnect < timeoutApSta &&
+          timeoutApSta < timeoutAp && timeoutBlock.find("finishWifiSetupRecovery()") == std::string::npos &&
+          recovery.find("finishWifiSetupRecovery();", connected) != std::string::npos &&
+          recovery.find("inputs.busy = wifiSetupRecoveryBusy();") != std::string::npos && dnsStop < apDisconnect &&
+          apDisconnect < sta && sta < leaveSetup && leaveSetup < reset && reset < server &&
+          server < connectedScreen,
+      "setup recovery must begin once, keep timeout in AP_STA, and leave DNS/AP/setup mode only after connection");
 }
 
 bool testCaptiveFirstResponseNeverBlocksOnWifiScan(const char* mainPath) {
@@ -855,6 +929,12 @@ int main(int argc, char** argv) {
     return 1;
   }
   if (!testSetupPortalIsReadyBeforeJoinInstructions(argv[3])) {
+    return 1;
+  }
+  if (!testNetworkWorkPrecedesWifiRecovery(argv[3])) {
+    return 1;
+  }
+  if (!testWifiRecoveryFirmwareWiring(argv[3])) {
     return 1;
   }
   if (!testCaptiveFirstResponseNeverBlocksOnWifiScan(argv[3])) {

--- a/firmware_esp8266/tests/gif_core_policy_test.cpp
+++ b/firmware_esp8266/tests/gif_core_policy_test.cpp
@@ -360,6 +360,42 @@ bool testWifiRecoveryFirmwareWiring(const char* mainPath) {
       "setup recovery must begin once, keep timeout in AP_STA, and leave DNS/AP/setup mode only after connection");
 }
 
+bool testUploadMutualExclusionPolicy(const char* mainPath) {
+  const std::string mainSource = readFile(mainPath);
+  const std::size_t rawStart = mainSource.find("void handleRawOtaClient()");
+  const std::size_t rawAccept = mainSource.find("WiFiClient client = rawOtaServer.accept();", rawStart);
+  const std::size_t assetStart = mainSource.find("void handleAssetUpload()");
+  const std::size_t assetEnd = mainSource.find("void handleAssetUploadResult()", assetStart);
+  const std::size_t otaStart = mainSource.find("void handleOtaUpload(int command, const char* target)");
+  const std::size_t otaEnd = mainSource.find("void scheduleReboot(", otaStart);
+  if (!expect(
+          rawStart != std::string::npos && rawAccept != std::string::npos && assetStart != std::string::npos &&
+              assetEnd != std::string::npos && otaStart != std::string::npos && otaEnd != std::string::npos,
+          "all upload handlers must remain discoverable")) {
+    return false;
+  }
+
+  const std::string rawGuard = mainSource.substr(rawStart, rawAccept - rawStart);
+  const std::string assetHandler = mainSource.substr(assetStart, assetEnd - assetStart);
+  const std::string otaHandler = mainSource.substr(otaStart, otaEnd - otaStart);
+  const std::size_t assetStartEvent = assetHandler.find("if (upload.status == UPLOAD_FILE_START)");
+  const std::size_t assetBusy =
+      assetHandler.find("if (otaUploadInProgress || assetUploadInProgress || rebootPending)", assetStartEvent);
+  const std::size_t assetSafeMode = assetHandler.find("enterAssetUploadSafeMode()", assetStartEvent);
+  const std::size_t otaStartEvent = otaHandler.find("if (upload.status == UPLOAD_FILE_START)");
+  const std::size_t otaBusy =
+      otaHandler.find("if (assetUploadInProgress || otaUploadInProgress || rebootPending)", otaStartEvent);
+  const std::size_t otaSafeMode = otaHandler.find("enterOtaSafeMode(", otaStartEvent);
+  return expect(
+      rawGuard.find("assetUploadInProgress") != std::string::npos &&
+          rawGuard.find("otaUploadInProgress") != std::string::npos &&
+          rawGuard.find("rebootPending") != std::string::npos && assetStartEvent != std::string::npos &&
+          assetBusy != std::string::npos && assetSafeMode != std::string::npos && assetBusy < assetSafeMode &&
+          otaStartEvent != std::string::npos && otaBusy != std::string::npos && otaSafeMode != std::string::npos &&
+          otaBusy < otaSafeMode,
+      "raw OTA and HTTP asset/filesystem/firmware uploads must exclude each other before safe mode");
+}
+
 bool testCaptiveFirstResponseNeverBlocksOnWifiScan(const char* mainPath) {
   const std::string mainSource = readFile(mainPath);
   const std::size_t rootStart = mainSource.find("void handleRoot()");
@@ -935,6 +971,9 @@ int main(int argc, char** argv) {
     return 1;
   }
   if (!testWifiRecoveryFirmwareWiring(argv[3])) {
+    return 1;
+  }
+  if (!testUploadMutualExclusionPolicy(argv[3])) {
     return 1;
   }
   if (!testCaptiveFirstResponseNeverBlocksOnWifiScan(argv[3])) {


### PR DESCRIPTION
## Root cause

`maintainWifiConnection()` returned immediately while `setupMode` was active. After a failed boot-time connection, the setup AP and portal stayed available, but the firmware never retried the saved network.

## Change

- Added a small overflow-safe, non-blocking setup Wi-Fi recovery state machine.
- Retries valid saved credentials after 5 seconds, monitors one `WiFi.begin()` attempt for up to 20 seconds, and defers retries while scans, uploads, OTA, reboot, or other locked states are active.
- Does not retry during first-time setup without saved credentials.
- Keeps `WIFI_AP_STA`, the setup AP, captive DNS, and HTTP portal available during recovery. On success it stops DNS, disables the setup AP, switches to `WIFI_STA`, leaves setup mode, and resumes the existing connected flow without rebooting.
- Added targeted regression tests for five-second scheduling, credentials, busy gates, single attempts, timeout, wraparound, and late success.
- Corrected the loop race by processing HTTP setup/upload and raw OTA work exactly once before Wi-Fi recovery evaluates busy state.
- Updated the AP readiness guard to require the old STA attempt to be stopped and `WIFI_AP_STA`, AP, DNS, and HTTP readiness before setup instructions; added source-policy coverage for the actual firmware wiring and recovery transitions.
- Added mutual upload exclusion so Raw-OTA cannot enter OTA safe mode during an asset upload, and HTTP asset/firmware/filesystem uploads cannot enter their safe mode during another upload or pending reboot.

## Validation

- `pio test -d firmware_esp8266 -e native_wifi_setup`: 16/16 passed
- `pio test -d firmware_esp8266 -e native_theme_spec_renderer`: 57/57 passed
- `./scripts/check-esp8266-soak-gate.sh`: passed (GIF/frame policy and companion daemon resilience)
- Upload mutual-exclusion source policy: passed via `check-esp8266-soak-gate.sh`
- `pio run -d firmware_esp8266 -e esp8266_smalltv_st7789`: success; RAM 52.3%, Flash 44.6%
- Firmware size budget: passed; 469856/482000 bytes, gzip 333227/350000 bytes
- Physical validation passed on VibeTV `5863327`: exact candidate firmware was flashed, setup mode stayed available without usable Wi-Fi, and the device automatically reconnected after being returned to usable Wi-Fi coverage.
- First-time setup remains protected: without saved credentials no automatic retry starts; scans defer retry attempts and saving new Wi-Fi credentials restarts the normal setup flow.
- `./scripts/validate_repo_layout.sh`: unavailable in `origin/main` (`No such file or directory`)

## Scope

No merge, release, tag, or production deployment was performed.
