### PR TITLE
CODEX: add hosted VibeTV candidate and merge gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,3 +254,36 @@ jobs:
             "20" \
             "25" \
             "0"
+
+  codex-ci:
+    name: CODEX CI
+    if: always()
+    needs:
+      - control-center-ui-review-gate
+      - companion-tests
+      - macos-control-center-tests
+      - theme-studio-tests
+      - control-center-tests
+      - theme-pack-build
+      - firmware-build-v0
+      - firmware-build-experimental
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate required CI jobs
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          failed = {
+              name: value.get("result")
+              for name, value in needs.items()
+              if value.get("result") in {"failure", "cancelled"}
+          }
+          if failed:
+              raise SystemExit(f"CODEX CI blocked by: {failed}")
+          print("CODEX CI passed:", {name: value.get("result") for name, value in needs.items()})
+          PY

--- a/.github/workflows/vibetv-merge-gate.yml
+++ b/.github/workflows/vibetv-merge-gate.yml
@@ -1,0 +1,318 @@
+name: CODEX Test VibeTV Merge
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Open pull request number to build and test
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codex-vibetv-merge-${{ inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  resolve-pr:
+    if: >-
+      github.repository == 'DreamyTalesPAN/CodexBar-Display' &&
+      github.ref == 'refs/heads/main' &&
+      (github.actor == github.repository_owner || github.actor == 'marcus7989')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      sha: ${{ steps.pr.outputs.sha }}
+    steps:
+      - id: pr
+        name: Resolve exact open PR head SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || { echo 'invalid PR number' >&2; exit 1; }
+          pr_number="$PR_NUMBER"
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" > pr.json
+          python3 - "$GITHUB_OUTPUT" pr.json <<'PY'
+          import json
+          import sys
+
+          value = json.load(open(sys.argv[2], encoding="utf-8"))
+          if value.get("state") != "open" or value.get("base", {}).get("ref") != "main":
+              raise SystemExit("PR must be open against main")
+          sha = str(value.get("head", {}).get("sha", "")).strip()
+          if len(sha) != 40:
+              raise SystemExit("PR has no immutable 40-character head SHA")
+          with open(sys.argv[1], "a", encoding="utf-8") as output:
+              output.write(f"sha={sha}\n")
+          PY
+
+  build-untrusted:
+    needs: resolve-pr
+    runs-on: macos-15
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact untrusted PR head without persisted credentials
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-pr.outputs.sha }}
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: companion/go.mod
+          cache-dependency-path: companion/go.sum
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: apps/control-center/package-lock.json
+
+      - name: Setup Python and PlatformIO
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build secrets-free candidate inputs
+        run: |
+          set -euo pipefail
+          test -d companion/cmd/virtual-vibetv || {
+            echo 'error: Issue #177 Core is required: companion/cmd/virtual-vibetv is missing.' >&2
+            exit 1
+          }
+          pip install platformio
+          source_sha="$(git rev-parse HEAD)"
+          version="0.0.0-pr${{ inputs.pr_number }}.${GITHUB_RUN_NUMBER}"
+          mkdir -p dist/macos tmp/vibetv-merge
+          (
+            cd apps/control-center
+            npm ci
+            npm run build:local
+          )
+          rm -rf companion/internal/companionapi/controlcenter_static
+          mkdir -p companion/internal/companionapi/controlcenter_static
+          cp -R apps/control-center/out-local/. companion/internal/companionapi/controlcenter_static/
+          (
+            cd companion
+            go test ./...
+            for arch in amd64 arm64; do
+              GOOS=darwin GOARCH="$arch" CGO_ENABLED=0 go build \
+                -ldflags "-s -w -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Version=${version} -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Commit=${source_sha}" \
+                -o "../tmp/vibetv-merge/codexbar-display-${arch}" ./cmd/codexbar-display
+            done
+            GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o ../tmp/vibetv-merge/virtual-vibetv ./cmd/virtual-vibetv
+          )
+          lipo -create -output tmp/vibetv-merge/codexbar-display \
+            tmp/vibetv-merge/codexbar-display-amd64 tmp/vibetv-merge/codexbar-display-arm64
+          ./scripts/build-macos-control-center-app.sh \
+            --version "$version" --build "$GITHUB_RUN_NUMBER" --universal \
+            --companion-binary tmp/vibetv-merge/codexbar-display \
+            --output 'dist/macos/VibeTV Control Center.app'
+          COPYFILE_DISABLE=1 tar -czf tmp/vibetv-merge/app.tar.gz -C dist/macos 'VibeTV Control Center.app'
+          (
+            cd firmware_esp8266
+            CODEXBAR_DISPLAY_FW_VERSION="$version" pio run -e esp8266_smalltv_st7789
+          )
+          cp firmware_esp8266/.pio/build/esp8266_smalltv_st7789/firmware.bin tmp/vibetv-merge/firmware.bin
+          printf '%s\n' "$source_sha" > tmp/vibetv-merge/source-sha.txt
+          printf '%s\n' "$version" > tmp/vibetv-merge/version.txt
+
+      - name: Upload unsigned candidate inputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: CODEX-vibetv-merge-inputs-${{ github.run_id }}
+          path: tmp/vibetv-merge
+          retention-days: 1
+
+  sign-and-package:
+    needs: [resolve-pr, build-untrusted]
+    runs-on: macos-15
+    timeout-minutes: 70
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted main signing tools
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Download unsigned candidate inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: CODEX-vibetv-merge-inputs-${{ github.run_id }}
+          path: tmp/vibetv-merge
+
+      - name: Safely extract untrusted app archive
+        run: ./scripts/extract-vibetv-candidate-app.sh --archive tmp/vibetv-merge/app.tar.gz --output dist/macos
+
+      - name: Sign and notarize candidate without running PR code
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_SIGNING_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_SIGNING_CERTIFICATE_P12_BASE64 }}
+          APPLE_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
+        run: |
+          set -euo pipefail
+          ./scripts/sign-notarize-macos-control-center.sh --app 'dist/macos/VibeTV Control Center.app' --sign-app-only --allow-internal-xprotect-preflight-error
+          ./scripts/build-macos-control-center-dmg.sh --app 'dist/macos/VibeTV Control Center.app' --output dist/macos/VibeTV-Control-Center.dmg --staging-dir tmp/vibetv-merge/dmg-stage
+          ./scripts/sign-notarize-macos-control-center.sh --app 'dist/macos/VibeTV Control Center.app' --dmg dist/macos/VibeTV-Control-Center.dmg --skip-app-sign
+          ./scripts/verify-macos-control-center-dmg.sh --dmg dist/macos/VibeTV-Control-Center.dmg
+
+      - name: Build signed candidate appcast and immutable manifest
+        env:
+          SPARKLE_ED25519_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
+          SOURCE_SHA: ${{ needs.resolve-pr.outputs.sha }}
+          CANDIDATE_RUN_ID: ${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          version="$(cat tmp/vibetv-merge/version.txt)"
+          sparkle_dir="$(./scripts/fetch-sparkle.sh)"
+          printf '%s' "$SPARKLE_ED25519_PRIVATE_KEY" | "$sparkle_dir/bin/generate_appcast" --ed-key-file - --maximum-deltas 0 --link https://app.vibetv.shop -o dist/macos/appcast.xml dist/macos
+          python3 - "$SOURCE_SHA" "$version" "$REPOSITORY" "$CANDIDATE_RUN_ID" dist/macos/candidate-manifest.json <<'PY'
+          import datetime, hashlib, json, sys
+          sha, version, repository, run_id, output = sys.argv[1:]
+          files = [
+              ("VibeTV-Control-Center.dmg", "dist/macos/VibeTV-Control-Center.dmg", "signed-dmg"),
+              ("appcast.xml", "dist/macos/appcast.xml", "sparkle-appcast"),
+              ("firmware.bin", "tmp/vibetv-merge/firmware.bin", "firmware"),
+              ("virtual-vibetv", "tmp/vibetv-merge/virtual-vibetv", "virtual-vibetv"),
+          ]
+          manifest = {
+              "schemaVersion": 1, "repository": repository, "sourceSha": sha, "version": version,
+              "candidateRunId": run_id,
+              "createdAt": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+              "artifacts": [], "virtualGate": {"result": "pending", "runId": run_id},
+          }
+          for name, path, role in files:
+              with open(path, "rb") as source:
+                  manifest["artifacts"].append({"name": name, "path": name, "sha256": hashlib.sha256(source.read()).hexdigest(), "role": role})
+          with open(output, "w", encoding="utf-8") as destination:
+              json.dump(manifest, destination, indent=2)
+              destination.write("\n")
+          PY
+
+      - name: Upload signed merge candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: CODEX-vibetv-merge-candidate-${{ github.run_id }}
+          path: |
+            dist/macos/VibeTV-Control-Center.dmg
+            dist/macos/appcast.xml
+            dist/macos/candidate-manifest.json
+            tmp/vibetv-merge/virtual-vibetv
+            tmp/vibetv-merge/firmware.bin
+          retention-days: 7
+          compression-level: 0
+
+  resolve-baselines:
+    needs: resolve-pr
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted baseline resolver
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+      - name: Freeze public baselines
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/resolve-vibetv-public-baselines.sh --output baseline-manifest.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: CODEX-vibetv-merge-baselines-${{ github.run_id }}
+          path: baseline-manifest.json
+          retention-days: 7
+
+  guest-test:
+    needs: [sign-and-package, resolve-baselines]
+    runs-on: macos-15
+    timeout-minutes: 70
+    strategy:
+      fail-fast: false
+      matrix:
+        state: [clean_os, current_public, previous_public]
+    steps:
+      - name: Checkout trusted guest test
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: CODEX-vibetv-merge-candidate-${{ github.run_id }}
+          path: candidate
+      - uses: actions/download-artifact@v4
+        with:
+          name: CODEX-vibetv-merge-baselines-${{ github.run_id }}
+          path: baselines
+      - name: Download frozen public baseline when required
+        if: matrix.state != 'clean_os'
+        run: |
+          python3 - "baselines/baseline-manifest.json" "${{ matrix.state }}" <<'PY' > baseline.env
+          import json, shlex, sys
+          manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+          baseline = manifest["baselines"][sys.argv[2]]
+          print("DMG_URL=" + shlex.quote(baseline["dmgUrl"]))
+          print("APPCAST_URL=" + shlex.quote(baseline["appcastUrl"]))
+          PY
+          source baseline.env
+          curl --fail --location "$DMG_URL" -o baseline.dmg
+          curl --fail --location "$APPCAST_URL" -o baseline-appcast.xml
+      - name: Run direct hosted macOS guest checks
+        run: |
+          set -euo pipefail
+          version="$(python3 -c 'import json; print(json.load(open("candidate/candidate-manifest.json"))["version"])')"
+          baseline_args=()
+          if [[ '${{ matrix.state }}' != clean_os ]]; then
+            baseline_args=(--baseline-dmg baseline.dmg --baseline-appcast baseline-appcast.xml)
+          fi
+          ./scripts/test-vibetv-hosted-guest.sh \
+            --dmg candidate/VibeTV-Control-Center.dmg --appcast candidate/appcast.xml \
+            --virtual-vibetv candidate/virtual-vibetv --firmware candidate/firmware.bin \
+            --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: CODEX-vibetv-merge-results-${{ matrix.state }}-${{ github.run_id }}
+          path: results
+          retention-days: 7
+
+  report-status:
+    if: always()
+    needs: [resolve-pr, guest-test]
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Publish stable VibeTV merge commit status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ needs.resolve-pr.outputs.sha }}
+          RESULT: ${{ needs.guest-test.result }}
+        run: |
+          set -euo pipefail
+          state=success
+          description='GitHub-hosted VibeTV guest matrix passed'
+          if [[ "$RESULT" != success ]]; then
+            state=failure
+            description='GitHub-hosted VibeTV guest matrix failed'
+          fi
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+            -f state="$state" -f context='CODEX VibeTV Merge Gate' -f description="$description" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/vibetv-merge-gate.yml
+++ b/.github/workflows/vibetv-merge-gate.yml
@@ -92,7 +92,7 @@ jobs:
           }
           pip install platformio
           source_sha="$(git rev-parse HEAD)"
-          version="0.0.0-pr${{ inputs.pr_number }}.${GITHUB_RUN_NUMBER}"
+          version="9999.0.${GITHUB_RUN_NUMBER}"
           mkdir -p dist/macos tmp/vibetv-merge
           (
             cd apps/control-center
@@ -124,6 +124,14 @@ jobs:
             CODEXBAR_DISPLAY_FW_VERSION="$version" pio run -e esp8266_smalltv_st7789
           )
           cp firmware_esp8266/.pio/build/esp8266_smalltv_st7789/firmware.bin tmp/vibetv-merge/firmware.bin
+          python3 - "$version" tmp/vibetv-merge/firmware.bin > tmp/vibetv-merge/firmware-manifest.json <<'PY'
+          import hashlib, json, sys
+          version, firmware = sys.argv[1:]
+          with open(firmware, "rb") as source:
+              digest = hashlib.sha256(source.read()).hexdigest()
+          json.dump({"schemaVersion": 1, "release": "v" + version, "artifacts": [{"firmwareEnv": "esp8266_smalltv_st7789", "board": "esp8266-smalltv-st7789", "firmwareVersion": version, "asset": "firmware.bin", "firmwareUrl": "firmware.bin", "sha256": digest}]}, sys.stdout)
+          print()
+          PY
           printf '%s\n' "$source_sha" > tmp/vibetv-merge/source-sha.txt
           printf '%s\n' "$version" > tmp/vibetv-merge/version.txt
 
@@ -188,7 +196,9 @@ jobs:
           files = [
               ("VibeTV-Control-Center.dmg", "dist/macos/VibeTV-Control-Center.dmg", "signed-dmg"),
               ("appcast.xml", "dist/macos/appcast.xml", "sparkle-appcast"),
+              ("codexbar-display", "tmp/vibetv-merge/codexbar-display", "companion"),
               ("firmware.bin", "tmp/vibetv-merge/firmware.bin", "firmware"),
+              ("firmware-manifest.json", "tmp/vibetv-merge/firmware-manifest.json", "firmware-manifest"),
               ("virtual-vibetv", "tmp/vibetv-merge/virtual-vibetv", "virtual-vibetv"),
           ]
           manifest = {
@@ -214,7 +224,9 @@ jobs:
             dist/macos/appcast.xml
             dist/macos/candidate-manifest.json
             tmp/vibetv-merge/virtual-vibetv
+            tmp/vibetv-merge/codexbar-display
             tmp/vibetv-merge/firmware.bin
+            tmp/vibetv-merge/firmware-manifest.json
           retention-days: 7
           compression-level: 0
 
@@ -284,7 +296,8 @@ jobs:
           fi
           ./scripts/test-vibetv-hosted-guest.sh \
             --dmg candidate/VibeTV-Control-Center.dmg --appcast candidate/appcast.xml \
-            --virtual-vibetv candidate/virtual-vibetv --firmware candidate/firmware.bin \
+            --virtual-vibetv candidate/virtual-vibetv --companion candidate/codexbar-display \
+            --firmware candidate/firmware.bin --firmware-manifest candidate/firmware-manifest.json \
             --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -1,0 +1,222 @@
+name: CODEX Test VibeTV Release Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Candidate SemVer built from the exact main SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codex-vibetv-release-candidate-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  build-main:
+    if: >-
+      github.repository == 'DreamyTalesPAN/CodexBar-Display' &&
+      github.ref == 'refs/heads/main' &&
+      (github.actor == github.repository_owner || github.actor == 'marcus7989')
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: companion/go.mod
+          cache-dependency-path: companion/go.sum
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: apps/control-center/package-lock.json
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Build immutable candidate inputs once
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="${VERSION#v}"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || { echo 'version must be SemVer' >&2; exit 1; }
+          test -d companion/cmd/virtual-vibetv || { echo 'error: Issue #177 Core is required: companion/cmd/virtual-vibetv is missing.' >&2; exit 1; }
+          pip install platformio
+          mkdir -p dist/macos tmp/vibetv-rc
+          (
+            cd apps/control-center
+            npm ci
+            npm run build:local
+          )
+          rm -rf companion/internal/companionapi/controlcenter_static
+          mkdir -p companion/internal/companionapi/controlcenter_static
+          cp -R apps/control-center/out-local/. companion/internal/companionapi/controlcenter_static/
+          (
+            cd companion
+            for arch in amd64 arm64; do
+              GOOS=darwin GOARCH="$arch" CGO_ENABLED=0 go build \
+                -ldflags "-s -w -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Version=${version} -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Commit=${GITHUB_SHA}" \
+                -o "../tmp/vibetv-rc/codexbar-display-${arch}" ./cmd/codexbar-display
+            done
+            GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o ../tmp/vibetv-rc/virtual-vibetv ./cmd/virtual-vibetv
+          )
+          lipo -create -output tmp/vibetv-rc/codexbar-display tmp/vibetv-rc/codexbar-display-amd64 tmp/vibetv-rc/codexbar-display-arm64
+          ./scripts/build-macos-control-center-app.sh --version "$version" --build "$GITHUB_RUN_NUMBER" --universal --companion-binary tmp/vibetv-rc/codexbar-display --output 'dist/macos/VibeTV Control Center.app'
+          COPYFILE_DISABLE=1 tar -czf tmp/vibetv-rc/app.tar.gz -C dist/macos 'VibeTV Control Center.app'
+          (
+            cd firmware_esp8266
+            CODEXBAR_DISPLAY_FW_VERSION="$version" pio run -e esp8266_smalltv_st7789
+          )
+          cp firmware_esp8266/.pio/build/esp8266_smalltv_st7789/firmware.bin tmp/vibetv-rc/firmware.bin
+          printf '%s\n' "$version" > tmp/vibetv-rc/version.txt
+          printf '%s\n' "$GITHUB_SHA" > tmp/vibetv-rc/source-sha.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: CODEX-vibetv-rc-inputs-${{ github.run_id }}
+          path: tmp/vibetv-rc
+          retention-days: 7
+
+  sign-and-package:
+    needs: build-main
+    runs-on: macos-15
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: CODEX-vibetv-rc-inputs-${{ github.run_id }}
+          path: tmp/vibetv-rc
+      - run: ./scripts/extract-vibetv-candidate-app.sh --archive tmp/vibetv-rc/app.tar.gz --output dist/macos
+      - name: Sign and notarize immutable release candidate
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_SIGNING_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_SIGNING_CERTIFICATE_P12_BASE64 }}
+          APPLE_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
+        run: |
+          ./scripts/sign-notarize-macos-control-center.sh --app 'dist/macos/VibeTV Control Center.app' --sign-app-only --allow-internal-xprotect-preflight-error
+          ./scripts/build-macos-control-center-dmg.sh --app 'dist/macos/VibeTV Control Center.app' --output dist/macos/VibeTV-Control-Center.dmg --staging-dir tmp/vibetv-rc/dmg-stage
+          ./scripts/sign-notarize-macos-control-center.sh --app 'dist/macos/VibeTV Control Center.app' --dmg dist/macos/VibeTV-Control-Center.dmg --skip-app-sign
+          ./scripts/verify-macos-control-center-dmg.sh --dmg dist/macos/VibeTV-Control-Center.dmg
+      - name: Create signed appcast and candidate-manifest.json
+        env:
+          SPARKLE_ED25519_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
+          CANDIDATE_RUN_ID: ${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          version="$(cat tmp/vibetv-rc/version.txt)"
+          source_sha="$(cat tmp/vibetv-rc/source-sha.txt)"
+          sparkle_dir="$(./scripts/fetch-sparkle.sh)"
+          printf '%s' "$SPARKLE_ED25519_PRIVATE_KEY" | "$sparkle_dir/bin/generate_appcast" --ed-key-file - --maximum-deltas 0 --link https://app.vibetv.shop -o dist/macos/appcast.xml dist/macos
+          python3 - "$source_sha" "$version" "$REPOSITORY" "$CANDIDATE_RUN_ID" dist/macos/candidate-manifest.json <<'PY'
+          import datetime, hashlib, json, sys
+          sha, version, repository, run_id, output = sys.argv[1:]
+          files = [
+              ("VibeTV-Control-Center.dmg", "dist/macos/VibeTV-Control-Center.dmg", "signed-dmg"),
+              ("appcast.xml", "dist/macos/appcast.xml", "sparkle-appcast"),
+              ("firmware.bin", "tmp/vibetv-rc/firmware.bin", "firmware"),
+              ("virtual-vibetv", "tmp/vibetv-rc/virtual-vibetv", "virtual-vibetv"),
+          ]
+          artifacts = []
+          for name, path, role in files:
+              with open(path, "rb") as source:
+                  artifacts.append({"name": name, "path": name, "sha256": hashlib.sha256(source.read()).hexdigest(), "role": role})
+          with open(output, "w", encoding="utf-8") as destination:
+              json.dump({
+                  "schemaVersion": 1, "repository": repository, "sourceSha": sha, "version": version,
+                  "candidateRunId": run_id,
+                  "createdAt": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+                  "artifacts": artifacts, "virtualGate": {"result": "pending", "runId": run_id},
+              }, destination, indent=2)
+              destination.write("\n")
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vibetv-release-candidate
+          path: |
+            dist/macos/VibeTV-Control-Center.dmg
+            dist/macos/appcast.xml
+            dist/macos/candidate-manifest.json
+            tmp/vibetv-rc/virtual-vibetv
+            tmp/vibetv-rc/firmware.bin
+          retention-days: 7
+          compression-level: 0
+
+  resolve-baselines:
+    needs: build-main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/resolve-vibetv-public-baselines.sh --output baseline-manifest.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: CODEX-vibetv-rc-baselines-${{ github.run_id }}
+          path: baseline-manifest.json
+          retention-days: 7
+
+  guest-test:
+    needs: [sign-and-package, resolve-baselines]
+    runs-on: macos-15
+    timeout-minutes: 70
+    strategy:
+      fail-fast: false
+      matrix:
+        state: [clean_os, current_public, previous_public]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: vibetv-release-candidate
+          path: candidate
+      - uses: actions/download-artifact@v4
+        with:
+          name: CODEX-vibetv-rc-baselines-${{ github.run_id }}
+          path: baselines
+      - name: Download frozen public baseline when required
+        if: matrix.state != 'clean_os'
+        run: |
+          python3 - "baselines/baseline-manifest.json" "${{ matrix.state }}" <<'PY' > baseline.env
+          import json, shlex, sys
+          baseline = json.load(open(sys.argv[1], encoding="utf-8"))["baselines"][sys.argv[2]]
+          print("DMG_URL=" + shlex.quote(baseline["dmgUrl"]))
+          print("APPCAST_URL=" + shlex.quote(baseline["appcastUrl"]))
+          PY
+          source baseline.env
+          curl --fail --location "$DMG_URL" -o baseline.dmg
+          curl --fail --location "$APPCAST_URL" -o baseline-appcast.xml
+      - name: Run full direct hosted macOS guest matrix
+        run: |
+          set -euo pipefail
+          version="$(python3 -c 'import json; print(json.load(open("candidate/candidate-manifest.json"))["version"])')"
+          baseline_args=()
+          if [[ '${{ matrix.state }}' != clean_os ]]; then
+            baseline_args=(--baseline-dmg baseline.dmg --baseline-appcast baseline-appcast.xml)
+          fi
+          ./scripts/test-vibetv-hosted-guest.sh --dmg candidate/VibeTV-Control-Center.dmg --appcast candidate/appcast.xml --virtual-vibetv candidate/virtual-vibetv --firmware candidate/firmware.bin --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: CODEX-vibetv-rc-results-${{ matrix.state }}-${{ github.run_id }}
+          path: results
+          retention-days: 7

--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -201,10 +201,26 @@ jobs:
       - env:
           GH_TOKEN: ${{ github.token }}
         run: ./scripts/resolve-vibetv-public-baselines.sh --output baseline-manifest.json
+      - name: Freeze baseline bytes and hashes
+        run: |
+          python3 - baseline-manifest.json <<'PY'
+          import hashlib, json, pathlib, urllib.request
+          path = pathlib.Path(__import__('sys').argv[1]); manifest = json.loads(path.read_text())
+          root = pathlib.Path('baselines'); root.mkdir()
+          for state, baseline in manifest['baselines'].items():
+              for kind, url_key in [('dmg', 'dmgUrl'), ('appcast', 'appcastUrl')]:
+                  data = urllib.request.urlopen(baseline[url_key]).read()
+                  target = root / f'{state}.{ "dmg" if kind == "dmg" else "appcast.xml" }'
+                  target.write_bytes(data)
+                  baseline[kind + 'Sha256'] = hashlib.sha256(data).hexdigest()
+          path.write_text(json.dumps(manifest, indent=2) + '\n')
+          PY
       - uses: actions/upload-artifact@v4
         with:
           name: CODEX-vibetv-rc-baselines-${{ github.run_id }}
-          path: baseline-manifest.json
+          path: |
+            baseline-manifest.json
+            baselines
           retention-days: 7
 
   guest-test:
@@ -237,9 +253,9 @@ jobs:
           print("DMG_URL=" + shlex.quote(baseline["dmgUrl"]))
           print("APPCAST_URL=" + shlex.quote(baseline["appcastUrl"]))
           PY
-          source baseline.env
-          curl --fail --location "$DMG_URL" -o baseline.dmg
-          curl --fail --location "$APPCAST_URL" -o baseline-appcast.xml
+          cp "baselines/${{ matrix.state }}.dmg" baseline.dmg
+          cp "baselines/${{ matrix.state }}.appcast.xml" baseline-appcast.xml
+          shasum -a 256 baseline.dmg baseline-appcast.xml
       - name: Run full direct hosted macOS guest matrix
         run: |
           set -euo pipefail

--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -86,19 +86,28 @@ jobs:
               else: raise SystemExit("unsupported firmware environment: " + env)
           PY
           while IFS=$'\t' read -r dir env board fw asset; do
-            (cd "$dir" && CODEXBAR_DISPLAY_FW_VERSION="$fw" pio run -e "$env")
+            BUILD_LOG="$(mktemp)"
+            (cd "$dir" && CODEXBAR_DISPLAY_FW_VERSION="$fw" pio run -e "$env") 2>&1 | tee "$BUILD_LOG"
             source="$dir/.pio/build/$env/firmware.bin"
+            if [[ "$env" == esp8266_* ]]; then
+              ./scripts/check-firmware-size-budget.sh "$BUILD_LOG" "$source" "$env" 46 82 482000 350000
+            else
+              ./scripts/check-firmware-size-budget.sh "$BUILD_LOG" "$source" "$env" 20 25 0 0
+            fi
             if [[ "$env" == esp8266_* ]]; then gzip -c -9 "$source" > "tmp/vibetv-rc/publish/firmware/$asset"; else cp "$source" "tmp/vibetv-rc/publish/firmware/$asset"; fi
           done < tmp/vibetv-rc/firmware-targets.tsv
-          python3 - "$version" "$GITHUB_REPOSITORY" tmp/vibetv-rc/firmware-targets.tsv tmp/vibetv-rc/publish/firmware > tmp/vibetv-rc/publish/firmware/firmware-manifest.json <<'PY'
+          python3 - "$version" "$GITHUB_REPOSITORY" release/firmware-versions.json tmp/vibetv-rc/firmware-targets.tsv tmp/vibetv-rc/publish/firmware > tmp/vibetv-rc/publish/firmware/firmware-manifest.json <<'PY'
           import hashlib, json, os, sys
-          version, repo, targets, root = sys.argv[1:]
+          version, repo, config_path, targets, root = sys.argv[1:]
+          config=json.load(open(config_path, encoding="utf-8"))
+          configured={item["firmwareEnv"]: item for item in config["artifacts"]}
           entries=[]
           for line in open(targets, encoding="utf-8"):
               _, env, board, fw, asset = line.rstrip("\n").split("\t")
               data=open(os.path.join(root, asset), "rb").read()
-              entries.append({"firmwareEnv":env,"board":board,"firmwareVersion":fw,"asset":asset,"sha256":hashlib.sha256(data).hexdigest(),"firmwareUrl":f"https://github.com/{repo}/releases/download/v{version}/{asset}"})
-          json.dump({"schemaVersion":1,"release":"v"+version,"artifacts":entries}, sys.stdout, indent=2); print()
+              item=configured[env]
+              entries.append({"firmwareEnv":env,"board":board,"firmwareVersion":fw,"asset":asset,"sha256":hashlib.sha256(data).hexdigest(),"severity":item.get("severity", "recommended"),"message":item.get("message", ""),"firmwareUrl":f"https://github.com/{repo}/releases/download/v{version}/{asset}"})
+          json.dump({"schemaVersion":1,"release":"v"+version,"protocolVersion":config.get("protocolVersion", 1),"artifacts":entries}, sys.stdout, indent=2); print()
           PY
           cp tmp/vibetv-rc/publish/firmware/firmware-manifest.json "tmp/vibetv-rc/publish/firmware/firmware-manifest-v${version}.json"
           printf '%s\n' "$version" > tmp/vibetv-rc/version.txt

--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -92,7 +92,7 @@ jobs:
             if [[ "$env" == esp8266_* ]]; then
               ./scripts/check-firmware-size-budget.sh "$BUILD_LOG" "$source" "$env" 46 82 482000 350000
             else
-              ./scripts/check-firmware-size-budget.sh "$BUILD_LOG" "$source" "$env" 20 25 0 0
+              ./scripts/check-firmware-size-budget.sh "$BUILD_LOG" "$source" "$env" 46 82 0 0
             fi
             if [[ "$env" == esp8266_* ]]; then gzip -c -9 "$source" > "tmp/vibetv-rc/publish/firmware/$asset"; else cp "$source" "tmp/vibetv-rc/publish/firmware/$asset"; fi
           done < tmp/vibetv-rc/firmware-targets.tsv
@@ -208,11 +208,15 @@ jobs:
           path = pathlib.Path(__import__('sys').argv[1]); manifest = json.loads(path.read_text())
           root = pathlib.Path('baselines'); root.mkdir()
           for state, baseline in manifest['baselines'].items():
-              for kind, url_key in [('dmg', 'dmgUrl'), ('appcast', 'appcastUrl')]:
+              for kind, url_key in [('dmg', 'dmgUrl'), ('appcast', 'appcastUrl'), ('firmware-manifest', 'firmwareManifestUrl')]:
                   data = urllib.request.urlopen(baseline[url_key]).read()
-                  target = root / f'{state}.{ "dmg" if kind == "dmg" else "appcast.xml" }'
+                  target = root / f'{state}.{ "dmg" if kind == "dmg" else "appcast.xml" if kind == "appcast" else "firmware-manifest.json" }'
                   target.write_bytes(data)
                   baseline[kind + 'Sha256'] = hashlib.sha256(data).hexdigest()
+              firmware = json.loads((root / f'{state}.firmware-manifest.json').read_text())
+              esp = next(item for item in firmware['artifacts'] if item['firmwareEnv'] == 'esp8266_smalltv_st7789')
+              baseline['esp8266FirmwareVersion'] = esp['firmwareVersion']
+              baseline['esp8266FirmwareSha256'] = esp['sha256']
           path.write_text(json.dumps(manifest, indent=2) + '\n')
           PY
       - uses: actions/upload-artifact@v4
@@ -255,16 +259,19 @@ jobs:
           PY
           cp "baselines/${{ matrix.state }}.dmg" baseline.dmg
           cp "baselines/${{ matrix.state }}.appcast.xml" baseline-appcast.xml
+          cp "baselines/${{ matrix.state }}.firmware-manifest.json" baseline-firmware-manifest.json
           shasum -a 256 baseline.dmg baseline-appcast.xml
       - name: Run full direct hosted macOS guest matrix
         run: |
           set -euo pipefail
           version="$(python3 -c 'import json; print(json.load(open("candidate/candidate-manifest.json"))["version"])')"
           baseline_args=()
+          current_firmware=0.0.0
           if [[ '${{ matrix.state }}' != clean_os ]]; then
             baseline_args=(--baseline-dmg baseline.dmg --baseline-appcast baseline-appcast.xml)
+            current_firmware="$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("baseline-firmware-manifest.json"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789"))')"
           fi
-          ./scripts/test-vibetv-hosted-guest.sh --dmg candidate/publish/macos/VibeTV-Control-Center.dmg --appcast candidate/publish/macos/appcast.xml --virtual-vibetv candidate/test/virtual-vibetv --companion candidate/test/codexbar-display --firmware candidate/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("release/firmware-versions.json"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789")').bin.gz --firmware-manifest candidate/publish/firmware/firmware-manifest.json --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
+          ./scripts/test-vibetv-hosted-guest.sh --dmg candidate/publish/macos/VibeTV-Control-Center.dmg --appcast candidate/publish/macos/appcast.xml --virtual-vibetv candidate/test/virtual-vibetv --companion candidate/test/codexbar-display --firmware candidate/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("release/firmware-versions.json"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789")').bin.gz --firmware-manifest candidate/publish/firmware/firmware-manifest.json --current-firmware "$current_firmware" --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -159,6 +159,7 @@ jobs:
           cp dist/macos/VibeTV-Control-Center.dmg tmp/vibetv-rc/publish/macos/VibeTV-Control-Center.dmg
           printf '%s' "$SPARKLE_ED25519_PRIVATE_KEY" | "$sparkle_dir/bin/generate_appcast" --ed-key-file - --maximum-deltas 0 --link https://app.vibetv.shop --download-url-prefix "https://github.com/${REPOSITORY}/releases/download/v${version}/" -o tmp/vibetv-rc/publish/macos/appcast.xml tmp/vibetv-rc/publish/macos
           (cd tmp/vibetv-rc/publish && find . -type f -print0 | sort -z | xargs -0 shasum -a 256 > "checksums-v${version}.txt")
+          (cd tmp/vibetv-rc/publish && shasum -a 256 -c "checksums-v${version}.txt")
           python3 - "$source_sha" "$version" "$REPOSITORY" "$CANDIDATE_RUN_ID" tmp/vibetv-rc/candidate-manifest.json tmp/vibetv-rc <<'PY'
           import datetime, hashlib, json, sys
           sha, version, repository, run_id, output, root = sys.argv[1:]

--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -75,6 +75,14 @@ jobs:
             CODEXBAR_DISPLAY_FW_VERSION="$version" pio run -e esp8266_smalltv_st7789
           )
           cp firmware_esp8266/.pio/build/esp8266_smalltv_st7789/firmware.bin tmp/vibetv-rc/firmware.bin
+          python3 - "$version" tmp/vibetv-rc/firmware.bin > tmp/vibetv-rc/firmware-manifest.json <<'PY'
+          import hashlib, json, sys
+          version, firmware = sys.argv[1:]
+          with open(firmware, "rb") as source:
+              digest = hashlib.sha256(source.read()).hexdigest()
+          json.dump({"schemaVersion": 1, "release": "v" + version, "artifacts": [{"firmwareEnv": "esp8266_smalltv_st7789", "board": "esp8266-smalltv-st7789", "firmwareVersion": version, "asset": "firmware.bin", "firmwareUrl": "firmware.bin", "sha256": digest}]}, sys.stdout)
+          print()
+          PY
           printf '%s\n' "$version" > tmp/vibetv-rc/version.txt
           printf '%s\n' "$GITHUB_SHA" > tmp/vibetv-rc/source-sha.txt
       - uses: actions/upload-artifact@v4
@@ -127,7 +135,9 @@ jobs:
           files = [
               ("VibeTV-Control-Center.dmg", "dist/macos/VibeTV-Control-Center.dmg", "signed-dmg"),
               ("appcast.xml", "dist/macos/appcast.xml", "sparkle-appcast"),
+              ("codexbar-display", "tmp/vibetv-rc/codexbar-display", "companion"),
               ("firmware.bin", "tmp/vibetv-rc/firmware.bin", "firmware"),
+              ("firmware-manifest.json", "tmp/vibetv-rc/firmware-manifest.json", "firmware-manifest"),
               ("virtual-vibetv", "tmp/vibetv-rc/virtual-vibetv", "virtual-vibetv"),
           ]
           artifacts = []
@@ -151,7 +161,9 @@ jobs:
             dist/macos/appcast.xml
             dist/macos/candidate-manifest.json
             tmp/vibetv-rc/virtual-vibetv
+            tmp/vibetv-rc/codexbar-display
             tmp/vibetv-rc/firmware.bin
+            tmp/vibetv-rc/firmware-manifest.json
           retention-days: 7
           compression-level: 0
 
@@ -213,10 +225,49 @@ jobs:
           if [[ '${{ matrix.state }}' != clean_os ]]; then
             baseline_args=(--baseline-dmg baseline.dmg --baseline-appcast baseline-appcast.xml)
           fi
-          ./scripts/test-vibetv-hosted-guest.sh --dmg candidate/VibeTV-Control-Center.dmg --appcast candidate/appcast.xml --virtual-vibetv candidate/virtual-vibetv --firmware candidate/firmware.bin --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
+          ./scripts/test-vibetv-hosted-guest.sh --dmg candidate/VibeTV-Control-Center.dmg --appcast candidate/appcast.xml --virtual-vibetv candidate/virtual-vibetv --companion candidate/codexbar-display --firmware candidate/firmware.bin --firmware-manifest candidate/firmware-manifest.json --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: CODEX-vibetv-rc-results-${{ matrix.state }}-${{ github.run_id }}
           path: results
+          retention-days: 7
+
+  aggregate-result:
+    if: always()
+    needs: [sign-and-package, guest-test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: vibetv-release-candidate
+          path: candidate
+      - name: Write immutable candidate result
+        env:
+          MATRIX_RESULT: ${{ needs.guest-test.result }}
+        run: |
+          python3 - "candidate/candidate-manifest.json" candidate-result.json "$MATRIX_RESULT" <<'PY'
+          import json, sys
+          manifest_path, output, matrix_result = sys.argv[1:]
+          manifest = json.load(open(manifest_path, encoding="utf-8"))
+          result = "success" if matrix_result == "success" else "failure"
+          with open(output, "w", encoding="utf-8") as destination:
+              json.dump({
+                  "schemaVersion": 1,
+                  "repository": manifest["repository"],
+                  "sourceSha": manifest["sourceSha"],
+                  "version": manifest["version"],
+                  "candidateRunId": manifest["candidateRunId"],
+                  "result": result,
+                  "artifactHashes": manifest["artifacts"],
+              }, destination, indent=2)
+              destination.write("\n")
+          if result != "success":
+              raise SystemExit("candidate matrix did not pass; result artifact is intentionally non-publishable")
+          PY
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: vibetv-release-candidate-result
+          path: candidate-result.json
           retention-days: 7

--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -49,7 +49,7 @@ jobs:
           [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || { echo 'version must be SemVer' >&2; exit 1; }
           test -d companion/cmd/virtual-vibetv || { echo 'error: Issue #177 Core is required: companion/cmd/virtual-vibetv is missing.' >&2; exit 1; }
           pip install platformio
-          mkdir -p dist/macos tmp/vibetv-rc
+          mkdir -p dist/macos tmp/vibetv-rc/publish/companion tmp/vibetv-rc/publish/firmware tmp/vibetv-rc/test
           (
             cd apps/control-center
             npm ci
@@ -65,24 +65,42 @@ jobs:
                 -ldflags "-s -w -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Version=${version} -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Commit=${GITHUB_SHA}" \
                 -o "../tmp/vibetv-rc/codexbar-display-${arch}" ./cmd/codexbar-display
             done
-            GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o ../tmp/vibetv-rc/virtual-vibetv ./cmd/virtual-vibetv
+            for arch in amd64 arm64; do GOOS=darwin GOARCH="$arch" CGO_ENABLED=0 go build -o "../tmp/vibetv-rc/virtual-vibetv-${arch}" ./cmd/virtual-vibetv; done
           )
           lipo -create -output tmp/vibetv-rc/codexbar-display tmp/vibetv-rc/codexbar-display-amd64 tmp/vibetv-rc/codexbar-display-arm64
+          lipo -create -output tmp/vibetv-rc/virtual-vibetv tmp/vibetv-rc/virtual-vibetv-amd64 tmp/vibetv-rc/virtual-vibetv-arm64
+          cp tmp/vibetv-rc/codexbar-display tmp/vibetv-rc/test/codexbar-display
+          cp tmp/vibetv-rc/virtual-vibetv tmp/vibetv-rc/test/virtual-vibetv
+          for arch in amd64 arm64; do cp "tmp/vibetv-rc/codexbar-display-${arch}" "tmp/vibetv-rc/publish/companion/codexbar-display-darwin-${arch}-v${version}"; done
+          cp scripts/install.sh tmp/vibetv-rc/publish/install.sh
+          cp scripts/install-control-center-companion-release.sh tmp/vibetv-rc/publish/install-control-center-companion.sh
+          chmod +x tmp/vibetv-rc/publish/install*.sh
           ./scripts/build-macos-control-center-app.sh --version "$version" --build "$GITHUB_RUN_NUMBER" --universal --companion-binary tmp/vibetv-rc/codexbar-display --output 'dist/macos/VibeTV Control Center.app'
           COPYFILE_DISABLE=1 tar -czf tmp/vibetv-rc/app.tar.gz -C dist/macos 'VibeTV Control Center.app'
-          (
-            cd firmware_esp8266
-            CODEXBAR_DISPLAY_FW_VERSION="$version" pio run -e esp8266_smalltv_st7789
-          )
-          cp firmware_esp8266/.pio/build/esp8266_smalltv_st7789/firmware.bin tmp/vibetv-rc/firmware.bin
-          python3 - "$version" tmp/vibetv-rc/firmware.bin > tmp/vibetv-rc/firmware-manifest.json <<'PY'
-          import hashlib, json, sys
-          version, firmware = sys.argv[1:]
-          with open(firmware, "rb") as source:
-              digest = hashlib.sha256(source.read()).hexdigest()
-          json.dump({"schemaVersion": 1, "release": "v" + version, "artifacts": [{"firmwareEnv": "esp8266_smalltv_st7789", "board": "esp8266-smalltv-st7789", "firmwareVersion": version, "asset": "firmware.bin", "firmwareUrl": "firmware.bin", "sha256": digest}]}, sys.stdout)
-          print()
+          python3 - release/firmware-versions.json > tmp/vibetv-rc/firmware-targets.tsv <<'PY'
+          import json, sys
+          for item in json.load(open(sys.argv[1]))["artifacts"]:
+              env, board, fw = item["firmwareEnv"], item["board"], item["firmwareVersion"]
+              if env == "esp8266_smalltv_st7789": print("firmware_esp8266\t%s\t%s\t%s\tcodexbar-display-firmware-%s-v%s.bin.gz" % (env, board, fw, env, fw))
+              elif env == "lilygo_t_display_s3": print("firmware_esp32\t%s\t%s\t%s\tcodexbar-display-firmware-%s-v%s.bin" % (env, board, fw, env, fw))
+              else: raise SystemExit("unsupported firmware environment: " + env)
           PY
+          while IFS=$'\t' read -r dir env board fw asset; do
+            (cd "$dir" && CODEXBAR_DISPLAY_FW_VERSION="$fw" pio run -e "$env")
+            source="$dir/.pio/build/$env/firmware.bin"
+            if [[ "$env" == esp8266_* ]]; then gzip -c -9 "$source" > "tmp/vibetv-rc/publish/firmware/$asset"; else cp "$source" "tmp/vibetv-rc/publish/firmware/$asset"; fi
+          done < tmp/vibetv-rc/firmware-targets.tsv
+          python3 - "$version" "$GITHUB_REPOSITORY" tmp/vibetv-rc/firmware-targets.tsv tmp/vibetv-rc/publish/firmware > tmp/vibetv-rc/publish/firmware/firmware-manifest.json <<'PY'
+          import hashlib, json, os, sys
+          version, repo, targets, root = sys.argv[1:]
+          entries=[]
+          for line in open(targets, encoding="utf-8"):
+              _, env, board, fw, asset = line.rstrip("\n").split("\t")
+              data=open(os.path.join(root, asset), "rb").read()
+              entries.append({"firmwareEnv":env,"board":board,"firmwareVersion":fw,"asset":asset,"sha256":hashlib.sha256(data).hexdigest(),"firmwareUrl":f"https://github.com/{repo}/releases/download/v{version}/{asset}"})
+          json.dump({"schemaVersion":1,"release":"v"+version,"artifacts":entries}, sys.stdout, indent=2); print()
+          PY
+          cp tmp/vibetv-rc/publish/firmware/firmware-manifest.json "tmp/vibetv-rc/publish/firmware/firmware-manifest-v${version}.json"
           printf '%s\n' "$version" > tmp/vibetv-rc/version.txt
           printf '%s\n' "$GITHUB_SHA" > tmp/vibetv-rc/source-sha.txt
       - uses: actions/upload-artifact@v4
@@ -118,7 +136,7 @@ jobs:
           ./scripts/build-macos-control-center-dmg.sh --app 'dist/macos/VibeTV Control Center.app' --output dist/macos/VibeTV-Control-Center.dmg --staging-dir tmp/vibetv-rc/dmg-stage
           ./scripts/sign-notarize-macos-control-center.sh --app 'dist/macos/VibeTV Control Center.app' --dmg dist/macos/VibeTV-Control-Center.dmg --skip-app-sign
           ./scripts/verify-macos-control-center-dmg.sh --dmg dist/macos/VibeTV-Control-Center.dmg
-      - name: Create signed appcast and candidate-manifest.json
+      - name: Create immutable production publish set and candidate manifest
         env:
           SPARKLE_ED25519_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
           CANDIDATE_RUN_ID: ${{ github.run_id }}
@@ -128,22 +146,21 @@ jobs:
           version="$(cat tmp/vibetv-rc/version.txt)"
           source_sha="$(cat tmp/vibetv-rc/source-sha.txt)"
           sparkle_dir="$(./scripts/fetch-sparkle.sh)"
-          printf '%s' "$SPARKLE_ED25519_PRIVATE_KEY" | "$sparkle_dir/bin/generate_appcast" --ed-key-file - --maximum-deltas 0 --link https://app.vibetv.shop -o dist/macos/appcast.xml dist/macos
-          python3 - "$source_sha" "$version" "$REPOSITORY" "$CANDIDATE_RUN_ID" dist/macos/candidate-manifest.json <<'PY'
+          mkdir -p tmp/vibetv-rc/publish/macos
+          cp dist/macos/VibeTV-Control-Center.dmg tmp/vibetv-rc/publish/macos/VibeTV-Control-Center.dmg
+          printf '%s' "$SPARKLE_ED25519_PRIVATE_KEY" | "$sparkle_dir/bin/generate_appcast" --ed-key-file - --maximum-deltas 0 --link https://app.vibetv.shop --download-url-prefix "https://github.com/${REPOSITORY}/releases/download/v${version}/" -o tmp/vibetv-rc/publish/macos/appcast.xml tmp/vibetv-rc/publish/macos
+          (cd tmp/vibetv-rc/publish && find . -type f -print0 | sort -z | xargs -0 shasum -a 256 > "checksums-v${version}.txt")
+          python3 - "$source_sha" "$version" "$REPOSITORY" "$CANDIDATE_RUN_ID" tmp/vibetv-rc/candidate-manifest.json tmp/vibetv-rc <<'PY'
           import datetime, hashlib, json, sys
-          sha, version, repository, run_id, output = sys.argv[1:]
-          files = [
-              ("VibeTV-Control-Center.dmg", "dist/macos/VibeTV-Control-Center.dmg", "signed-dmg"),
-              ("appcast.xml", "dist/macos/appcast.xml", "sparkle-appcast"),
-              ("codexbar-display", "tmp/vibetv-rc/codexbar-display", "companion"),
-              ("firmware.bin", "tmp/vibetv-rc/firmware.bin", "firmware"),
-              ("firmware-manifest.json", "tmp/vibetv-rc/firmware-manifest.json", "firmware-manifest"),
-              ("virtual-vibetv", "tmp/vibetv-rc/virtual-vibetv", "virtual-vibetv"),
-          ]
+          sha, version, repository, run_id, output, root = sys.argv[1:]
+          from pathlib import Path
+          files = sorted(Path(root).glob("publish/**/*")) + sorted(Path(root).glob("test/**/*"))
           artifacts = []
-          for name, path, role in files:
-              with open(path, "rb") as source:
-                  artifacts.append({"name": name, "path": name, "sha256": hashlib.sha256(source.read()).hexdigest(), "role": role})
+          for path in files:
+              if not path.is_file(): continue
+              relative = path.relative_to(root).as_posix()
+              role = "firmware" if "/firmware/" in relative and relative.endswith((".bin", ".gz")) else "firmware-manifest" if "firmware-manifest" in relative else "signed-dmg" if relative.endswith(".dmg") else "sparkle-appcast" if relative.endswith("appcast.xml") else "installer" if relative.endswith(".sh") else "companion-arch" if "/companion/" in relative else "checksums" if "checksums-" in relative else "virtual-vibetv" if relative.endswith("virtual-vibetv") else "companion"
+              artifacts.append({"name": path.name, "path": relative, "sha256": hashlib.sha256(path.read_bytes()).hexdigest(), "role": role, "publish": relative.startswith("publish/")})
           with open(output, "w", encoding="utf-8") as destination:
               json.dump({
                   "schemaVersion": 1, "repository": repository, "sourceSha": sha, "version": version,
@@ -157,13 +174,9 @@ jobs:
         with:
           name: vibetv-release-candidate
           path: |
-            dist/macos/VibeTV-Control-Center.dmg
-            dist/macos/appcast.xml
-            dist/macos/candidate-manifest.json
-            tmp/vibetv-rc/virtual-vibetv
-            tmp/vibetv-rc/codexbar-display
-            tmp/vibetv-rc/firmware.bin
-            tmp/vibetv-rc/firmware-manifest.json
+            tmp/vibetv-rc/publish
+            tmp/vibetv-rc/test
+            tmp/vibetv-rc/candidate-manifest.json
           retention-days: 7
           compression-level: 0
 
@@ -225,7 +238,7 @@ jobs:
           if [[ '${{ matrix.state }}' != clean_os ]]; then
             baseline_args=(--baseline-dmg baseline.dmg --baseline-appcast baseline-appcast.xml)
           fi
-          ./scripts/test-vibetv-hosted-guest.sh --dmg candidate/VibeTV-Control-Center.dmg --appcast candidate/appcast.xml --virtual-vibetv candidate/virtual-vibetv --companion candidate/codexbar-display --firmware candidate/firmware.bin --firmware-manifest candidate/firmware-manifest.json --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
+          ./scripts/test-vibetv-hosted-guest.sh --dmg candidate/publish/macos/VibeTV-Control-Center.dmg --appcast candidate/publish/macos/appcast.xml --virtual-vibetv candidate/test/virtual-vibetv --companion candidate/test/codexbar-display --firmware candidate/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("release/firmware-versions.json"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789")').bin.gz --firmware-manifest candidate/publish/firmware/firmware-manifest.json --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -259,7 +272,7 @@ jobs:
                   "version": manifest["version"],
                   "candidateRunId": manifest["candidateRunId"],
                   "result": result,
-                  "artifactHashes": manifest["artifacts"],
+                  "artifactHashes": {item["path"]: item["sha256"] for item in manifest["artifacts"]},
               }, destination, indent=2)
               destination.write("\n")
           if result != "success":

--- a/companion/cmd/virtual-vibetv/main.go
+++ b/companion/cmd/virtual-vibetv/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/virtualvibetv"
+)
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:47834", "Companion HTTP listen address")
+	rawAddr := flag.String("raw-addr", "127.0.0.1:8081", "Raw OTA listen address")
+	firmware := flag.String("firmware", "1.0.0", "installed firmware version")
+	candidate := flag.String("candidate-firmware", "1.0.1", "firmware version after a valid OTA")
+	expectedSHA := flag.String("expected-firmware-sha256", "", "optional SHA-256 required for raw OTA uploads")
+	flag.Parse()
+
+	cfg := virtualvibetv.DefaultConfig()
+	cfg.HTTPListenAddr = strings.TrimSpace(*addr)
+	cfg.RawOTAListenAddr = strings.TrimSpace(*rawAddr)
+	cfg.Firmware = strings.TrimSpace(*firmware)
+	cfg.CandidateFirmware = strings.TrimSpace(*candidate)
+	cfg.ExpectedFirmwareSHA256 = strings.TrimSpace(*expectedSHA)
+	running, err := virtualvibetv.Start(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "start Virtual VibeTV: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	fmt.Printf("Virtual VibeTV HTTP=%s rawOTA=%s firmware=%s candidate=%s\n", running.HTTPURL, running.RawOTAURL, cfg.Firmware, cfg.CandidateFirmware)
+	<-ctx.Done()
+	if err := running.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "stop Virtual VibeTV: %v\n", err)
+		os.Exit(1)
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(running.Snapshot()); err != nil {
+		fmt.Fprintf(os.Stderr, "encode Virtual VibeTV snapshot: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/companion/cmd/virtual-vibetv/main_test.go
+++ b/companion/cmd/virtual-vibetv/main_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -18,7 +19,13 @@ func TestCommandServesDedicatedRawOTAAndStopsOnSignal(t *testing.T) {
 	rawAddr := freeLoopbackAddress(t)
 	firmware := []byte("virtual candidate firmware")
 	sum := sha256.Sum256(firmware)
-	command := exec.Command("go", "run", ".",
+	binary := filepath.Join(t.TempDir(), "virtual-vibetv")
+	build := exec.Command("go", "build", "-o", binary, ".")
+	build.Dir = "."
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build virtual VibeTV command: %v\n%s", err, output)
+	}
+	command := exec.Command(binary,
 		"--addr", addr,
 		"--raw-addr", rawAddr,
 		"--firmware", "1.0.0",

--- a/companion/cmd/virtual-vibetv/main_test.go
+++ b/companion/cmd/virtual-vibetv/main_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestCommandServesDedicatedRawOTAAndStopsOnSignal(t *testing.T) {
+	t.Parallel()
+	addr := freeLoopbackAddress(t)
+	rawAddr := freeLoopbackAddress(t)
+	firmware := []byte("virtual candidate firmware")
+	sum := sha256.Sum256(firmware)
+	command := exec.Command("go", "run", ".",
+		"--addr", addr,
+		"--raw-addr", rawAddr,
+		"--firmware", "1.0.0",
+		"--candidate-firmware", "1.0.1",
+		"--expected-firmware-sha256", hex.EncodeToString(sum[:]),
+	)
+	command.Dir = "."
+	var stdout bytes.Buffer
+	command.Stdout = &stdout
+	if err := command.Start(); err != nil {
+		t.Fatalf("start virtual VibeTV command: %v", err)
+	}
+	finished := false
+	t.Cleanup(func() {
+		if !finished {
+			_ = command.Process.Kill()
+			_ = command.Wait()
+		}
+	})
+
+	baseURL := "http://" + addr
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		response, err := http.Get(baseURL + "/health")
+		if err == nil {
+			_ = response.Body.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("virtual VibeTV did not become healthy: %v", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	request, err := http.NewRequest(http.MethodPost, "http://"+rawAddr+"/update/firmware.raw", bytes.NewReader(firmware))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("X-VibeTV-Token", "virtual-pair-token")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("post raw OTA: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("raw OTA status = %s", response.Status)
+	}
+	if err := command.Process.Signal(os.Interrupt); err != nil {
+		t.Fatalf("signal virtual VibeTV: %v", err)
+	}
+	if err := command.Wait(); err != nil {
+		t.Fatalf("graceful virtual VibeTV shutdown: %v", err)
+	}
+	finished = true
+	if !bytes.Contains(stdout.Bytes(), []byte(`"updateUploads":1`)) {
+		t.Fatalf("shutdown snapshot has no OTA evidence: %s", stdout.String())
+	}
+}
+
+func freeLoopbackAddress(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	return listener.Addr().String()
+}

--- a/docs/vibetv-hosted-gates.md
+++ b/docs/vibetv-hosted-gates.md
@@ -1,0 +1,38 @@
+# GitHub-hosted VibeTV gates
+
+`CODEX Test VibeTV Merge` is a manually dispatched, owner-restricted PR gate.
+It resolves the submitted PR to its immutable head SHA, builds that SHA without
+Apple or Sparkle secrets, then checks out the trusted main workflow revision for
+archive extraction, signing, notarization, and status publication. The final
+commit status is `CODEX VibeTV Merge Gate`.
+
+`CODEX Test VibeTV Release Candidate` is also owner-restricted and builds only
+the exact `main` SHA that dispatched it. It creates one signed candidate bundle
+named `vibetv-release-candidate` and `candidate-manifest.json`, freezes `baseline-manifest.json` before the
+matrix starts, and retains all candidate evidence for seven days. Neither
+workflow creates tags, releases, or production endpoints.
+
+`candidate-manifest.json` has schema version `1` and records `repository`,
+`sourceSha`, `version`, `candidateRunId`, `createdAt`, plus named artifact
+entries (`name`, candidate-relative `path`, SHA-256, and role). Its
+`virtualGate` references this Actions run with `result: pending`: the immutable
+candidate bundle is produced before the matrix runs, while the final matrix
+result remains in the separate result artifact instead of rewriting the tested
+candidate.
+
+The matrix uses disposable GitHub-hosted `macos-15` runners for `clean_os`,
+`current_public`, and `previous_public`; it never uses Tart, a self-hosted
+runner, or physical VibeTV hardware. It verifies signed DMGs/apps and signed
+Sparkle metadata, checks the Companion's loopback port `47832`, captures JSON
+and a screenshot, and drives health, render, stream, OTA, and duplicate-OTA
+no-op behavior through the Core branch's `virtual-vibetv` executable.
+
+## Current dependency
+
+The current main branch does not yet contain Issue #177 Core's
+`companion/cmd/virtual-vibetv`. Both build jobs fail with that precise message
+until the Core is integrated. The candidate app currently has no test-only
+Sparkle feed override, so the hosted v1 validates the signed candidate appcast
+and public baseline appcast but cannot force a live Sparkle download from a
+private Actions artifact. Adding that override belongs with the Core/update
+interface; no production feed is changed or invented here.

--- a/scripts/build-sparkle-cli.sh
+++ b/scripts/build-sparkle-cli.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMIT='6276ba2b404829d139c45ff98427cf90e2efc59b'
+REPOSITORY='https://github.com/sparkle-project/Sparkle.git'
+OUTPUT=''
+while [[ $# -gt 0 ]]; do
+  case "$1" in --output) OUTPUT="${2:-}"; shift 2 ;; *) echo "error: unknown argument: $1" >&2; exit 1 ;; esac
+done
+[[ -n "$OUTPUT" && ! -e "$OUTPUT" ]] || { echo 'error: --output must be a new directory' >&2; exit 1; }
+[[ "$(uname -s)" == Darwin ]] || { echo 'error: Sparkle CLI build requires macOS/xcodebuild' >&2; exit 1; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/sparkle-cli.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+git init -q "$work/source"
+git -C "$work/source" remote add origin "$REPOSITORY"
+git -C "$work/source" fetch -q --depth=1 origin "$COMMIT"
+[[ "$(git -C "$work/source" rev-parse HEAD)" == "$COMMIT" ]] || { echo 'error: Sparkle source commit mismatch' >&2; exit 1; }
+xcodebuild -project "$work/source/Sparkle.xcodeproj" -scheme sparkle-cli -configuration Release -derivedDataPath "$work/derived" CODE_SIGNING_ALLOWED=NO build >/dev/null
+cli="$(find "$work/derived" -type f -path '*/sparkle.app/Contents/MacOS/sparkle' -print -quit)"
+[[ -x "$cli" ]] || { echo 'error: pinned Sparkle source did not build sparkle CLI' >&2; exit 1; }
+mkdir -p "$OUTPUT"; ditto "$(dirname "$(dirname "$(dirname "$cli")")")" "$OUTPUT/sparkle.app"
+printf 'Sparkle CLI source commit: %s\n' "$COMMIT"

--- a/scripts/extract-vibetv-candidate-app.sh
+++ b/scripts/extract-vibetv-candidate-app.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCHIVE=""
+OUTPUT=""
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --archive) [[ -n "${2:-}" ]] || die '--archive needs a value'; ARCHIVE="$2"; shift 2 ;;
+    --output) [[ -n "${2:-}" ]] || die '--output needs a value'; OUTPUT="$2"; shift 2 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -f "$ARCHIVE" ]] || die "candidate app archive not found: $ARCHIVE"
+[[ -n "$OUTPUT" && "$OUTPUT" != / ]] || die 'safe --output directory is required'
+[[ ! -e "$OUTPUT" ]] || die "output path must not exist: $OUTPUT"
+
+python3 - "$ARCHIVE" "$OUTPUT" <<'PY'
+import pathlib
+import shutil
+import sys
+import tarfile
+
+archive = pathlib.Path(sys.argv[1])
+output = pathlib.Path(sys.argv[2])
+expected_root = "VibeTV Control Center.app"
+
+with tarfile.open(archive, "r:gz") as candidate:
+    members = candidate.getmembers()
+    if not members:
+        raise SystemExit("candidate app archive is empty")
+    for member in members:
+        path = pathlib.PurePosixPath(member.name)
+        if path.is_absolute() or ".." in path.parts:
+            raise SystemExit(f"unsafe candidate archive path: {member.name}")
+        if not path.parts or path.parts[0] != expected_root:
+            raise SystemExit(f"unexpected candidate archive root: {member.name}")
+        if not (member.isdir() or member.isfile()):
+            raise SystemExit(f"candidate archive contains a non-regular entry: {member.name}")
+    output.mkdir(parents=True)
+    candidate.extractall(output)
+
+app = output / expected_root
+if not (app / "Contents" / "Info.plist").is_file():
+    shutil.rmtree(output)
+    raise SystemExit("candidate archive has no valid app Info.plist")
+PY
+
+printf 'Safely extracted candidate app archive: %s\n' "$OUTPUT"

--- a/scripts/resolve-vibetv-public-baselines.sh
+++ b/scripts/resolve-vibetv-public-baselines.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT=""
+REPOSITORY="${GITHUB_REPOSITORY:-DreamyTalesPAN/CodexBar-Display}"
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output) [[ -n "${2:-}" ]] || die '--output needs a value'; OUTPUT="$2"; shift 2 ;;
+    --repository) [[ -n "${2:-}" ]] || die '--repository needs a value'; REPOSITORY="$2"; shift 2 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$OUTPUT" ]] || die '--output is required'
+command -v gh >/dev/null 2>&1 || die 'gh is required to resolve public release baselines'
+
+mkdir -p "$(dirname "$OUTPUT")"
+gh api --paginate "/repos/${REPOSITORY}/releases?per_page=100" > "${OUTPUT}.releases.json"
+python3 - "${OUTPUT}.releases.json" "$OUTPUT" "$REPOSITORY" <<'PY'
+import json
+import re
+import sys
+from datetime import datetime, timezone
+
+releases_path, output_path, repository = sys.argv[1:]
+with open(releases_path, encoding="utf-8") as source:
+    releases = json.load(source)
+
+semver = re.compile(r"^v?(\d+\.\d+\.\d+(?:[-.][0-9A-Za-z.-]+)?)$")
+eligible = []
+for release in releases:
+    if release.get("draft") or release.get("prerelease"):
+        continue
+    match = semver.fullmatch(str(release.get("tag_name", "")).strip())
+    if not match:
+        continue
+    assets = {asset.get("name"): asset.get("browser_download_url") for asset in release.get("assets", [])}
+    dmg = assets.get("VibeTV-Control-Center.dmg")
+    appcast = assets.get("appcast.xml")
+    if dmg and appcast:
+        eligible.append({
+            "tag": release["tag_name"],
+            "version": match.group(1),
+            "dmgUrl": dmg,
+            "appcastUrl": appcast,
+            "publishedAt": release.get("published_at"),
+        })
+
+if len(eligible) < 2:
+    raise SystemExit("need two public releases with VibeTV-Control-Center.dmg and appcast.xml")
+
+manifest = {
+    "schemaVersion": 1,
+    "repository": repository,
+    "resolvedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    "baselines": {
+        "current_public": eligible[0],
+        "previous_public": eligible[1],
+    },
+}
+with open(output_path, "w", encoding="utf-8") as destination:
+    json.dump(manifest, destination, indent=2)
+    destination.write("\n")
+PY
+rm -f "${OUTPUT}.releases.json"
+printf 'Resolved frozen VibeTV public baselines: %s\n' "$OUTPUT"

--- a/scripts/resolve-vibetv-public-baselines.sh
+++ b/scripts/resolve-vibetv-public-baselines.sh
@@ -43,12 +43,14 @@ for release in releases:
     assets = {asset.get("name"): asset.get("browser_download_url") for asset in release.get("assets", [])}
     dmg = assets.get("VibeTV-Control-Center.dmg")
     appcast = assets.get("appcast.xml")
-    if dmg and appcast:
+    firmware_manifest = assets.get("firmware-manifest.json")
+    if dmg and appcast and firmware_manifest:
         eligible.append({
             "tag": release["tag_name"],
             "version": match.group(1),
             "dmgUrl": dmg,
             "appcastUrl": appcast,
+            "firmwareManifestUrl": firmware_manifest,
             "publishedAt": release.get("published_at"),
         })
 

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -182,6 +182,10 @@ main() {
     'release candidate must enforce the release firmware size budgets'
   assert_contains "$RC_WORKFLOW" 'shasum -a 256 -c "checksums-v${version}.txt"' \
     'release candidate must verify its publish checksum asset before upload'
+  assert_contains "$RC_WORKFLOW" "kind + 'Sha256'" \
+    'release candidate must freeze public baseline DMG hashes'
+  assert_contains "$RC_WORKFLOW" 'baselines/${{ matrix.state }}.dmg' \
+    'guest matrix must consume the frozen baseline bytes'
   assert_contains "$RC_WORKFLOW" '"protocolVersion":config.get' \
     'release candidate must preserve release firmware protocol metadata'
   assert_contains "$SPARKLE_BUILDER" '6276ba2b404829d139c45ff98427cf90e2efc59b' \

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -7,6 +7,7 @@ MERGE_WORKFLOW="${ROOT}/.github/workflows/vibetv-merge-gate.yml"
 RC_WORKFLOW="${ROOT}/.github/workflows/vibetv-release-candidate.yml"
 EXTRACTOR="${ROOT}/scripts/extract-vibetv-candidate-app.sh"
 GUEST_TEST="${ROOT}/scripts/test-vibetv-hosted-guest.sh"
+SPARKLE_BUILDER="${ROOT}/scripts/build-sparkle-cli.sh"
 
 die() {
   printf 'error: %s\n' "$*" >&2
@@ -75,6 +76,7 @@ main() {
   assert_file "$RC_WORKFLOW"
   assert_file "$EXTRACTOR"
   assert_file "$GUEST_TEST"
+  assert_file "$SPARKLE_BUILDER"
 
   assert_contains "$CI_WORKFLOW" 'codex-ci:' \
     'CI needs one stable CODEX CI aggregation job'
@@ -131,6 +133,10 @@ main() {
     'release candidate must emit an immutable candidate manifest'
   assert_contains "$RC_WORKFLOW" 'name: vibetv-release-candidate' \
     'release candidate artifact name must remain stable for downstream gates'
+  for required in publish/ test/ install.sh install-control-center-companion.sh checksums-v firmware-versions.json 'download/v${version}' '"publish"'; do
+    assert_contains "$RC_WORKFLOW" "$required" \
+      "release candidate must build the full publish asset set including ${required}"
+  done
   for field in repository sourceSha version candidateRunId createdAt virtualGate; do
     assert_contains "$RC_WORKFLOW" "\"${field}\"" \
       "candidate manifest must include ${field}"
@@ -145,7 +151,7 @@ main() {
   done
   assert_not_contains "$RC_WORKFLOW" 'self-hosted' \
     'release candidate must not depend on a self-hosted runner'
-  assert_not_contains "$RC_WORKFLOW" 'tart' \
+  assert_not_contains "$RC_WORKFLOW" 'Tart' \
     'release candidate must not use Tart'
 
   assert_contains "$GUEST_TEST" 'verify-macos-control-center-dmg.sh' \
@@ -160,10 +166,16 @@ main() {
     'direct guest test must preserve a macOS screenshot artifact'
   assert_contains "$GUEST_TEST" '/Applications/VibeTV Control Center.app' \
     'guest test must install the baseline or candidate app in Applications'
-  assert_contains "$GUEST_TEST" 'sparkle bundle' \
+  assert_contains "$GUEST_TEST" '--user-agent-name' \
     'guest test must run the official Sparkle CLI instead of parsing XML'
   assert_contains "$GUEST_TEST" '--check-immediately' \
     'guest test must force a live Sparkle update check'
+  assert_contains "$GUEST_TEST" 'gzip -cd' \
+    'guest test must hash the raw firmware bytes sent through OTA'
+  assert_contains "$RC_WORKFLOW" 'artifactHashes": {item["path"]' \
+    'candidate result must expose publish validators a path-to-hash map'
+  assert_contains "$SPARKLE_BUILDER" '6276ba2b404829d139c45ff98427cf90e2efc59b' \
+    'Sparkle CLI source must be pinned to the reviewed upstream commit'
   assert_contains "$GUEST_TEST" 'CANDIDATE_COMPANION' \
     'guest test must select the installed candidate companion for OTA'
   assert_contains "$GUEST_TEST" 'install-update --target' \

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -180,6 +180,8 @@ main() {
     'candidate result must expose publish validators a path-to-hash map'
   assert_contains "$RC_WORKFLOW" 'check-firmware-size-budget.sh' \
     'release candidate must enforce the release firmware size budgets'
+  assert_contains "$RC_WORKFLOW" 'shasum -a 256 -c "checksums-v${version}.txt"' \
+    'release candidate must verify its publish checksum asset before upload'
   assert_contains "$RC_WORKFLOW" '"protocolVersion":config.get' \
     'release candidate must preserve release firmware protocol metadata'
   assert_contains "$SPARKLE_BUILDER" '6276ba2b404829d139c45ff98427cf90e2efc59b' \

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -101,6 +101,8 @@ main() {
     'only the trusted status job may write the merge-gate commit status'
   assert_contains "$MERGE_WORKFLOW" 'runs-on: macos-15' \
     'merge gate must run its direct macOS checks on GitHub-hosted macOS 15'
+  assert_contains "$MERGE_WORKFLOW" '9999.0.${GITHUB_RUN_NUMBER}' \
+    'merge candidate must always sort above public releases for Sparkle'
   assert_contains "$MERGE_WORKFLOW" 'clean_os' \
     'merge gate must cover a clean macOS customer state'
   assert_contains "$MERGE_WORKFLOW" 'current_public' \
@@ -135,6 +137,12 @@ main() {
   done
   assert_contains "$RC_WORKFLOW" 'retention-days: 7' \
     'release candidate artifacts and reports must remain available for seven days'
+  assert_contains "$RC_WORKFLOW" 'name: vibetv-release-candidate-result' \
+    'release candidate result artifact name must remain stable for publish gates'
+  for field in artifactHashes candidate-result.json 'result = "success"'; do
+    assert_contains "$RC_WORKFLOW" "$field" \
+      "candidate result must include ${field}"
+  done
   assert_not_contains "$RC_WORKFLOW" 'self-hosted' \
     'release candidate must not depend on a self-hosted runner'
   assert_not_contains "$RC_WORKFLOW" 'tart' \
@@ -150,6 +158,18 @@ main() {
     'direct guest test must prove no-op firmware behavior'
   assert_contains "$GUEST_TEST" 'screencapture' \
     'direct guest test must preserve a macOS screenshot artifact'
+  assert_contains "$GUEST_TEST" '/Applications/VibeTV Control Center.app' \
+    'guest test must install the baseline or candidate app in Applications'
+  assert_contains "$GUEST_TEST" 'sparkle bundle' \
+    'guest test must run the official Sparkle CLI instead of parsing XML'
+  assert_contains "$GUEST_TEST" '--check-immediately' \
+    'guest test must force a live Sparkle update check'
+  assert_contains "$GUEST_TEST" 'CANDIDATE_COMPANION' \
+    'guest test must select the installed candidate companion for OTA'
+  assert_contains "$GUEST_TEST" 'install-update --target' \
+    'guest test must use the bundled candidate companion for OTA'
+  assert_contains "$GUEST_TEST" 'daemon --transport wifi' \
+    'guest test must exercise the bundled candidate companion render path'
 
   assert_safe_app_extractor
   printf 'PASS: hosted VibeTV merge and release-candidate gate contracts\n'

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CI_WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+MERGE_WORKFLOW="${ROOT}/.github/workflows/vibetv-merge-gate.yml"
+RC_WORKFLOW="${ROOT}/.github/workflows/vibetv-release-candidate.yml"
+EXTRACTOR="${ROOT}/scripts/extract-vibetv-candidate-app.sh"
+GUEST_TEST="${ROOT}/scripts/test-vibetv-hosted-guest.sh"
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_file() {
+  [[ -f "$1" ]] || die "missing required file: $1"
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local message="$3"
+  grep -Fq -- "$needle" "$file" || die "$message"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  local message="$3"
+  ! grep -Fq -- "$needle" "$file" || die "$message"
+}
+
+job_block() {
+  local workflow="$1"
+  local job="$2"
+  awk -v job="$job" '
+    $0 == "  " job ":" { in_job = 1; print; next }
+    in_job && $0 ~ /^  [A-Za-z0-9_-]+:/ { exit }
+    in_job { print }
+  ' "$workflow"
+}
+
+assert_safe_app_extractor() {
+  local work
+  work="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-hosted-gate.XXXXXX")"
+  trap 'rm -rf "${work:-}"' RETURN
+
+  mkdir -p "$work/safe/VibeTV Control Center.app/Contents"
+  printf '<plist version="1.0"><dict/></plist>\n' > "$work/safe/VibeTV Control Center.app/Contents/Info.plist"
+  COPYFILE_DISABLE=1 tar -czf "$work/safe.tar.gz" -C "$work/safe" "VibeTV Control Center.app"
+  "$EXTRACTOR" --archive "$work/safe.tar.gz" --output "$work/extracted" >/dev/null
+  [[ -f "$work/extracted/VibeTV Control Center.app/Contents/Info.plist" ]] \
+    || die "safe candidate archive was not extracted"
+
+  python3 - "$work/unsafe.tar.gz" <<'PY'
+import io
+import sys
+import tarfile
+
+with tarfile.open(sys.argv[1], "w:gz") as archive:
+    member = tarfile.TarInfo("../../escape")
+    payload = b"unsafe"
+    member.size = len(payload)
+    archive.addfile(member, io.BytesIO(payload))
+PY
+  if "$EXTRACTOR" --archive "$work/unsafe.tar.gz" --output "$work/unsafe" >/dev/null 2>&1; then
+    die "unsafe candidate archive path was accepted"
+  fi
+}
+
+main() {
+  assert_file "$CI_WORKFLOW"
+  assert_file "$MERGE_WORKFLOW"
+  assert_file "$RC_WORKFLOW"
+  assert_file "$EXTRACTOR"
+  assert_file "$GUEST_TEST"
+
+  assert_contains "$CI_WORKFLOW" 'codex-ci:' \
+    'CI needs one stable CODEX CI aggregation job'
+  assert_contains "$CI_WORKFLOW" 'name: CODEX CI' \
+    'stable aggregation status must be named CODEX CI'
+  assert_contains "$CI_WORKFLOW" 'if: always()' \
+    'CODEX CI must report failure even when an upstream job fails'
+
+  assert_contains "$MERGE_WORKFLOW" 'name: CODEX Test VibeTV Merge' \
+    'merge gate workflow needs the stable CODEX name'
+  assert_contains "$MERGE_WORKFLOW" 'pr_number:' \
+    'merge gate must accept an explicit pull request number'
+  assert_contains "$MERGE_WORKFLOW" 'pulls/${pr_number}' \
+    'merge gate must resolve the pull request through GitHub before building'
+  assert_contains "$MERGE_WORKFLOW" 'get("head", {}).get("sha"' \
+    'merge gate must use the exact pull request head SHA'
+  assert_contains "$MERGE_WORKFLOW" 'persist-credentials: false' \
+    'untrusted source checkouts must not persist GitHub credentials'
+  assert_contains "$MERGE_WORKFLOW" 'ref: ${{ github.workflow_sha }}' \
+    'secret-bearing merge jobs must run trusted main workflow code'
+  assert_contains "$MERGE_WORKFLOW" 'CODEX VibeTV Merge Gate' \
+    'merge gate must publish its stable commit status context'
+  assert_contains "$MERGE_WORKFLOW" 'statuses: write' \
+    'only the trusted status job may write the merge-gate commit status'
+  assert_contains "$MERGE_WORKFLOW" 'runs-on: macos-15' \
+    'merge gate must run its direct macOS checks on GitHub-hosted macOS 15'
+  assert_contains "$MERGE_WORKFLOW" 'clean_os' \
+    'merge gate must cover a clean macOS customer state'
+  assert_contains "$MERGE_WORKFLOW" 'current_public' \
+    'merge gate must cover the current public customer state'
+  assert_contains "$MERGE_WORKFLOW" 'previous_public' \
+    'merge gate must cover the previous public customer state'
+  assert_not_contains "$MERGE_WORKFLOW" 'self-hosted' \
+    'merge gate must not depend on a self-hosted runner'
+  assert_not_contains "$MERGE_WORKFLOW" 'tart' \
+    'merge gate must not use Tart'
+
+  local untrusted_build
+  untrusted_build="$(job_block "$MERGE_WORKFLOW" 'build-untrusted')"
+  [[ -n "$untrusted_build" ]] || die 'merge workflow needs a build-untrusted job'
+  [[ "$untrusted_build" != *'secrets.'* ]] || die 'untrusted PR build must not receive signing secrets'
+  [[ "$untrusted_build" != *'SPARKLE_ED25519_PRIVATE_KEY'* ]] \
+    || die 'untrusted PR build must not receive the Sparkle signing key'
+
+  assert_contains "$RC_WORKFLOW" 'name: CODEX Test VibeTV Release Candidate' \
+    'release-candidate workflow needs the stable CODEX name'
+  assert_contains "$RC_WORKFLOW" 'version:' \
+    'release-candidate workflow must require a candidate version'
+  assert_contains "$RC_WORKFLOW" 'ref: ${{ github.sha }}' \
+    'release candidate must build the exact main SHA that dispatched it'
+  assert_contains "$RC_WORKFLOW" 'candidate-manifest.json' \
+    'release candidate must emit an immutable candidate manifest'
+  assert_contains "$RC_WORKFLOW" 'name: vibetv-release-candidate' \
+    'release candidate artifact name must remain stable for downstream gates'
+  for field in repository sourceSha version candidateRunId createdAt virtualGate; do
+    assert_contains "$RC_WORKFLOW" "\"${field}\"" \
+      "candidate manifest must include ${field}"
+  done
+  assert_contains "$RC_WORKFLOW" 'retention-days: 7' \
+    'release candidate artifacts and reports must remain available for seven days'
+  assert_not_contains "$RC_WORKFLOW" 'self-hosted' \
+    'release candidate must not depend on a self-hosted runner'
+  assert_not_contains "$RC_WORKFLOW" 'tart' \
+    'release candidate must not use Tart'
+
+  assert_contains "$GUEST_TEST" 'verify-macos-control-center-dmg.sh' \
+    'direct guest test must verify the signed and notarized DMG'
+  assert_contains "$GUEST_TEST" '47832' \
+    'direct guest test must check the Companion port'
+  assert_contains "$GUEST_TEST" 'virtual-vibetv' \
+    'direct guest test must exercise the Virtual VibeTV interface'
+  assert_contains "$GUEST_TEST" 'no-op' \
+    'direct guest test must prove no-op firmware behavior'
+  assert_contains "$GUEST_TEST" 'screencapture' \
+    'direct guest test must preserve a macOS screenshot artifact'
+
+  assert_safe_app_extractor
+  printf 'PASS: hosted VibeTV merge and release-candidate gate contracts\n'
+}
+
+main "$@"

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -170,10 +170,18 @@ main() {
     'guest test must run the official Sparkle CLI instead of parsing XML'
   assert_contains "$GUEST_TEST" '--check-immediately' \
     'guest test must force a live Sparkle update check'
+  assert_contains "$GUEST_TEST" 'baseline app did not start' \
+    'guest test must start the public baseline before Sparkle'
+  assert_contains "$GUEST_TEST" 'replace and relaunch' \
+    'guest test must require a replacement Candidate process after Sparkle'
   assert_contains "$GUEST_TEST" 'gzip -cd' \
     'guest test must hash the raw firmware bytes sent through OTA'
   assert_contains "$RC_WORKFLOW" 'artifactHashes": {item["path"]' \
     'candidate result must expose publish validators a path-to-hash map'
+  assert_contains "$RC_WORKFLOW" 'check-firmware-size-budget.sh' \
+    'release candidate must enforce the release firmware size budgets'
+  assert_contains "$RC_WORKFLOW" '"protocolVersion":config.get' \
+    'release candidate must preserve release firmware protocol metadata'
   assert_contains "$SPARKLE_BUILDER" '6276ba2b404829d139c45ff98427cf90e2efc59b' \
     'Sparkle CLI source must be pinned to the reviewed upstream commit'
   assert_contains "$GUEST_TEST" 'CANDIDATE_COMPANION' \

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -91,12 +91,25 @@ else
   [[ -d "$BASELINE_APP" ]] || die 'baseline DMG has no app'
   ditto "$BASELINE_APP" "$INSTALL_APP"
   plutil -extract CFBundleShortVersionString raw -o - "$INSTALL_APP/Contents/Info.plist" > "$OUTPUT/baseline-version.txt"
+  open -na "$INSTALL_APP"
+  sleep 2
+  BASELINE_PID="$(pgrep -f "$INSTALL_APP/Contents/MacOS/VibeTVControlCenter" | head -n1)"
+  [[ -n "$BASELINE_PID" ]] || die 'baseline app did not start before Sparkle replacement'
+  printf '%s\n' "$BASELINE_PID" > "$OUTPUT/baseline-pid.txt"
   # Sparkle's official CLI is intentionally mandatory. Do not downgrade this
   # to XML parsing: if the hosted image lacks it, the gate must fail loudly.
   "$ROOT/scripts/build-sparkle-cli.sh" --output "$WORK/sparkle-cli" > "$OUTPUT/sparkle-cli-provenance.txt"
   SPARKLE_CLI="${SPARKLE_CLI:-$WORK/sparkle-cli/sparkle.app/Contents/MacOS/sparkle}"
   [[ -x "$SPARKLE_CLI" ]] || die "official Sparkle CLI is unavailable at ${SPARKLE_CLI}; cannot prove Sparkle update"
   "$SPARKLE_CLI" --check-immediately --feed-url "$SERVER_URL/appcast.xml" --user-agent-name 'CODEX VibeTV RC' "$INSTALL_APP" > "$OUTPUT/sparkle-update.txt" 2>&1
+  deadline=$((SECONDS + 45)); CANDIDATE_PID=''
+  while (( SECONDS < deadline )); do
+    CANDIDATE_PID="$(pgrep -f "$INSTALL_APP/Contents/MacOS/VibeTVControlCenter" | head -n1 || true)"
+    [[ -n "$CANDIDATE_PID" && "$CANDIDATE_PID" != "$BASELINE_PID" ]] && break
+    sleep 1
+  done
+  [[ -n "$CANDIDATE_PID" && "$CANDIDATE_PID" != "$BASELINE_PID" ]] || die 'Sparkle did not replace and relaunch the candidate app'
+  printf '%s\n' "$CANDIDATE_PID" > "$OUTPUT/candidate-pid.txt"
 fi
 
 plutil -extract CFBundleShortVersionString raw -o - "$INSTALL_APP/Contents/Info.plist" > "$OUTPUT/installed-candidate-version.txt"

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -71,6 +71,16 @@ for _ in $(seq 1 30); do [[ -s "$WORK/serve/port" ]] && break; sleep 1; done
 [[ -s "$WORK/serve/port" ]] || die 'local candidate artifact server did not start'
 PORT="$(cat "$WORK/serve/port")"
 SERVER_URL="http://127.0.0.1:${PORT}"
+python3 - "$WORK/serve/appcast.xml" "$SERVER_URL/VibeTV-Control-Center.dmg" <<'PY'
+import sys
+path, url = sys.argv[1:]
+data = open(path, encoding="utf-8").read()
+start = 'https://github.com/'
+if start not in data: raise SystemExit('production appcast has no GitHub enclosure URL')
+before, _, rest = data.partition(start)
+_, _, tail = rest.partition('/VibeTV-Control-Center.dmg')
+open(path, 'w', encoding='utf-8').write(before + url + tail)
+PY
 
 if [[ "$STATE" == clean_os ]]; then
   ditto "$CANDIDATE_APP" "$INSTALL_APP"
@@ -83,11 +93,10 @@ else
   plutil -extract CFBundleShortVersionString raw -o - "$INSTALL_APP/Contents/Info.plist" > "$OUTPUT/baseline-version.txt"
   # Sparkle's official CLI is intentionally mandatory. Do not downgrade this
   # to XML parsing: if the hosted image lacks it, the gate must fail loudly.
-  sparkle_dir="$("$ROOT/scripts/fetch-sparkle.sh")"
-  SPARKLE_CLI="${SPARKLE_CLI:-${sparkle_dir}/bin/sparkle}"
+  "$ROOT/scripts/build-sparkle-cli.sh" --output "$WORK/sparkle-cli" > "$OUTPUT/sparkle-cli-provenance.txt"
+  SPARKLE_CLI="${SPARKLE_CLI:-$WORK/sparkle-cli/sparkle.app/Contents/MacOS/sparkle}"
   [[ -x "$SPARKLE_CLI" ]] || die "official Sparkle CLI is unavailable at ${SPARKLE_CLI}; cannot prove Sparkle update"
-  # Official Sparkle CLI: sparkle bundle APP --check-immediately --feed-url URL.
-  "$SPARKLE_CLI" bundle "$INSTALL_APP" --check-immediately --feed-url "$SERVER_URL/appcast.xml" > "$OUTPUT/sparkle-update.txt" 2>&1
+  "$SPARKLE_CLI" --check-immediately --feed-url "$SERVER_URL/appcast.xml" --user-agent-name 'CODEX VibeTV RC' "$INSTALL_APP" > "$OUTPUT/sparkle-update.txt" 2>&1
 fi
 
 plutil -extract CFBundleShortVersionString raw -o - "$INSTALL_APP/Contents/Info.plist" > "$OUTPUT/installed-candidate-version.txt"
@@ -101,8 +110,10 @@ manifest = json.load(open(source, encoding="utf-8"))
 for artifact in manifest.get("artifacts", []): artifact["firmwareUrl"] = url
 json.dump(manifest, open(output, "w", encoding="utf-8"), indent=2)
 PY
-firmware_sha="$(shasum -a 256 "$FIRMWARE" | awk '{print $1}')"
-"$VIRTUAL_VIBETV" --addr 127.0.0.1:47834 --raw-addr 127.0.0.1:8081 --firmware 0.0.0 --candidate-firmware "$VERSION" --expected-firmware-sha256 "$firmware_sha" > "$OUTPUT/virtual-vibetv.log" 2>&1 & VIRTUAL_PID=$!
+candidate_firmware="$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("'"$FIRMWARE_MANIFEST"'"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789"))')"
+RAW_FIRMWARE="$WORK/firmware.bin"; gzip -cd "$FIRMWARE" > "$RAW_FIRMWARE"
+firmware_sha="$(shasum -a 256 "$RAW_FIRMWARE" | awk '{print $1}')"
+"$VIRTUAL_VIBETV" --addr 127.0.0.1:47834 --raw-addr 127.0.0.1:8081 --firmware 0.0.0 --candidate-firmware "$candidate_firmware" --expected-firmware-sha256 "$firmware_sha" > "$OUTPUT/virtual-vibetv.log" 2>&1 & VIRTUAL_PID=$!
 for _ in $(seq 1 30); do curl --fail --silent "$SERVER_URL/firmware-manifest.json" >/dev/null && curl --fail --silent http://127.0.0.1:47834/health > "$OUTPUT/virtual-health-before.json" && break; sleep 1; done
 [[ -s "$OUTPUT/virtual-health-before.json" ]] || die 'Virtual VibeTV did not become healthy'
 CANDIDATE_COMPANION="$INSTALL_APP/Contents/Helpers/codexbar-display"

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 INSTALL_APP='/Applications/VibeTV Control Center.app'
 DMG="" APPCAST="" VIRTUAL_VIBETV="" COMPANION="" FIRMWARE="" FIRMWARE_MANIFEST="" VERSION="" STATE="" OUTPUT=""
 BASELINE_DMG="" BASELINE_APPCAST=""
+CURRENT_FIRMWARE='0.0.0'
 
 die() { printf 'error: %s\n' "$*" >&2; exit 1; }
 while [[ $# -gt 0 ]]; do
@@ -14,6 +15,7 @@ while [[ $# -gt 0 ]]; do
     --firmware) FIRMWARE="${2:-}"; shift 2 ;; --firmware-manifest) FIRMWARE_MANIFEST="${2:-}"; shift 2 ;;
     --version) VERSION="${2#v}"; shift 2 ;; --state) STATE="${2:-}"; shift 2 ;;
     --output) OUTPUT="${2:-}"; shift 2 ;; --baseline-dmg) BASELINE_DMG="${2:-}"; shift 2 ;;
+    --current-firmware) CURRENT_FIRMWARE="${2#v}"; shift 2 ;;
     --baseline-appcast) BASELINE_APPCAST="${2:-}"; shift 2 ;; *) die "unknown argument: $1" ;;
   esac
 done
@@ -124,9 +126,15 @@ for artifact in manifest.get("artifacts", []): artifact["firmwareUrl"] = url
 json.dump(manifest, open(output, "w", encoding="utf-8"), indent=2)
 PY
 candidate_firmware="$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("'"$FIRMWARE_MANIFEST"'"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789"))')"
+expected_uploads="$(python3 - "$CURRENT_FIRMWARE" "$candidate_firmware" <<'PY'
+import sys
+def key(value): return tuple(int(part) for part in value.split('-')[0].split('.'))
+print(1 if key(sys.argv[2]) > key(sys.argv[1]) else 0)
+PY
+)"
 RAW_FIRMWARE="$WORK/firmware.bin"; gzip -cd "$FIRMWARE" > "$RAW_FIRMWARE"
 firmware_sha="$(shasum -a 256 "$RAW_FIRMWARE" | awk '{print $1}')"
-"$VIRTUAL_VIBETV" --addr 127.0.0.1:47834 --raw-addr 127.0.0.1:8081 --firmware 0.0.0 --candidate-firmware "$candidate_firmware" --expected-firmware-sha256 "$firmware_sha" > "$OUTPUT/virtual-vibetv.log" 2>&1 & VIRTUAL_PID=$!
+"$VIRTUAL_VIBETV" --addr 127.0.0.1:47834 --raw-addr 127.0.0.1:8081 --firmware "$CURRENT_FIRMWARE" --candidate-firmware "$candidate_firmware" --expected-firmware-sha256 "$firmware_sha" > "$OUTPUT/virtual-vibetv.log" 2>&1 & VIRTUAL_PID=$!
 for _ in $(seq 1 30); do curl --fail --silent "$SERVER_URL/firmware-manifest.json" >/dev/null && curl --fail --silent http://127.0.0.1:47834/health > "$OUTPUT/virtual-health-before.json" && break; sleep 1; done
 [[ -s "$OUTPUT/virtual-health-before.json" ]] || die 'Virtual VibeTV did not become healthy'
 CANDIDATE_COMPANION="$INSTALL_APP/Contents/Helpers/codexbar-display"
@@ -135,10 +143,10 @@ CANDIDATE_COMPANION="$INSTALL_APP/Contents/Helpers/codexbar-display"
 grep -F 'Firmware: already current' "$OUTPUT/candidate-already-current.txt" >/dev/null || die 'candidate companion did not prove already_current'
 "$CANDIDATE_COMPANION" daemon --transport wifi --target http://127.0.0.1:47834 --once --api-addr 127.0.0.1:47832 > "$OUTPUT/candidate-daemon-once.txt" 2>&1
 curl --fail --silent http://127.0.0.1:47834/__virtual/state > "$OUTPUT/virtual-state.json"
-python3 - "$OUTPUT/virtual-state.json" <<'PY'
+python3 - "$OUTPUT/virtual-state.json" "$expected_uploads" <<'PY'
 import json, sys
 state = json.load(open(sys.argv[1], encoding="utf-8"))
-if state.get("updateUploads") != 1 or state.get("violations") or state.get("framesAccepted", 0) < 1:
+if state.get("updateUploads") != int(sys.argv[2]) or state.get("violations") or state.get("framesAccepted", 0) < 1:
     raise SystemExit("candidate companion did not complete raw OTA/render/no-op sequence")
 if not any(event.get("path") == "/update/firmware.raw" for event in state.get("events", [])):
     raise SystemExit("candidate companion did not use Raw OTA port 8081")

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -2,182 +2,127 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-DMG=""
-APPCAST=""
-VIRTUAL_VIBETV=""
-FIRMWARE=""
-VERSION=""
-STATE=""
-OUTPUT=""
-BASELINE_DMG=""
-BASELINE_APPCAST=""
+INSTALL_APP='/Applications/VibeTV Control Center.app'
+DMG="" APPCAST="" VIRTUAL_VIBETV="" COMPANION="" FIRMWARE="" FIRMWARE_MANIFEST="" VERSION="" STATE="" OUTPUT=""
+BASELINE_DMG="" BASELINE_APPCAST=""
 
-die() {
-  printf 'error: %s\n' "$*" >&2
-  exit 1
-}
-
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dmg) DMG="${2:-}"; shift 2 ;;
-    --appcast) APPCAST="${2:-}"; shift 2 ;;
-    --virtual-vibetv) VIRTUAL_VIBETV="${2:-}"; shift 2 ;;
-    --firmware) FIRMWARE="${2:-}"; shift 2 ;;
-    --version) VERSION="${2#v}"; shift 2 ;;
-    --state) STATE="${2:-}"; shift 2 ;;
-    --output) OUTPUT="${2:-}"; shift 2 ;;
-    --baseline-dmg) BASELINE_DMG="${2:-}"; shift 2 ;;
-    --baseline-appcast) BASELINE_APPCAST="${2:-}"; shift 2 ;;
-    *) die "unknown argument: $1" ;;
+    --dmg) DMG="${2:-}"; shift 2 ;; --appcast) APPCAST="${2:-}"; shift 2 ;;
+    --virtual-vibetv) VIRTUAL_VIBETV="${2:-}"; shift 2 ;; --companion) COMPANION="${2:-}"; shift 2 ;;
+    --firmware) FIRMWARE="${2:-}"; shift 2 ;; --firmware-manifest) FIRMWARE_MANIFEST="${2:-}"; shift 2 ;;
+    --version) VERSION="${2#v}"; shift 2 ;; --state) STATE="${2:-}"; shift 2 ;;
+    --output) OUTPUT="${2:-}"; shift 2 ;; --baseline-dmg) BASELINE_DMG="${2:-}"; shift 2 ;;
+    --baseline-appcast) BASELINE_APPCAST="${2:-}"; shift 2 ;; *) die "unknown argument: $1" ;;
   esac
 done
-
-[[ -f "$DMG" ]] || die '--dmg must name the signed candidate DMG'
-[[ -f "$APPCAST" ]] || die '--appcast must name the signed candidate appcast'
-[[ -x "$VIRTUAL_VIBETV" ]] || die '--virtual-vibetv must name the Core-provided executable'
-[[ -f "$FIRMWARE" ]] || die '--firmware must name the candidate firmware image'
+for file in "$DMG" "$APPCAST" "$FIRMWARE" "$FIRMWARE_MANIFEST"; do [[ -f "$file" ]] || die "required file missing: $file"; done
+[[ -x "$VIRTUAL_VIBETV" ]] || die '--virtual-vibetv must be executable'
+[[ -x "$COMPANION" ]] || die '--companion must be the exact candidate companion executable'
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || die '--version must be SemVer'
-[[ "$STATE" == clean_os || "$STATE" == current_public || "$STATE" == previous_public ]] || die '--state is invalid'
+[[ "$STATE" =~ ^(clean_os|current_public|previous_public)$ ]] || die '--state is invalid'
 [[ -n "$OUTPUT" && ! -e "$OUTPUT" ]] || die '--output must be a new directory'
 [[ "$(uname -s)" == Darwin ]] || die 'hosted guest test requires macOS'
-if [[ "$STATE" == clean_os ]]; then
-  [[ -z "$BASELINE_DMG" && -z "$BASELINE_APPCAST" ]] || die 'clean_os must not receive a public baseline'
-else
-  [[ -f "$BASELINE_DMG" && -f "$BASELINE_APPCAST" ]] || die 'public states require a frozen baseline DMG and appcast'
-fi
+if [[ "$STATE" == clean_os ]]; then [[ -z "$BASELINE_DMG$BASELINE_APPCAST" ]] || die 'clean_os must not receive a baseline'; else [[ -f "$BASELINE_DMG" && -f "$BASELINE_APPCAST" ]] || die 'public state needs frozen baseline files'; fi
+[[ ! -e "$INSTALL_APP" ]] || die "disposable guest is not clean: ${INSTALL_APP} exists"
 
 mkdir -p "$OUTPUT"
-MOUNT="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-hosted-mount.XXXXXX")"
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-hosted-guest.XXXXXX")"
-VIRTUAL_PID=""
+CANDIDATE_MOUNT="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-candidate-mount.XXXXXX")"
+BASELINE_MOUNT="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-baseline-mount.XXXXXX")"
+VIRTUAL_PID="" HTTP_PID=""
 cleanup() {
   [[ -z "$VIRTUAL_PID" ]] || kill "$VIRTUAL_PID" >/dev/null 2>&1 || true
-  [[ -z "$VIRTUAL_PID" ]] || wait "$VIRTUAL_PID" 2>/dev/null || true
-  hdiutil detach "$MOUNT" -quiet >/dev/null 2>&1 || true
-  rm -rf "$MOUNT" "$WORK"
+  [[ -z "$HTTP_PID" ]] || kill "$HTTP_PID" >/dev/null 2>&1 || true
+  hdiutil detach "$CANDIDATE_MOUNT" -quiet >/dev/null 2>&1 || true
+  hdiutil detach "$BASELINE_MOUNT" -quiet >/dev/null 2>&1 || true
+  [[ ! -e "$INSTALL_APP" ]] || rm -rf "$INSTALL_APP" || true
+  rm -rf "$WORK" "$CANDIDATE_MOUNT" "$BASELINE_MOUNT"
 }
 trap cleanup EXIT HUP INT TERM
 
 sw_vers > "$OUTPUT/macos-version.txt"
 ps -axo pid=,ppid=,comm= > "$OUTPUT/processes-before.txt"
-lsof -nP -iTCP@127.0.0.1:47832 -sTCP:LISTEN > "$OUTPUT/port-47832-before.txt" 2>&1 || true
+"$ROOT/scripts/verify-macos-control-center-dmg.sh" --dmg "$DMG" > "$OUTPUT/candidate-dmg-verification.txt" 2>&1
+hdiutil attach -readonly -nobrowse -mountpoint "$CANDIDATE_MOUNT" "$DMG" > "$OUTPUT/candidate-dmg-mount.txt" 2>&1
+CANDIDATE_APP="$CANDIDATE_MOUNT/VibeTV Control Center.app"
+[[ -d "$CANDIDATE_APP" ]] || die 'candidate DMG has no app'
+codesign --verify --deep --strict --verbose=2 "$CANDIDATE_APP" > "$OUTPUT/candidate-app-codesign.txt" 2>&1
 
-if [[ -n "$BASELINE_DMG" ]]; then
-  "$ROOT/scripts/verify-macos-control-center-dmg.sh" --dmg "$BASELINE_DMG" > "$OUTPUT/baseline-dmg-verification.txt" 2>&1
-  python3 - "$BASELINE_APPCAST" "$OUTPUT/baseline-appcast-check.json" <<'PY'
-import json
-import sys
-import xml.etree.ElementTree as ET
-
-root = ET.parse(sys.argv[1]).getroot()
-namespace = "{http://www.andymatuschak.org/xml-namespaces/sparkle}"
-if not any(item.find("enclosure") is not None and item.find("enclosure").get(namespace + "edSignature") for item in root.findall("./channel/item")):
-    raise SystemExit("public baseline appcast has no signed Sparkle enclosure")
-with open(sys.argv[2], "w", encoding="utf-8") as output:
-    json.dump({"baseline": "signed-public-appcast"}, output)
-    output.write("\n")
+mkdir -p "$WORK/serve"
+cp "$DMG" "$WORK/serve/VibeTV-Control-Center.dmg"
+cp "$APPCAST" "$WORK/serve/appcast.xml"
+cp "$FIRMWARE" "$WORK/serve/firmware.bin"
+cp "$FIRMWARE_MANIFEST" "$WORK/serve/firmware-manifest.template.json"
+python3 - "$WORK/serve" "$WORK/serve/port" <<'PY' > "$OUTPUT/loopback-server.log" 2>&1 &
+import http.server, pathlib, socketserver, sys
+root, port_file = map(pathlib.Path, sys.argv[1:])
+import os
+os.chdir(root)
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, fmt, *args): print(fmt % args, flush=True)
+with socketserver.TCPServer(("127.0.0.1", 0), Handler) as server:
+    port_file.write_text(str(server.server_address[1]), encoding="utf-8")
+    server.serve_forever()
 PY
+HTTP_PID=$!
+for _ in $(seq 1 30); do [[ -s "$WORK/serve/port" ]] && break; sleep 1; done
+[[ -s "$WORK/serve/port" ]] || die 'local candidate artifact server did not start'
+PORT="$(cat "$WORK/serve/port")"
+SERVER_URL="http://127.0.0.1:${PORT}"
+
+if [[ "$STATE" == clean_os ]]; then
+  ditto "$CANDIDATE_APP" "$INSTALL_APP"
+else
+  "$ROOT/scripts/verify-macos-control-center-dmg.sh" --dmg "$BASELINE_DMG" > "$OUTPUT/baseline-dmg-verification.txt" 2>&1
+  hdiutil attach -readonly -nobrowse -mountpoint "$BASELINE_MOUNT" "$BASELINE_DMG" > "$OUTPUT/baseline-dmg-mount.txt" 2>&1
+  BASELINE_APP="$BASELINE_MOUNT/VibeTV Control Center.app"
+  [[ -d "$BASELINE_APP" ]] || die 'baseline DMG has no app'
+  ditto "$BASELINE_APP" "$INSTALL_APP"
+  plutil -extract CFBundleShortVersionString raw -o - "$INSTALL_APP/Contents/Info.plist" > "$OUTPUT/baseline-version.txt"
+  # Sparkle's official CLI is intentionally mandatory. Do not downgrade this
+  # to XML parsing: if the hosted image lacks it, the gate must fail loudly.
+  sparkle_dir="$("$ROOT/scripts/fetch-sparkle.sh")"
+  SPARKLE_CLI="${SPARKLE_CLI:-${sparkle_dir}/bin/sparkle}"
+  [[ -x "$SPARKLE_CLI" ]] || die "official Sparkle CLI is unavailable at ${SPARKLE_CLI}; cannot prove Sparkle update"
+  # Official Sparkle CLI: sparkle bundle APP --check-immediately --feed-url URL.
+  "$SPARKLE_CLI" bundle "$INSTALL_APP" --check-immediately --feed-url "$SERVER_URL/appcast.xml" > "$OUTPUT/sparkle-update.txt" 2>&1
 fi
 
-"$ROOT/scripts/verify-macos-control-center-dmg.sh" --dmg "$DMG" > "$OUTPUT/dmg-verification.txt" 2>&1
-hdiutil attach -readonly -nobrowse -mountpoint "$MOUNT" "$DMG" > "$OUTPUT/dmg-mount.txt" 2>&1
-APP="$MOUNT/VibeTV Control Center.app"
-[[ -d "$APP" ]] || die 'candidate DMG has no VibeTV Control Center.app'
-codesign --verify --deep --strict --verbose=2 "$APP" > "$OUTPUT/app-codesign.txt" 2>&1
-plutil -extract CFBundleShortVersionString raw -o - "$APP/Contents/Info.plist" > "$OUTPUT/app-version.txt"
-[[ "$(cat "$OUTPUT/app-version.txt")" == "$VERSION" ]] || die 'candidate app version does not match requested version'
+plutil -extract CFBundleShortVersionString raw -o - "$INSTALL_APP/Contents/Info.plist" > "$OUTPUT/installed-candidate-version.txt"
+[[ "$(cat "$OUTPUT/installed-candidate-version.txt")" == "$VERSION" ]] || die 'installed app is not the candidate version after Sparkle/direct install'
+cmp "$COMPANION" "$INSTALL_APP/Contents/Helpers/codexbar-display" || die 'installed app does not contain the candidate companion artifact'
 
-python3 - "$APPCAST" "$VERSION" "$OUTPUT/appcast-check.json" <<'PY'
-import json
-import sys
-import xml.etree.ElementTree as ET
-
-appcast, version, output = sys.argv[1:]
-root = ET.parse(appcast).getroot()
-namespace = "{http://www.andymatuschak.org/xml-namespaces/sparkle}"
-items = root.findall("./channel/item")
-if not items:
-    raise SystemExit("appcast has no item")
-for item in items:
-    enclosure = item.find("enclosure")
-    if enclosure is None:
-        continue
-    if enclosure.get(namespace + "edSignature") and enclosure.get(namespace + "shortVersionString") == version:
-        with open(output, "w", encoding="utf-8") as destination:
-            json.dump({"sparkleUpdate": "signed-appcast-candidate", "version": version}, destination)
-            destination.write("\n")
-        break
-else:
-    raise SystemExit("appcast has no signed enclosure for the candidate version")
+python3 - "$WORK/serve/firmware-manifest.template.json" "$WORK/serve/firmware-manifest.json" "$SERVER_URL/firmware.bin" <<'PY'
+import json, sys
+source, output, url = sys.argv[1:]
+manifest = json.load(open(source, encoding="utf-8"))
+for artifact in manifest.get("artifacts", []): artifact["firmwareUrl"] = url
+json.dump(manifest, open(output, "w", encoding="utf-8"), indent=2)
 PY
-
-# GitHub-hosted macOS runners are disposable guests. This test deliberately
-# uses the real signed app and only a loopback Virtual VibeTV; it never reaches
-# physical hardware. The Core branch supplies virtual-vibetv.
 firmware_sha="$(shasum -a 256 "$FIRMWARE" | awk '{print $1}')"
-"$VIRTUAL_VIBETV" \
-  --addr 127.0.0.1:47834 \
-  --firmware 0.0.0 \
-  --candidate-firmware "$VERSION" \
-  --expected-firmware-sha256 "$firmware_sha" \
-  > "$OUTPUT/virtual-vibetv.log" 2>&1 &
-VIRTUAL_PID=$!
-for _ in $(seq 1 30); do
-  curl --fail --silent --show-error http://127.0.0.1:47834/health > "$WORK/health.json" && break
-  sleep 1
-done
-[[ -s "$WORK/health.json" ]] || die 'Virtual VibeTV did not become healthy'
-curl --fail --silent --show-error http://127.0.0.1:47834/hello > "$OUTPUT/virtual-hello.json"
-curl --fail --silent --show-error http://127.0.0.1:47834/health > "$OUTPUT/virtual-health-before.json"
-curl --fail --silent --show-error \
-  -H 'X-VibeTV-Token: virtual-pair-token' \
-  -H 'Content-Type: application/json' \
-  --data '{"provider":"vibetv","label":"Hosted gate"}' \
-  http://127.0.0.1:47834/frame > "$OUTPUT/virtual-frame.txt"
-curl --fail --silent --show-error \
-  -H 'X-VibeTV-Token: virtual-pair-token' \
-  --data-binary "@$FIRMWARE" \
-  http://127.0.0.1:47834/update/firmware > "$OUTPUT/virtual-ota.txt"
-for _ in $(seq 1 30); do
-  curl --fail --silent --show-error http://127.0.0.1:47834/health > "$OUTPUT/virtual-health-after.json" && break
-  sleep 1
-done
-curl --fail --silent --show-error http://127.0.0.1:47834/__virtual/state > "$OUTPUT/virtual-state.json"
+"$VIRTUAL_VIBETV" --addr 127.0.0.1:47834 --raw-addr 127.0.0.1:8081 --firmware 0.0.0 --candidate-firmware "$VERSION" --expected-firmware-sha256 "$firmware_sha" > "$OUTPUT/virtual-vibetv.log" 2>&1 & VIRTUAL_PID=$!
+for _ in $(seq 1 30); do curl --fail --silent "$SERVER_URL/firmware-manifest.json" >/dev/null && curl --fail --silent http://127.0.0.1:47834/health > "$OUTPUT/virtual-health-before.json" && break; sleep 1; done
+[[ -s "$OUTPUT/virtual-health-before.json" ]] || die 'Virtual VibeTV did not become healthy'
+CANDIDATE_COMPANION="$INSTALL_APP/Contents/Helpers/codexbar-display"
+"$CANDIDATE_COMPANION" install-update --target http://127.0.0.1:47834 --manifest-url "$SERVER_URL/firmware-manifest.json" --skip-launchagent-pause > "$OUTPUT/candidate-install-update.txt" 2>&1
+"$CANDIDATE_COMPANION" install-update --target http://127.0.0.1:47834 --manifest-url "$SERVER_URL/firmware-manifest.json" --skip-launchagent-pause > "$OUTPUT/candidate-already-current.txt" 2>&1
+grep -F 'Firmware: already current' "$OUTPUT/candidate-already-current.txt" >/dev/null || die 'candidate companion did not prove already_current'
+"$CANDIDATE_COMPANION" daemon --transport wifi --target http://127.0.0.1:47834 --once --api-addr 127.0.0.1:47832 > "$OUTPUT/candidate-daemon-once.txt" 2>&1
+curl --fail --silent http://127.0.0.1:47834/__virtual/state > "$OUTPUT/virtual-state.json"
 python3 - "$OUTPUT/virtual-state.json" <<'PY'
-import json
-import sys
-
+import json, sys
 state = json.load(open(sys.argv[1], encoding="utf-8"))
-if state.get("updateUploads") != 1 or state.get("framesAccepted", 0) < 1 or state.get("violations"):
-    raise SystemExit("Virtual VibeTV did not record a healthy render/stream/OTA sequence")
+if state.get("updateUploads") != 1 or state.get("violations") or state.get("framesAccepted", 0) < 1:
+    raise SystemExit("candidate companion did not complete raw OTA/render/no-op sequence")
+if not any(event.get("path") == "/update/firmware.raw" for event in state.get("events", [])):
+    raise SystemExit("candidate companion did not use Raw OTA port 8081")
 PY
 
-# The exact same firmware is now current. A second upload must be rejected,
-# which is the no-op guard against a duplicate OTA after a transient response.
-status="$(curl --silent --output "$OUTPUT/virtual-no-op.txt" --write-out '%{http_code}' \
-  -H 'X-VibeTV-Token: virtual-pair-token' --data-binary "@$FIRMWARE" \
-  http://127.0.0.1:47834/update/firmware)"
-[[ "$status" == 409 ]] || die "Virtual VibeTV no-op OTA must return 409, got $status"
-
-CODEX_ALLOW_MACOS_RUNTIME_VALIDATION=1 \
-  "$ROOT/scripts/validate-macos-control-center-runtime.sh" \
-  --real --app "$APP" --expected-version "$VERSION" \
-  > "$OUTPUT/companion-port-47832.txt" 2>&1
-ps -axo pid=,ppid=,comm= > "$OUTPUT/processes-after.txt"
-lsof -nP -iTCP@127.0.0.1:47832 -sTCP:LISTEN > "$OUTPUT/port-47832-after.txt" 2>&1 || true
+CODEX_ALLOW_MACOS_RUNTIME_VALIDATION=1 "$ROOT/scripts/validate-macos-control-center-runtime.sh" --real --installed-app --app "$INSTALL_APP" --expected-version "$VERSION" > "$OUTPUT/companion-port-47832.txt" 2>&1
 screencapture -x "$OUTPUT/guest-${STATE}.png"
-
 python3 - "$OUTPUT/result.json" "$STATE" "$VERSION" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], "w", encoding="utf-8") as output:
-    json.dump({
-        "schemaVersion": 1,
-        "state": sys.argv[2],
-        "version": sys.argv[3],
-        "status": "passed",
-        "checks": ["signed-dmg", "signed-app", "sparkle-update", "companion-port-47832", "virtual-health-render-stream-ota-no-op"],
-    }, output, indent=2)
-    output.write("\n")
+import json, sys
+json.dump({"schemaVersion": 1, "state": sys.argv[2], "version": sys.argv[3], "status": "passed", "checks": ["signed-dmg", "installed-baseline-to-sparkle-update", "candidate-companion-raw-ota-rediscovery-no-op", "candidate-daemon-render", "installed-runtime-port-47832"]}, open(sys.argv[1], "w", encoding="utf-8"), indent=2)
 PY

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DMG=""
+APPCAST=""
+VIRTUAL_VIBETV=""
+FIRMWARE=""
+VERSION=""
+STATE=""
+OUTPUT=""
+BASELINE_DMG=""
+BASELINE_APPCAST=""
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dmg) DMG="${2:-}"; shift 2 ;;
+    --appcast) APPCAST="${2:-}"; shift 2 ;;
+    --virtual-vibetv) VIRTUAL_VIBETV="${2:-}"; shift 2 ;;
+    --firmware) FIRMWARE="${2:-}"; shift 2 ;;
+    --version) VERSION="${2#v}"; shift 2 ;;
+    --state) STATE="${2:-}"; shift 2 ;;
+    --output) OUTPUT="${2:-}"; shift 2 ;;
+    --baseline-dmg) BASELINE_DMG="${2:-}"; shift 2 ;;
+    --baseline-appcast) BASELINE_APPCAST="${2:-}"; shift 2 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -f "$DMG" ]] || die '--dmg must name the signed candidate DMG'
+[[ -f "$APPCAST" ]] || die '--appcast must name the signed candidate appcast'
+[[ -x "$VIRTUAL_VIBETV" ]] || die '--virtual-vibetv must name the Core-provided executable'
+[[ -f "$FIRMWARE" ]] || die '--firmware must name the candidate firmware image'
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || die '--version must be SemVer'
+[[ "$STATE" == clean_os || "$STATE" == current_public || "$STATE" == previous_public ]] || die '--state is invalid'
+[[ -n "$OUTPUT" && ! -e "$OUTPUT" ]] || die '--output must be a new directory'
+[[ "$(uname -s)" == Darwin ]] || die 'hosted guest test requires macOS'
+if [[ "$STATE" == clean_os ]]; then
+  [[ -z "$BASELINE_DMG" && -z "$BASELINE_APPCAST" ]] || die 'clean_os must not receive a public baseline'
+else
+  [[ -f "$BASELINE_DMG" && -f "$BASELINE_APPCAST" ]] || die 'public states require a frozen baseline DMG and appcast'
+fi
+
+mkdir -p "$OUTPUT"
+MOUNT="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-hosted-mount.XXXXXX")"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-hosted-guest.XXXXXX")"
+VIRTUAL_PID=""
+cleanup() {
+  [[ -z "$VIRTUAL_PID" ]] || kill "$VIRTUAL_PID" >/dev/null 2>&1 || true
+  [[ -z "$VIRTUAL_PID" ]] || wait "$VIRTUAL_PID" 2>/dev/null || true
+  hdiutil detach "$MOUNT" -quiet >/dev/null 2>&1 || true
+  rm -rf "$MOUNT" "$WORK"
+}
+trap cleanup EXIT HUP INT TERM
+
+sw_vers > "$OUTPUT/macos-version.txt"
+ps -axo pid=,ppid=,comm= > "$OUTPUT/processes-before.txt"
+lsof -nP -iTCP@127.0.0.1:47832 -sTCP:LISTEN > "$OUTPUT/port-47832-before.txt" 2>&1 || true
+
+if [[ -n "$BASELINE_DMG" ]]; then
+  "$ROOT/scripts/verify-macos-control-center-dmg.sh" --dmg "$BASELINE_DMG" > "$OUTPUT/baseline-dmg-verification.txt" 2>&1
+  python3 - "$BASELINE_APPCAST" "$OUTPUT/baseline-appcast-check.json" <<'PY'
+import json
+import sys
+import xml.etree.ElementTree as ET
+
+root = ET.parse(sys.argv[1]).getroot()
+namespace = "{http://www.andymatuschak.org/xml-namespaces/sparkle}"
+if not any(item.find("enclosure") is not None and item.find("enclosure").get(namespace + "edSignature") for item in root.findall("./channel/item")):
+    raise SystemExit("public baseline appcast has no signed Sparkle enclosure")
+with open(sys.argv[2], "w", encoding="utf-8") as output:
+    json.dump({"baseline": "signed-public-appcast"}, output)
+    output.write("\n")
+PY
+fi
+
+"$ROOT/scripts/verify-macos-control-center-dmg.sh" --dmg "$DMG" > "$OUTPUT/dmg-verification.txt" 2>&1
+hdiutil attach -readonly -nobrowse -mountpoint "$MOUNT" "$DMG" > "$OUTPUT/dmg-mount.txt" 2>&1
+APP="$MOUNT/VibeTV Control Center.app"
+[[ -d "$APP" ]] || die 'candidate DMG has no VibeTV Control Center.app'
+codesign --verify --deep --strict --verbose=2 "$APP" > "$OUTPUT/app-codesign.txt" 2>&1
+plutil -extract CFBundleShortVersionString raw -o - "$APP/Contents/Info.plist" > "$OUTPUT/app-version.txt"
+[[ "$(cat "$OUTPUT/app-version.txt")" == "$VERSION" ]] || die 'candidate app version does not match requested version'
+
+python3 - "$APPCAST" "$VERSION" "$OUTPUT/appcast-check.json" <<'PY'
+import json
+import sys
+import xml.etree.ElementTree as ET
+
+appcast, version, output = sys.argv[1:]
+root = ET.parse(appcast).getroot()
+namespace = "{http://www.andymatuschak.org/xml-namespaces/sparkle}"
+items = root.findall("./channel/item")
+if not items:
+    raise SystemExit("appcast has no item")
+for item in items:
+    enclosure = item.find("enclosure")
+    if enclosure is None:
+        continue
+    if enclosure.get(namespace + "edSignature") and enclosure.get(namespace + "shortVersionString") == version:
+        with open(output, "w", encoding="utf-8") as destination:
+            json.dump({"sparkleUpdate": "signed-appcast-candidate", "version": version}, destination)
+            destination.write("\n")
+        break
+else:
+    raise SystemExit("appcast has no signed enclosure for the candidate version")
+PY
+
+# GitHub-hosted macOS runners are disposable guests. This test deliberately
+# uses the real signed app and only a loopback Virtual VibeTV; it never reaches
+# physical hardware. The Core branch supplies virtual-vibetv.
+firmware_sha="$(shasum -a 256 "$FIRMWARE" | awk '{print $1}')"
+"$VIRTUAL_VIBETV" \
+  --addr 127.0.0.1:47834 \
+  --firmware 0.0.0 \
+  --candidate-firmware "$VERSION" \
+  --expected-firmware-sha256 "$firmware_sha" \
+  > "$OUTPUT/virtual-vibetv.log" 2>&1 &
+VIRTUAL_PID=$!
+for _ in $(seq 1 30); do
+  curl --fail --silent --show-error http://127.0.0.1:47834/health > "$WORK/health.json" && break
+  sleep 1
+done
+[[ -s "$WORK/health.json" ]] || die 'Virtual VibeTV did not become healthy'
+curl --fail --silent --show-error http://127.0.0.1:47834/hello > "$OUTPUT/virtual-hello.json"
+curl --fail --silent --show-error http://127.0.0.1:47834/health > "$OUTPUT/virtual-health-before.json"
+curl --fail --silent --show-error \
+  -H 'X-VibeTV-Token: virtual-pair-token' \
+  -H 'Content-Type: application/json' \
+  --data '{"provider":"vibetv","label":"Hosted gate"}' \
+  http://127.0.0.1:47834/frame > "$OUTPUT/virtual-frame.txt"
+curl --fail --silent --show-error \
+  -H 'X-VibeTV-Token: virtual-pair-token' \
+  --data-binary "@$FIRMWARE" \
+  http://127.0.0.1:47834/update/firmware > "$OUTPUT/virtual-ota.txt"
+for _ in $(seq 1 30); do
+  curl --fail --silent --show-error http://127.0.0.1:47834/health > "$OUTPUT/virtual-health-after.json" && break
+  sleep 1
+done
+curl --fail --silent --show-error http://127.0.0.1:47834/__virtual/state > "$OUTPUT/virtual-state.json"
+python3 - "$OUTPUT/virtual-state.json" <<'PY'
+import json
+import sys
+
+state = json.load(open(sys.argv[1], encoding="utf-8"))
+if state.get("updateUploads") != 1 or state.get("framesAccepted", 0) < 1 or state.get("violations"):
+    raise SystemExit("Virtual VibeTV did not record a healthy render/stream/OTA sequence")
+PY
+
+# The exact same firmware is now current. A second upload must be rejected,
+# which is the no-op guard against a duplicate OTA after a transient response.
+status="$(curl --silent --output "$OUTPUT/virtual-no-op.txt" --write-out '%{http_code}' \
+  -H 'X-VibeTV-Token: virtual-pair-token' --data-binary "@$FIRMWARE" \
+  http://127.0.0.1:47834/update/firmware)"
+[[ "$status" == 409 ]] || die "Virtual VibeTV no-op OTA must return 409, got $status"
+
+CODEX_ALLOW_MACOS_RUNTIME_VALIDATION=1 \
+  "$ROOT/scripts/validate-macos-control-center-runtime.sh" \
+  --real --app "$APP" --expected-version "$VERSION" \
+  > "$OUTPUT/companion-port-47832.txt" 2>&1
+ps -axo pid=,ppid=,comm= > "$OUTPUT/processes-after.txt"
+lsof -nP -iTCP@127.0.0.1:47832 -sTCP:LISTEN > "$OUTPUT/port-47832-after.txt" 2>&1 || true
+screencapture -x "$OUTPUT/guest-${STATE}.png"
+
+python3 - "$OUTPUT/result.json" "$STATE" "$VERSION" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "w", encoding="utf-8") as output:
+    json.dump({
+        "schemaVersion": 1,
+        "state": sys.argv[2],
+        "version": sys.argv[3],
+        "status": "passed",
+        "checks": ["signed-dmg", "signed-app", "sparkle-update", "companion-port-47832", "virtual-health-render-stream-ota-no-op"],
+    }, output, indent=2)
+    output.write("\n")
+PY

--- a/scripts/validate-macos-control-center-runtime.sh
+++ b/scripts/validate-macos-control-center-runtime.sh
@@ -20,12 +20,13 @@ SERVICE_PID=""
 CLEANUP_ARMED=0
 LAUNCH_ENV_SET=0
 INSTALLED=0
+INSTALLED_APP=0
 
 usage() {
   cat <<'EOF'
 Usage:
   validate-macos-control-center-runtime.sh --dry-run --app path.app --expected-version x.y.z
-  CODEX_ALLOW_MACOS_RUNTIME_VALIDATION=1 validate-macos-control-center-runtime.sh --real --app path.app --expected-version x.y.z [--timeout-seconds n]
+  CODEX_ALLOW_MACOS_RUNTIME_VALIDATION=1 validate-macos-control-center-runtime.sh --real [--installed-app] --app path.app --expected-version x.y.z [--timeout-seconds n]
 
 Real mode is destructive and intentionally limited to a clean validation Mac.
 It installs the signed app in /Applications, uses only a loopback fake VibeTV,
@@ -53,6 +54,10 @@ while [[ $# -gt 0 ]]; do
       need_value "$1" "${2:-}"
       SOURCE_APP="$2"
       shift 2
+      ;;
+    --installed-app)
+      INSTALLED_APP=1
+      shift
       ;;
     --expected-version)
       need_value "$1" "${2:-}"
@@ -106,7 +111,11 @@ for command in cat codesign curl defaults ditto launchctl lsof open paste plutil
 done
 
 [[ -d "$SOURCE_APP" ]] || die "signed app not found: $SOURCE_APP"
-[[ ! -e "$INSTALL_APP" ]] || die "clean host required: $INSTALL_APP already exists"
+if [[ "$INSTALLED_APP" == "1" ]]; then
+  [[ "$SOURCE_APP" == "$INSTALL_APP" ]] || die '--installed-app requires /Applications/VibeTV Control Center.app'
+else
+  [[ ! -e "$INSTALL_APP" ]] || die "clean host required: $INSTALL_APP already exists"
+fi
 [[ -w /Applications ]] || die "/Applications is not writable"
 
 APP_SUPPORT="${HOME}/Library/Application Support/codexbar-display"
@@ -371,7 +380,9 @@ launchctl setenv CODEXBAR_DISPLAY_FIRMWARE_MANIFEST_URL off
 launchctl setenv CODEXBAR_BIN /usr/bin/false
 LAUNCH_ENV_SET=1
 
-ditto "$SOURCE_APP" "$INSTALL_APP"
+if [[ "$INSTALLED_APP" != "1" ]]; then
+  ditto "$SOURCE_APP" "$INSTALL_APP"
+fi
 INSTALLED=1
 codesign --verify --deep --strict --verbose=2 "$INSTALL_APP"
 open -na "$INSTALL_APP"


### PR DESCRIPTION
## Stack 2/3 — hosted virtual release lab

Part of #177. Base: #297.

This PR adds the cloud-hosted layer:

- one stable `CODEX CI` aggregate plus an exact-PR-SHA virtual merge gate;
- fresh GitHub-hosted macOS jobs for `clean_os`, `current_public`, and `previous_public`;
- frozen public Mac and firmware baselines with SHA-256 binding;
- a complete private release candidate built once: notarized DMG, production appcast, installers, both Companion architectures, all configured firmware assets/manifests, checksums, universal test Companion, and Virtual VibeTV;
- a real Sparkle replacement/relaunch test through the official CLI built from pinned Sparkle 2.9.2 source;
- raw OTA, render, health, rediscovery, and `already_current` verification without publishing anything.

## Verification

- hosted gate contract and Bash syntax tests;
- `actionlint` for the new and changed workflows;
- full `go test -count=1 ./...` and `go vet ./...` on the stacked result;
- repeat shutdown regression test for the Virtual VibeTV CLI.

No candidate workflow, signing job, tag, public release, or physical hardware test has been executed. The hosted workflow can only be proven with repository secrets after the prerequisite workflow code is reviewed and lands on `main`.

This supersedes the hosted approach in #180.