### PR TITLE
CODEX: add Virtual VibeTV core for issue #177

### DIFF
--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -71,6 +71,7 @@ var (
 	flashReleaseFirmwareImageFn                        = flashReleaseFirmwareImage
 	uploadFirmwareOTAFn                                = uploadFirmwareOTA
 	firmwareRawDialContextFn                           = dialFirmwareRawConnection
+	firmwareRawOTAPort                                 = "8081"
 	firmwareHTTPVerifyPollInterval                     = 2 * time.Second
 	firmwareHTTPVerifyProbeTimeout                     = 2 * time.Second
 	firmwareUpdateRediscoveryAfter                     = 10 * time.Second
@@ -779,6 +780,11 @@ func discoverInstallUpdateTarget(ctx context.Context, home, base, deviceID strin
 	})
 	if err != nil {
 		return "", err
+	}
+	expectedDeviceID := strings.TrimSpace(deviceID)
+	discoveredDeviceID := strings.TrimSpace(result.Hello.DeviceID)
+	if expectedDeviceID != "" && discoveredDeviceID != "" && !strings.EqualFold(discoveredDeviceID, expectedDeviceID) {
+		return "", fmt.Errorf("rediscovered deviceId %q does not match original deviceId %q", discoveredDeviceID, expectedDeviceID)
 	}
 	target, err := normalizeHTTPBaseURL(result.Target)
 	if err != nil {
@@ -1697,7 +1703,11 @@ func rawFirmwareEndpoint(base string) (string, error) {
 	if host == "" {
 		return "", fmt.Errorf("target host is required")
 	}
-	parsed.Host = host + ":8081"
+	port := strings.TrimSpace(firmwareRawOTAPort)
+	if port == "" {
+		port = "8081"
+	}
+	parsed.Host = net.JoinHostPort(host, port)
 	parsed.Path = "/update/firmware.raw"
 	parsed.RawQuery = ""
 	parsed.Fragment = ""

--- a/companion/cmd/codexbar-display/virtual_vibetv_test.go
+++ b/companion/cmd/codexbar-display/virtual_vibetv_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
+	transportlayer "github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/transport"
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/virtualvibetv"
+)
+
+func TestRunInstallUpdateUsesDedicatedRawOTAAndDoesNotFlashAlreadyCurrentDevice(t *testing.T) {
+	previousClient, previousPoll, previousPort := releaseHTTPClient, firmwareHTTPVerifyPollInterval, firmwareRawOTAPort
+	t.Cleanup(func() {
+		releaseHTTPClient, firmwareHTTPVerifyPollInterval, firmwareRawOTAPort = previousClient, previousPoll, previousPort
+	})
+	t.Setenv("HOME", t.TempDir())
+	firmwareHTTPVerifyPollInterval = time.Millisecond
+
+	image := []byte("virtual raw OTA candidate")
+	cfg := virtualvibetv.DefaultConfig()
+	cfg.HTTPListenAddr, cfg.RawOTAListenAddr = "127.0.0.1:0", "127.0.0.1:0"
+	cfg.RebootUnavailableRequests = 0
+	sum := sha256.Sum256(image)
+	cfg.ExpectedFirmwareSHA256 = hex.EncodeToString(sum[:])
+	device, err := virtualvibetv.Start(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = device.Close() })
+
+	rawURL, err := url.Parse(device.RawOTAURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firmwareRawOTAPort = rawURL.Port()
+	manifestURL := virtualFirmwareManifestServer(t, image)
+	releaseHTTPClient = &http.Client{Timeout: time.Second}
+	args := []string{"--target", device.HTTPURL, "--manifest-url", manifestURL, "--skip-launchagent-pause"}
+	if _, err := captureStdout(t, func() error { return runInstallUpdate(args) }); err != nil {
+		t.Fatalf("install through raw OTA listener: %v", err)
+	}
+	output, err := captureStdout(t, func() error { return runInstallUpdate(args) })
+	if err != nil {
+		t.Fatalf("already-current update: %v", err)
+	}
+	if !strings.Contains(output, "Firmware: already current (1.0.1)") {
+		t.Fatalf("missing already-current output: %s", output)
+	}
+	state := device.Snapshot()
+	if state.UpdateUploads != 1 || len(state.Violations) != 0 {
+		t.Fatalf("OTA was repeated or not raw: %+v", state)
+	}
+	if !hasEvent(state.Events, "/update/firmware.raw") {
+		t.Fatalf("raw OTA listener was not exercised: %+v", state.Events)
+	}
+}
+
+func TestRunInstallUpdateAcceptsDroppedRawOTAResponseWithoutSecondFlash(t *testing.T) {
+	previousClient, previousPoll, previousPort, previousTimeout := releaseHTTPClient, firmwareHTTPVerifyPollInterval, firmwareRawOTAPort, firmwareInterruptedVerifyTimeout
+	t.Cleanup(func() {
+		releaseHTTPClient, firmwareHTTPVerifyPollInterval, firmwareRawOTAPort, firmwareInterruptedVerifyTimeout = previousClient, previousPoll, previousPort, previousTimeout
+	})
+	t.Setenv("HOME", t.TempDir())
+	firmwareHTTPVerifyPollInterval, firmwareInterruptedVerifyTimeout = time.Millisecond, 100*time.Millisecond
+
+	image := []byte("accepted raw OTA then disconnected")
+	cfg := virtualvibetv.DefaultConfig()
+	cfg.HTTPListenAddr, cfg.RawOTAListenAddr = "127.0.0.1:0", "127.0.0.1:0"
+	cfg.DropUpdateResponseAfterAccept, cfg.RebootUnavailableRequests = true, 0
+	sum := sha256.Sum256(image)
+	cfg.ExpectedFirmwareSHA256 = hex.EncodeToString(sum[:])
+	device, err := virtualvibetv.Start(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = device.Close() })
+	rawURL, err := url.Parse(device.RawOTAURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firmwareRawOTAPort = rawURL.Port()
+	releaseHTTPClient = &http.Client{Timeout: time.Second}
+
+	if _, err := captureStdout(t, func() error {
+		return runInstallUpdate([]string{"--target", device.HTTPURL, "--manifest-url", virtualFirmwareManifestServer(t, image), "--skip-launchagent-pause"})
+	}); err != nil {
+		t.Fatalf("accepted OTA response loss: %v", err)
+	}
+	if state := device.Snapshot(); state.UpdateUploads != 1 || len(state.Violations) != 0 {
+		t.Fatalf("ambiguous OTA was flashed twice: %+v", state)
+	}
+}
+
+func TestFirmwareRediscoveryRejectsDifferentVirtualDevice(t *testing.T) {
+	previousClient, previousPoll, previousAfter, previousInterval, previousDiscover := releaseHTTPClient, firmwareHTTPVerifyPollInterval, firmwareUpdateRediscoveryAfter, firmwareUpdateRediscoveryInterval, discoverWiFiDeviceFn
+	t.Cleanup(func() {
+		releaseHTTPClient, firmwareHTTPVerifyPollInterval, firmwareUpdateRediscoveryAfter, firmwareUpdateRediscoveryInterval, discoverWiFiDeviceFn = previousClient, previousPoll, previousAfter, previousInterval, previousDiscover
+	})
+	firmwareHTTPVerifyPollInterval, firmwareUpdateRediscoveryAfter, firmwareUpdateRediscoveryInterval = time.Millisecond, time.Millisecond, time.Millisecond
+	old := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(old.Close)
+	cfg := virtualvibetv.DefaultConfig()
+	cfg.HTTPListenAddr, cfg.RawOTAListenAddr = "127.0.0.1:0", "127.0.0.1:0"
+	cfg.DeviceID, cfg.Firmware = "wrong-device", cfg.CandidateFirmware
+	wrong, err := virtualvibetv.Start(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = wrong.Close() })
+	releaseHTTPClient = &http.Client{Timeout: time.Second}
+	discoverWiFiDeviceFn = func(context.Context, transportlayer.WiFiDiscoveryOptions) (transportlayer.WiFiDiscoveryResult, error) {
+		return transportlayer.WiFiDiscoveryResult{Target: wrong.HTTPURL, Hello: protocol.DeviceHello{DeviceID: cfg.DeviceID, Firmware: cfg.Firmware}}, nil
+	}
+	_, err = waitForHTTPFirmwareVersionWithDiscovery(context.Background(), t.TempDir(), old.URL, cfg.Firmware, "expected-device", 20*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "does not match original deviceId") {
+		t.Fatalf("wrong device was accepted: %v", err)
+	}
+}
+
+func virtualFirmwareManifestServer(t *testing.T, image []byte) string {
+	t.Helper()
+	sum := sha256.Sum256(image)
+	serverURL := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			_, _ = fmt.Fprintf(w, `{"schemaVersion":1,"release":"v1.0.1","artifacts":[{"firmwareEnv":"esp8266_smalltv_st7789","board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.1","asset":"firmware.bin","firmwareUrl":%q,"sha256":%q}]}`, serverURL+"/firmware.bin", hex.EncodeToString(sum[:]))
+		case "/firmware.bin":
+			_, _ = w.Write(image)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	serverURL = server.URL
+	return server.URL + "/manifest.json"
+}
+
+func hasEvent(events []virtualvibetv.Event, path string) bool {
+	for _, event := range events {
+		if event.Path == path {
+			return true
+		}
+	}
+	return false
+}

--- a/companion/internal/virtualvibetv/server.go
+++ b/companion/internal/virtualvibetv/server.go
@@ -1,0 +1,570 @@
+package virtualvibetv
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
+)
+
+const maxUploadBytes = 8 << 20
+
+// Config describes one deterministic Virtual VibeTV scenario.
+type Config struct {
+	HTTPListenAddr                string
+	RawOTAListenAddr              string
+	DeviceID                      string
+	DeviceIDAfterUpdate           string
+	Board                         string
+	Firmware                      string
+	CandidateFirmware             string
+	PairingToken                  string
+	ExpectedFirmwareSHA256        string
+	RebootUnavailableRequests     int
+	NeverReturnsAfterUpdate       bool
+	HealthUnhealthy               bool
+	RenderVerificationFails       bool
+	StreamRestartFails            bool
+	DropUpdateResponseAfterAccept bool
+	RejectUnnecessarySecondFlash  bool
+}
+
+func DefaultConfig() Config {
+	return Config{
+		HTTPListenAddr:               "127.0.0.1:0",
+		RawOTAListenAddr:             "127.0.0.1:8081",
+		DeviceID:                     "virtual-vibetv-001",
+		Board:                        "esp8266-smalltv-st7789",
+		Firmware:                     "1.0.0",
+		CandidateFirmware:            "1.0.1",
+		PairingToken:                 "virtual-pair-token",
+		RebootUnavailableRequests:    2,
+		RejectUnnecessarySecondFlash: true,
+	}
+}
+
+// RunningServer owns the Companion HTTP listener and its separate Raw-OTA
+// listener. Raw OTA defaults to 8081 to mirror the firmware device protocol.
+type RunningServer struct {
+	*Server
+	HTTPURL    string
+	RawOTAURL  string
+	httpServer *http.Server
+	rawServer  *http.Server
+	httpListen net.Listener
+	rawListen  net.Listener
+}
+
+// Start opens real loopback listeners so tests exercise the same TCP Raw-OTA
+// path as the release client instead of its multipart compatibility fallback.
+func Start(cfg Config) (*RunningServer, error) {
+	device := New(cfg)
+	httpAddr := strings.TrimSpace(cfg.HTTPListenAddr)
+	if httpAddr == "" {
+		httpAddr = DefaultConfig().HTTPListenAddr
+	}
+	rawAddr := strings.TrimSpace(cfg.RawOTAListenAddr)
+	if rawAddr == "" {
+		rawAddr = DefaultConfig().RawOTAListenAddr
+	}
+	httpListen, err := net.Listen("tcp", httpAddr)
+	if err != nil {
+		return nil, fmt.Errorf("listen Companion HTTP: %w", err)
+	}
+	rawListen, err := net.Listen("tcp", rawAddr)
+	if err != nil {
+		_ = httpListen.Close()
+		return nil, fmt.Errorf("listen Raw OTA: %w", err)
+	}
+	running := &RunningServer{
+		Server:     device,
+		HTTPURL:    "http://" + httpListen.Addr().String(),
+		RawOTAURL:  "http://" + rawListen.Addr().String(),
+		httpListen: httpListen,
+		rawListen:  rawListen,
+	}
+	running.httpServer = &http.Server{Handler: device}
+	running.rawServer = &http.Server{Handler: http.HandlerFunc(device.serveRawOTA)}
+	go func() { _ = running.httpServer.Serve(httpListen) }()
+	go func() { _ = running.rawServer.Serve(rawListen) }()
+	return running, nil
+}
+
+func (s *RunningServer) Close() error {
+	if s == nil {
+		return nil
+	}
+	firstErr := s.httpServer.Close()
+	if err := s.rawServer.Close(); firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+type Event struct {
+	Sequence int    `json:"sequence"`
+	At       string `json:"at"`
+	Method   string `json:"method"`
+	Path     string `json:"path"`
+	Status   int    `json:"status"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+type Asset struct {
+	Path      string `json:"path"`
+	SizeBytes int64  `json:"sizeBytes"`
+	SHA256    string `json:"sha256"`
+}
+
+type Snapshot struct {
+	DeviceID          string          `json:"deviceId"`
+	Firmware          string          `json:"firmware"`
+	ActiveTheme       string          `json:"activeTheme"`
+	ActiveThemePath   string          `json:"activeThemePath,omitempty"`
+	ActiveThemeSHA256 string          `json:"activeThemeSha256,omitempty"`
+	UpdateUploads     int             `json:"updateUploads"`
+	FramesAccepted    int             `json:"framesAccepted"`
+	LastFrame         json.RawMessage `json:"lastFrame,omitempty"`
+	Assets            []Asset         `json:"assets,omitempty"`
+	Violations        []string        `json:"violations,omitempty"`
+	Events            []Event         `json:"events"`
+}
+
+type Server struct {
+	mu sync.Mutex
+
+	cfg Config
+
+	firmware            string
+	activeTheme         string
+	activeThemePath     string
+	activeThemeSHA256   string
+	assets              map[string][]byte
+	lastFrame           json.RawMessage
+	framesAccepted      int
+	updateUploads       int
+	offlineRequestsLeft int
+	droppedUpdateReply  bool
+	violations          []string
+	events              []Event
+}
+
+func New(cfg Config) *Server {
+	defaults := DefaultConfig()
+	if strings.TrimSpace(cfg.DeviceID) == "" {
+		cfg.DeviceID = defaults.DeviceID
+	}
+	if strings.TrimSpace(cfg.Board) == "" {
+		cfg.Board = defaults.Board
+	}
+	if strings.TrimSpace(cfg.Firmware) == "" {
+		cfg.Firmware = defaults.Firmware
+	}
+	if strings.TrimSpace(cfg.CandidateFirmware) == "" {
+		cfg.CandidateFirmware = defaults.CandidateFirmware
+	}
+	if strings.TrimSpace(cfg.PairingToken) == "" {
+		cfg.PairingToken = defaults.PairingToken
+	}
+	return &Server{
+		cfg:         cfg,
+		firmware:    strings.TrimSpace(cfg.Firmware),
+		activeTheme: "mini-classic",
+		assets:      make(map[string][]byte),
+	}
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.temporarilyUnavailable(w, r) {
+		return
+	}
+
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == "/hello":
+		s.handleHello(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/health":
+		s.handleHealth(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/api/pair":
+		s.handlePair(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/frame":
+		s.handleFrame(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/assets":
+		s.handleAssets(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/assets":
+		s.handleAssetUpload(w, r)
+	case r.Method == http.MethodDelete && r.URL.Path == "/assets":
+		s.handleAssetDelete(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/theme/active":
+		s.handleThemeActive(w, r)
+	case r.Method == http.MethodPost && (r.URL.Path == "/update" || r.URL.Path == "/update/firmware"):
+		s.handleFirmwareUpdate(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/framebuffer":
+		s.handleFramebuffer(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/__virtual/state":
+		s.writeJSON(w, r, http.StatusOK, s.Snapshot(), "")
+	default:
+		s.respond(w, r, http.StatusNotFound, "not found", "")
+	}
+}
+
+func (s *Server) serveRawOTA(w http.ResponseWriter, r *http.Request) {
+	if s.temporarilyUnavailable(w, r) {
+		return
+	}
+	if r.Method != http.MethodPost || r.URL.Path != "/update/firmware.raw" {
+		s.respond(w, r, http.StatusNotFound, "not found", "")
+		return
+	}
+	s.handleFirmwareUpdate(w, r)
+}
+
+func (s *Server) Snapshot() Snapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	assets := make([]Asset, 0, len(s.assets))
+	for path, data := range s.assets {
+		assets = append(assets, Asset{Path: path, SizeBytes: int64(len(data)), SHA256: sha256Hex(data)})
+	}
+	sort.Slice(assets, func(i, j int) bool { return assets[i].Path < assets[j].Path })
+	return Snapshot{
+		DeviceID:          s.currentDeviceIDLocked(),
+		Firmware:          s.firmware,
+		ActiveTheme:       s.activeTheme,
+		ActiveThemePath:   s.activeThemePath,
+		ActiveThemeSHA256: s.activeThemeSHA256,
+		UpdateUploads:     s.updateUploads,
+		FramesAccepted:    s.framesAccepted,
+		LastFrame:         append(json.RawMessage(nil), s.lastFrame...),
+		Assets:            assets,
+		Violations:        append([]string(nil), s.violations...),
+		Events:            append([]Event(nil), s.events...),
+	}
+}
+
+func (s *Server) handleHello(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	firmware := s.firmware
+	deviceID := s.currentDeviceIDLocked()
+	s.mu.Unlock()
+	hello := protocol.DeviceHello{
+		Kind:                      "hello",
+		ProtocolVersion:           2,
+		SupportedProtocolVersions: []int{2, 1},
+		PreferredProtocolVersion:  2,
+		Board:                     s.cfg.Board,
+		Firmware:                  firmware,
+		DeviceID:                  deviceID,
+		NetworkMode:               "station",
+		Features:                  []string{protocol.FeatureTheme, protocol.FeatureThemeSpecV1},
+		MaxFrameBytes:             4096,
+		Capabilities: protocol.CapabilityBlock{
+			Display: protocol.DisplayCapabilities{WidthPx: 240, HeightPx: 240, ColorDepthBits: 16},
+			Theme: protocol.ThemeCapabilities{
+				SupportsThemeSpecV1: true,
+				MaxThemeSpecBytes:   4096,
+				MaxThemePrimitives:  64,
+				BuiltinThemes:       []string{"mini-classic", "claude-creature"},
+			},
+			Transport: protocol.TransportCapabilities{Active: "wifi", Supported: []string{"usb", "wifi"}, Mode: "station"},
+		},
+	}
+	s.writeJSON(w, r, http.StatusOK, hello, "")
+}
+
+func (s *Server) currentDeviceIDLocked() string {
+	if s.updateUploads > 0 && strings.TrimSpace(s.cfg.DeviceIDAfterUpdate) != "" {
+		return strings.TrimSpace(s.cfg.DeviceIDAfterUpdate)
+	}
+	return strings.TrimSpace(s.cfg.DeviceID)
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	payload := map[string]any{
+		"ok": !s.cfg.HealthUnhealthy,
+		"display": map[string]any{
+			"activeTheme": s.activeTheme,
+			"themeSpec": map[string]any{
+				"active":         s.activeThemePath != "",
+				"path":           s.activeThemePath,
+				"hash":           s.activeThemeSHA256,
+				"renderOk":       !s.cfg.RenderVerificationFails,
+				"renderError":    renderError(s.cfg.RenderVerificationFails),
+				"renderFailures": boolInt(s.cfg.RenderVerificationFails),
+			},
+		},
+		"stream": map[string]any{
+			"healthy": !s.cfg.StreamRestartFails,
+		},
+	}
+	s.mu.Unlock()
+	s.writeJSON(w, r, http.StatusOK, payload, "")
+}
+
+func (s *Server) handlePair(w http.ResponseWriter, r *http.Request) {
+	s.writeJSON(w, r, http.StatusOK, map[string]any{"ok": true, "token": s.cfg.PairingToken}, "paired")
+}
+
+func (s *Server) handleFrame(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(w, r) {
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 4097))
+	if err != nil || len(body) == 0 || len(body) > 4096 || !json.Valid(body) {
+		s.respond(w, r, http.StatusBadRequest, "invalid frame", "invalid frame")
+		return
+	}
+	s.mu.Lock()
+	s.lastFrame = append(s.lastFrame[:0], body...)
+	s.framesAccepted++
+	s.mu.Unlock()
+	s.respond(w, r, http.StatusOK, "ok", "frame accepted")
+}
+
+func (s *Server) handleAssets(w http.ResponseWriter, r *http.Request) {
+	snapshot := s.Snapshot()
+	s.writeJSON(w, r, http.StatusOK, map[string]any{"mounted": true, "assets": snapshot.Assets}, "")
+}
+
+func (s *Server) handleAssetUpload(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(w, r) {
+		return
+	}
+	path := cleanAssetPath(r.URL.Query().Get("path"))
+	if path == "" {
+		s.respond(w, r, http.StatusBadRequest, "asset path required", "missing asset path")
+		return
+	}
+	data, err := readMultipartFile(r, "asset")
+	if err != nil {
+		s.respond(w, r, http.StatusBadRequest, err.Error(), "invalid asset")
+		return
+	}
+	s.mu.Lock()
+	s.assets[path] = append([]byte(nil), data...)
+	s.mu.Unlock()
+	s.respond(w, r, http.StatusOK, "ok", "asset uploaded "+path)
+}
+
+func (s *Server) handleAssetDelete(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(w, r) {
+		return
+	}
+	path := cleanAssetPath(r.URL.Query().Get("path"))
+	s.mu.Lock()
+	if path == s.activeThemePath {
+		s.mu.Unlock()
+		s.respond(w, r, http.StatusConflict, "active theme cannot be deleted", "active asset delete rejected")
+		return
+	}
+	delete(s.assets, path)
+	s.mu.Unlock()
+	s.respond(w, r, http.StatusOK, "ok", "asset deleted "+path)
+}
+
+func (s *Server) handleThemeActive(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(w, r) {
+		return
+	}
+	var request struct {
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&request); err != nil {
+		s.respond(w, r, http.StatusBadRequest, "invalid theme activation", "invalid theme activation")
+		return
+	}
+	path := cleanAssetPath(request.Path)
+	s.mu.Lock()
+	data, ok := s.assets[path]
+	if ok {
+		s.activeThemePath = path
+		s.activeTheme = strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		s.activeThemeSHA256 = sha256Hex(data)
+	}
+	s.mu.Unlock()
+	if !ok {
+		s.respond(w, r, http.StatusNotFound, "theme not found", "theme activation missing asset")
+		return
+	}
+	s.writeJSON(w, r, http.StatusOK, map[string]any{"ok": true, "path": path, "hash": sha256Hex(data)}, "theme activated "+path)
+}
+
+func (s *Server) handleFirmwareUpdate(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(w, r) {
+		return
+	}
+	data, err := readFirmwareBody(r)
+	if err != nil {
+		s.respond(w, r, http.StatusBadRequest, err.Error(), "invalid firmware upload")
+		return
+	}
+	actualSHA := sha256Hex(data)
+	expectedSHA := strings.ToLower(strings.TrimSpace(s.cfg.ExpectedFirmwareSHA256))
+	if expectedSHA != "" && actualSHA != expectedSHA {
+		s.respond(w, r, http.StatusUnprocessableEntity, "firmware sha256 mismatch", "firmware sha256 mismatch")
+		return
+	}
+
+	s.mu.Lock()
+	if s.cfg.RejectUnnecessarySecondFlash && s.firmware == strings.TrimSpace(s.cfg.CandidateFirmware) {
+		s.violations = append(s.violations, "unnecessary second firmware flash")
+		s.mu.Unlock()
+		s.respond(w, r, http.StatusConflict, "firmware already current", "second flash rejected")
+		return
+	}
+	s.updateUploads++
+	s.firmware = strings.TrimSpace(s.cfg.CandidateFirmware)
+	s.offlineRequestsLeft = s.cfg.RebootUnavailableRequests
+	dropReply := s.cfg.DropUpdateResponseAfterAccept && !s.droppedUpdateReply
+	if dropReply {
+		s.droppedUpdateReply = true
+	}
+	s.mu.Unlock()
+
+	if dropReply {
+		s.record(r, 0, "firmware accepted; response connection dropped")
+		if hijacker, ok := w.(http.Hijacker); ok {
+			conn, _, hijackErr := hijacker.Hijack()
+			if hijackErr == nil {
+				_ = conn.Close()
+				return
+			}
+		}
+		return
+	}
+	s.respond(w, r, http.StatusOK, "ok", "firmware accepted sha256="+actualSHA)
+}
+
+func (s *Server) handleFramebuffer(w http.ResponseWriter, r *http.Request) {
+	snapshot := s.Snapshot()
+	s.writeJSON(w, r, http.StatusOK, map[string]any{
+		"renderOk": !s.cfg.RenderVerificationFails,
+		"frame":    snapshot.LastFrame,
+	}, "")
+}
+
+func (s *Server) temporarilyUnavailable(w http.ResponseWriter, r *http.Request) bool {
+	s.mu.Lock()
+	unavailable := false
+	if s.cfg.NeverReturnsAfterUpdate && s.updateUploads > 0 {
+		unavailable = true
+	} else if s.offlineRequestsLeft > 0 {
+		s.offlineRequestsLeft--
+		unavailable = true
+	}
+	s.mu.Unlock()
+	if unavailable {
+		s.respond(w, r, http.StatusServiceUnavailable, "rebooting", "temporarily unavailable")
+	}
+	return unavailable
+}
+
+func (s *Server) authorize(w http.ResponseWriter, r *http.Request) bool {
+	expected := strings.TrimSpace(s.cfg.PairingToken)
+	if expected == "" || r.Header.Get("X-VibeTV-Token") == expected || r.URL.Query().Get("token") == expected {
+		return true
+	}
+	s.respond(w, r, http.StatusUnauthorized, "pairing token required", "authentication rejected")
+	return false
+}
+
+func (s *Server) writeJSON(w http.ResponseWriter, r *http.Request, status int, payload any, detail string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+	s.record(r, status, detail)
+}
+
+func (s *Server) respond(w http.ResponseWriter, r *http.Request, status int, body, detail string) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, body)
+	s.record(r, status, detail)
+}
+
+func (s *Server) record(r *http.Request, status int, detail string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, Event{
+		Sequence: len(s.events) + 1,
+		At:       time.Now().UTC().Format(time.RFC3339Nano),
+		Method:   r.Method,
+		Path:     r.URL.Path,
+		Status:   status,
+		Detail:   detail,
+	})
+}
+
+func readFirmwareBody(r *http.Request) ([]byte, error) {
+	if strings.HasPrefix(strings.ToLower(r.Header.Get("Content-Type")), "multipart/form-data") {
+		return readMultipartFile(r, "firmware")
+	}
+	data, err := io.ReadAll(io.LimitReader(r.Body, maxUploadBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("firmware body required")
+	}
+	if len(data) > maxUploadBytes {
+		return nil, fmt.Errorf("firmware body too large")
+	}
+	return data, nil
+}
+
+func readMultipartFile(r *http.Request, field string) ([]byte, error) {
+	if err := r.ParseMultipartForm(maxUploadBytes); err != nil {
+		return nil, fmt.Errorf("parse multipart: %w", err)
+	}
+	file, _, err := r.FormFile(field)
+	if err != nil {
+		return nil, fmt.Errorf("multipart field %q required: %w", field, err)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maxUploadBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxUploadBytes {
+		return nil, fmt.Errorf("multipart field %q too large", field)
+	}
+	return data, nil
+}
+
+func cleanAssetPath(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || !strings.HasPrefix(raw, "/") || strings.Contains(raw, "..") {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(raw))
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func renderError(failed bool) string {
+	if failed {
+		return "simulated render verification failure"
+	}
+	return ""
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/companion/internal/virtualvibetv/server_test.go
+++ b/companion/internal/virtualvibetv/server_test.go
@@ -1,0 +1,154 @@
+package virtualvibetv
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestStartServesCompanionAndRawOTAOnSeparateListeners(t *testing.T) {
+	firmware := []byte("candidate firmware")
+	sum := sha256.Sum256(firmware)
+	cfg := DefaultConfig()
+	cfg.HTTPListenAddr = "127.0.0.1:0"
+	cfg.RawOTAListenAddr = "127.0.0.1:0"
+	cfg.ExpectedFirmwareSHA256 = hex.EncodeToString(sum[:])
+	cfg.RebootUnavailableRequests = 0
+
+	running, err := Start(cfg)
+	if err != nil {
+		t.Fatalf("start virtual VibeTV: %v", err)
+	}
+	t.Cleanup(func() { _ = running.Close() })
+	if running.HTTPURL == running.RawOTAURL {
+		t.Fatalf("HTTP and raw OTA must use separate listeners: %q", running.HTTPURL)
+	}
+
+	resp, err := http.Get(running.HTTPURL + "/hello")
+	if err != nil {
+		t.Fatalf("get hello: %v", err)
+	}
+	defer resp.Body.Close()
+	var hello struct {
+		DeviceID string `json:"deviceId"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&hello); err != nil {
+		t.Fatalf("decode hello: %v", err)
+	}
+	if hello.DeviceID != cfg.DeviceID {
+		t.Fatalf("deviceId = %q, want %q", hello.DeviceID, cfg.DeviceID)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, running.RawOTAURL+"/update/firmware.raw", bytes.NewReader(firmware))
+	if err != nil {
+		t.Fatalf("create raw OTA request: %v", err)
+	}
+	req.Header.Set("X-VibeTV-Token", cfg.PairingToken)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("raw OTA request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("raw OTA status = %s", resp.Status)
+	}
+	if got := running.Snapshot(); got.UpdateUploads != 1 || got.Firmware != cfg.CandidateFirmware {
+		t.Fatalf("unexpected post-OTA state: %+v", got)
+	}
+}
+
+func TestScenariosExposeRequiredFailureStates(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  func(*Config)
+		want func(t *testing.T, server *Server, baseURL string)
+	}{
+		{
+			name: "wrong device after update",
+			cfg:  func(cfg *Config) { cfg.DeviceIDAfterUpdate = "wrong-device" },
+			want: func(t *testing.T, server *Server, _ string) {
+				server.mu.Lock()
+				server.updateUploads = 1
+				server.mu.Unlock()
+				if got := server.Snapshot().DeviceID; got != "wrong-device" {
+					t.Fatalf("deviceId = %q", got)
+				}
+			},
+		},
+		{
+			name: "never returns",
+			cfg:  func(cfg *Config) { cfg.NeverReturnsAfterUpdate = true },
+			want: func(t *testing.T, server *Server, baseURL string) {
+				server.mu.Lock()
+				server.updateUploads = 1
+				server.mu.Unlock()
+				resp, err := http.Get(baseURL + "/hello")
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusServiceUnavailable {
+					t.Fatalf("status = %s", resp.Status)
+				}
+			},
+		},
+		{
+			name: "unhealthy",
+			cfg:  func(cfg *Config) { cfg.HealthUnhealthy = true },
+			want: func(t *testing.T, _ *Server, baseURL string) { assertHealth(t, baseURL, false, true, true) },
+		},
+		{
+			name: "render failure",
+			cfg:  func(cfg *Config) { cfg.RenderVerificationFails = true },
+			want: func(t *testing.T, _ *Server, baseURL string) { assertHealth(t, baseURL, true, false, true) },
+		},
+		{
+			name: "stream restart failure",
+			cfg:  func(cfg *Config) { cfg.StreamRestartFails = true },
+			want: func(t *testing.T, _ *Server, baseURL string) { assertHealth(t, baseURL, true, true, false) },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.HTTPListenAddr = "127.0.0.1:0"
+			cfg.RawOTAListenAddr = "127.0.0.1:0"
+			tt.cfg(&cfg)
+			running, err := Start(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = running.Close() })
+			tt.want(t, running.Server, running.HTTPURL)
+		})
+	}
+}
+
+func assertHealth(t *testing.T, baseURL string, wantOK, wantRenderOK, wantStreamHealthy bool) {
+	t.Helper()
+	resp, err := http.Get(baseURL + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var health struct {
+		OK      bool `json:"ok"`
+		Display struct {
+			ThemeSpec struct {
+				RenderOK bool `json:"renderOk"`
+			} `json:"themeSpec"`
+		} `json:"display"`
+		Stream struct {
+			Healthy bool `json:"healthy"`
+		} `json:"stream"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		t.Fatal(err)
+	}
+	if health.OK != wantOK || health.Display.ThemeSpec.RenderOK != wantRenderOK || health.Stream.Healthy != wantStreamHealthy {
+		t.Fatalf("unexpected health: %+v", health)
+	}
+}


### PR DESCRIPTION
## Stack 1/3 — deterministic core

Part of #177. This PR intentionally contains only the hardware-independent foundation:

- protocol-faithful Virtual VibeTV with separate HTTP and raw-OTA listeners;
- deterministic health, render, stream, reboot, wrong-device and never-returns scenarios;
- real Companion OTA integration coverage, including lost acknowledgements and prevention of blind second flashes;
- exact `deviceId` verification after rediscovery.

## Verification

- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`

No physical VibeTV, firmware write, tag, release, or production endpoint was touched.

This is the replacement core slice for the earlier #179 and is the base of the new three-PR stack.