### PR TITLE
CODEX: require physical evidence before VibeTV releases

### DIFF
--- a/.github/workflows/record-hardware-canary.yml
+++ b/.github/workflows/record-hardware-canary.yml
@@ -1,0 +1,86 @@
+name: CODEX Record VibeTV Hardware Canary
+
+on:
+  workflow_dispatch:
+    inputs:
+      evidence_base64:
+        description: Base64-encoded hardware-canary.json from the guided physical canary
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+  statuses: write
+
+jobs:
+  record:
+    if: github.repository == 'DreamyTalesPAN/CodexBar-Display' && github.ref == 'refs/heads/main' && (github.actor == github.repository_owner || github.actor == 'marcus7989')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted validator
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Decode evidence
+        env:
+          EVIDENCE_BASE64: ${{ inputs.evidence_base64 }}
+        run: |
+          set -euo pipefail
+          mkdir -p evidence candidate
+          printf '%s' "$EVIDENCE_BASE64" | base64 --decode > evidence/hardware-canary.json
+          python3 -m json.tool evidence/hardware-canary.json >/dev/null
+
+      - name: Verify successful immutable candidate run
+        id: candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          run_id="$(python3 -c 'import json; print(json.load(open("evidence/hardware-canary.json"))["candidateRunId"])')"
+          source_sha="$(python3 -c 'import json; print(json.load(open("evidence/hardware-canary.json"))["sourceSha"])')"
+          run="$(gh run view "${run_id}" --repo "${GITHUB_REPOSITORY}" --json conclusion,workflowName,headSha)"
+          conclusion="$(printf '%s' "$run" | python3 -c 'import json,sys; print(json.load(sys.stdin)["conclusion"])')"
+          workflow="$(printf '%s' "$run" | python3 -c 'import json,sys; print(json.load(sys.stdin)["workflowName"])')"
+          head_sha="$(printf '%s' "$run" | python3 -c 'import json,sys; print(json.load(sys.stdin)["headSha"])')"
+          [[ "${conclusion}" == success && "${workflow}" == 'CODEX Test VibeTV Release Candidate' && "${head_sha}" == "${source_sha}" ]] || { echo 'candidate run identity/conclusion mismatch' >&2; exit 1; }
+          gh run download "${run_id}" --repo "${GITHUB_REPOSITORY}" --name vibetv-release-candidate --dir candidate
+          gh run download "${run_id}" --repo "${GITHUB_REPOSITORY}" --name vibetv-release-candidate-result --dir candidate-result
+          ./scripts/validate-hardware-canary.py candidate-result --candidate-dir candidate --result candidate-result/candidate-result.json
+          echo "source_sha=${source_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate evidence against candidate bundle
+        id: validate
+        run: |
+          set -euo pipefail
+          ./scripts/validate-hardware-canary.py evidence --candidate-dir candidate --evidence evidence/hardware-canary.json
+          result="$(python3 -c 'import json; print(json.load(open("evidence/hardware-canary.json"))["result"])')"
+          [[ "${result}" == "success" ]]
+
+      - name: Upload hardware canary evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vibetv-hardware-canary
+          path: evidence/hardware-canary.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Set hardware canary commit status
+        if: always() && steps.candidate.outputs.source_sha != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.candidate.outputs.source_sha }}
+          VALIDATION_OUTCOME: ${{ steps.validate.outcome }}
+        run: |
+          set -euo pipefail
+          state=failure
+          description='hardware evidence validation failed'
+          if [[ "${VALIDATION_OUTCOME}" == success ]]; then
+            state=success
+            description='hardware canary evidence validated'
+          fi
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${SOURCE_SHA}" \
+            -f state="${state}" -f context='CODEX VibeTV Hardware Canary' -f description="${description}"

--- a/.github/workflows/record-hardware-canary.yml
+++ b/.github/workflows/record-hardware-canary.yml
@@ -32,6 +32,7 @@ jobs:
           mkdir -p evidence candidate
           printf '%s' "$EVIDENCE_BASE64" | base64 --decode > evidence/hardware-canary.json
           python3 -m json.tool evidence/hardware-canary.json >/dev/null
+          [[ "$(python3 -c 'import json; print(json.load(open("evidence/hardware-canary.json"))["actor"])')" == "${GITHUB_ACTOR}" ]]
 
       - name: Verify successful immutable candidate run
         id: candidate
@@ -41,11 +42,13 @@ jobs:
           set -euo pipefail
           run_id="$(python3 -c 'import json; print(json.load(open("evidence/hardware-canary.json"))["candidateRunId"])')"
           source_sha="$(python3 -c 'import json; print(json.load(open("evidence/hardware-canary.json"))["sourceSha"])')"
-          run="$(gh run view "${run_id}" --repo "${GITHUB_REPOSITORY}" --json conclusion,workflowName,headSha)"
+          run="$(gh run view "${run_id}" --repo "${GITHUB_REPOSITORY}" --json conclusion,workflowName,headSha,headBranch,event)"
           conclusion="$(printf '%s' "$run" | python3 -c 'import json,sys; print(json.load(sys.stdin)["conclusion"])')"
           workflow="$(printf '%s' "$run" | python3 -c 'import json,sys; print(json.load(sys.stdin)["workflowName"])')"
           head_sha="$(printf '%s' "$run" | python3 -c 'import json,sys; print(json.load(sys.stdin)["headSha"])')"
-          [[ "${conclusion}" == success && "${workflow}" == 'CODEX Test VibeTV Release Candidate' && "${head_sha}" == "${source_sha}" ]] || { echo 'candidate run identity/conclusion mismatch' >&2; exit 1; }
+          head_branch="$(printf '%s' "$run" | python3 -c 'import json,sys; print(json.load(sys.stdin)["headBranch"])')"
+          event="$(printf '%s' "$run" | python3 -c 'import json,sys; print(json.load(sys.stdin)["event"])')"
+          [[ "${conclusion}" == success && "${workflow}" == 'CODEX Test VibeTV Release Candidate' && "${head_sha}" == "${source_sha}" && "${head_branch}" == main && "${event}" == workflow_dispatch ]] || { echo 'candidate run identity/conclusion mismatch' >&2; exit 1; }
           gh run download "${run_id}" --repo "${GITHUB_REPOSITORY}" --name vibetv-release-candidate --dir candidate
           gh run download "${run_id}" --repo "${GITHUB_REPOSITORY}" --name vibetv-release-candidate-result --dir candidate-result
           ./scripts/validate-hardware-canary.py candidate-result --candidate-dir candidate --result candidate-result/candidate-result.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,425 +1,239 @@
-name: Release
+name: CODEX Publish VibeTV Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Public release SemVer without a leading v
+        required: true
+        type: string
+      candidate_run_id:
+        description: Successful CODEX VibeTV release-candidate run id
+        required: true
+        type: string
+      hardware_canary_run_id:
+        description: Successful CODEX hardware-canary record run id
+        required: true
+        type: string
 
 permissions:
   contents: read
+  actions: read
+
+concurrency:
+  group: codex-publish-vibetv-release-${{ inputs.version }}
+  cancel-in-progress: false
 
 jobs:
-  build-macos-dmg:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: macos-15
-    timeout-minutes: 90
-    env:
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      APPLE_SIGNING_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_SIGNING_CERTIFICATE_P12_BASE64 }}
-      APPLE_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD }}
-      APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
-      APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
-      APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
-      SPARKLE_ED25519_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: companion/go.mod
-          cache-dependency-path: companion/go.sum
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: apps/control-center/package-lock.json
-
-      - name: Validate Apple release secrets
-        run: |
-          set -euo pipefail
-
-          missing=0
-          for name in \
-            APPLE_TEAM_ID \
-            APPLE_SIGNING_CERTIFICATE_P12_BASE64 \
-            APPLE_SIGNING_CERTIFICATE_PASSWORD \
-            APPLE_NOTARY_KEY_ID \
-            APPLE_NOTARY_ISSUER_ID \
-            APPLE_NOTARY_KEY_P8_BASE64 \
-            SPARKLE_ED25519_PRIVATE_KEY
-          do
-            if [[ -z "${!name:-}" ]]; then
-              echo "::error::Missing required GitHub Actions secret: ${name}"
-              missing=1
-            fi
-          done
-          (( missing == 0 ))
-
-      - name: Build signed and notarized Mac DMG
-        env:
-          VERSION: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          VERSION="${VERSION#v}"
-          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "error: macOS DMG version must be SemVer x.y.z, got ${VERSION}" >&2
-            exit 1
-          fi
-          mkdir -p dist/macos tmp/macos-release
-
-          (
-            cd apps/control-center
-            npm ci
-            npm run build:local
-          )
-          rm -rf companion/internal/companionapi/controlcenter_static
-          mkdir -p companion/internal/companionapi/controlcenter_static
-          cp -R apps/control-center/out-local/. companion/internal/companionapi/controlcenter_static/
-
-          cd companion
-          for ARCH in amd64 arm64; do
-            GOOS=darwin GOARCH="${ARCH}" CGO_ENABLED=0 \
-              go build \
-              -ldflags "-s -w -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Version=${VERSION} -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Commit=${GITHUB_SHA} -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-              -o "../tmp/macos-release/codexbar-display-${ARCH}" ./cmd/codexbar-display
-          done
-          cd ..
-          lipo -create \
-            -output "tmp/macos-release/codexbar-display" \
-            "tmp/macos-release/codexbar-display-amd64" \
-            "tmp/macos-release/codexbar-display-arm64"
-
-          ./scripts/build-macos-control-center-app.sh \
-            --version "${VERSION}" \
-            --build "${GITHUB_RUN_NUMBER:-0}" \
-            --universal \
-            --companion-binary "tmp/macos-release/codexbar-display" \
-            --output "dist/macos/VibeTV Control Center.app"
-
-          ./scripts/verify-bundled-codexbar.sh \
-            --app "dist/macos/VibeTV Control Center.app"
-
-          ./scripts/sign-notarize-macos-control-center.sh \
-            --app "dist/macos/VibeTV Control Center.app" \
-            --sign-app-only \
-            --allow-internal-xprotect-preflight-error
-
-          ./scripts/build-macos-control-center-dmg.sh \
-            --app "dist/macos/VibeTV Control Center.app" \
-            --output "dist/macos/VibeTV-Control-Center.dmg" \
-            --staging-dir "tmp/macos-release/dmg-stage"
-
-          ./scripts/sign-notarize-macos-control-center.sh \
-            --app "dist/macos/VibeTV Control Center.app" \
-            --dmg "dist/macos/VibeTV-Control-Center.dmg" \
-            --skip-app-sign \
-            --notary-log "tmp/macos-release/notarization-log.json"
-
-      - name: Verify notarized Mac DMG for distribution
-        run: |
-          ./scripts/verify-macos-control-center-dmg.sh \
-            --dmg "dist/macos/VibeTV-Control-Center.dmg"
-
-      - name: Build signed Sparkle appcast
-        run: |
-          set -euo pipefail
-
-          sparkle_dir="$(./scripts/fetch-sparkle.sh)"
-          printf '%s' "$SPARKLE_ED25519_PRIVATE_KEY" | \
-            "${sparkle_dir}/bin/generate_appcast" \
-              --ed-key-file - \
-              --maximum-deltas 0 \
-              --download-url-prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/" \
-              --link "https://app.vibetv.shop" \
-              -o dist/macos/appcast.xml \
-              dist/macos
-          test -s dist/macos/appcast.xml
-          grep -F 'sparkle:edSignature=' dist/macos/appcast.xml >/dev/null
-
-      - name: Upload notarization evidence
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: vibetv-control-center-notarization
-          path: tmp/macos-release/notarization-log.json
-          if-no-files-found: warn
-          retention-days: 30
-
-      - name: Upload notarized Mac DMG
-        uses: actions/upload-artifact@v4
-        with:
-          name: vibetv-control-center-dmg
-          path: |
-            dist/macos/VibeTV-Control-Center.dmg
-            dist/macos/appcast.xml
-          if-no-files-found: error
-          retention-days: 7
-
-  build-and-release:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+  preflight:
+    if: >-
+      github.repository == 'DreamyTalesPAN/CodexBar-Display' &&
+      github.ref == 'refs/heads/main' &&
+      (github.actor == github.repository_owner || github.actor == 'marcus7989')
     runs-on: ubuntu-latest
-    needs: build-macos-dmg
+    timeout-minutes: 20
+    env:
+      VERSION: ${{ inputs.version }}
+      CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+      HARDWARE_CANARY_RUN_ID: ${{ inputs.hardware_canary_run_id }}
+      SOURCE_SHA: ${{ github.sha }}
+      CANDIDATE_WORKFLOW: .github/workflows/vibetv-release-candidate.yml
+      HARDWARE_WORKFLOW: .github/workflows/record-hardware-canary.yml
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout trusted publish gate from current main
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Validate run inputs and unpublished version
+        run: |
+          set -euo pipefail
+          [[ "${VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] \
+            || { echo "error: version must be SemVer x.y.z without a leading v" >&2; exit 1; }
+          [[ "${CANDIDATE_RUN_ID}" =~ ^[0-9]+$ ]] \
+            || { echo "error: candidate_run_id must contain digits only" >&2; exit 1; }
+          [[ "${HARDWARE_CANARY_RUN_ID}" =~ ^[0-9]+$ ]] \
+            || { echo "error: hardware_canary_run_id must contain digits only" >&2; exit 1; }
+
+          ensure_absent() {
+            local endpoint="$1"
+            local label="$2"
+            local error_file
+            error_file="$(mktemp)"
+            if gh api "${endpoint}" >/dev/null 2>"${error_file}"; then
+              echo "error: ${label} already exists" >&2
+              exit 1
+            fi
+            if ! grep -F "HTTP 404" "${error_file}" >/dev/null; then
+              cat "${error_file}" >&2
+              echo "error: could not prove ${label} is absent" >&2
+              exit 1
+            fi
+          }
+          ensure_absent \
+            "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${VERSION}" \
+            "tag v${VERSION}"
+          ensure_absent \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" \
+            "release v${VERSION}"
+
+      - name: Read authoritative workflow-run metadata
+        run: |
+          set -euo pipefail
+          mkdir -p evidence
+
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${CANDIDATE_RUN_ID}" \
+            > evidence/candidate-run.json
+          candidate_workflow_id="$(
+            python3 -c 'import json; print(json.load(open("evidence/candidate-run.json"))["workflow_id"])'
+          )"
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/${candidate_workflow_id}" \
+            > evidence/candidate-workflow.json
+
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${HARDWARE_CANARY_RUN_ID}" \
+            > evidence/hardware-run.json
+          hardware_workflow_id="$(
+            python3 -c 'import json; print(json.load(open("evidence/hardware-run.json"))["workflow_id"])'
+          )"
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/${hardware_workflow_id}" \
+            > evidence/hardware-workflow.json
+
+      - name: Download immutable candidate, result, and hardware evidence
+        run: |
+          set -euo pipefail
+          gh run download "${CANDIDATE_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name vibetv-release-candidate \
+            --dir candidate
+          gh run download "${CANDIDATE_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name vibetv-release-candidate-result \
+            --dir candidate-result
+          gh run download "${HARDWARE_CANARY_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name vibetv-hardware-canary \
+            --dir hardware
+
+      - name: Validate exact publish evidence and freeze assets
+        run: |
+          set -euo pipefail
+          python3 scripts/validate-release-publish-gate.py preflight \
+            --repository "${GITHUB_REPOSITORY}" \
+            --source-sha "${SOURCE_SHA}" \
+            --version "${VERSION}" \
+            --candidate-run-id "${CANDIDATE_RUN_ID}" \
+            --candidate-run evidence/candidate-run.json \
+            --candidate-workflow evidence/candidate-workflow.json \
+            --candidate-dir candidate \
+            --candidate-result candidate-result/candidate-result.json \
+            --hardware-canary-run-id "${HARDWARE_CANARY_RUN_ID}" \
+            --hardware-run evidence/hardware-run.json \
+            --hardware-workflow evidence/hardware-workflow.json \
+            --hardware-evidence hardware/hardware-canary.json \
+            --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --output validated/publish-payload.json \
+            --copy-dir validated/assets
+
+      - name: Upload validated internal publish payload
+        uses: actions/upload-artifact@v4
+        with:
+          name: vibetv-validated-publish
+          path: |
+            validated/publish-payload.json
+            validated/assets
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-release:
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: Production
     permissions:
       contents: write
+      actions: read
+    env:
+      VERSION: ${{ inputs.version }}
+      SOURCE_SHA: ${{ github.sha }}
+      GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: companion/go.mod
-          cache-dependency-path: companion/go.sum
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: apps/control-center/package-lock.json
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install PlatformIO
-        run: pip install platformio intelhex
-
-      - name: Build Release Artifacts
-        env:
-          VERSION: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          VERSION="${VERSION#v}"
-          mkdir -p dist/companion dist/firmware
-
-          if [[ ! -f scripts/install.sh ]]; then
-            echo "error: scripts/install.sh is missing" >&2
-            exit 1
-          fi
-          cp scripts/install.sh dist/install.sh
-          chmod +x dist/install.sh
-          cp scripts/install-control-center-companion-release.sh dist/install-control-center-companion.sh
-          chmod +x dist/install-control-center-companion.sh
-
-          (
-            cd apps/control-center
-            npm ci
-            npx playwright install --with-deps chromium
-            npm run build:local
-            npm run test:customer-smoke
-          )
-          rm -rf companion/internal/companionapi/controlcenter_static
-          mkdir -p companion/internal/companionapi/controlcenter_static
-          cp -R apps/control-center/out-local/. companion/internal/companionapi/controlcenter_static/
-
-          cd companion
-          for ARCH in amd64 arm64; do
-            OUT="../dist/companion/codexbar-display-darwin-${ARCH}-v${VERSION}"
-            GOOS=darwin GOARCH="${ARCH}" CGO_ENABLED=0 \
-              go build \
-              -ldflags "-s -w -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Version=${VERSION} -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Commit=${GITHUB_SHA} -X github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/buildinfo.Date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-              -o "${OUT}" ./cmd/codexbar-display
-          done
-          cd ..
-
-          ./scripts/build-macos-control-center-app.sh \
-            --dry-run \
-            --version "${VERSION}" \
-            --build "${GITHUB_RUN_NUMBER:-0}" \
-            --output "tmp/macos-release-dry-run/VibeTV Control Center.app"
-          ./scripts/build-macos-control-center-dmg.sh \
-            --dry-run \
-            --app "tmp/macos-release-dry-run/VibeTV Control Center.app" \
-            --output "tmp/macos-release-dry-run/VibeTV-Control-Center-v${VERSION}.dmg" \
-            --staging-dir "tmp/macos-release-dry-run/dmg-stage"
-          ./scripts/sign-notarize-macos-control-center.sh \
-            --dry-run \
-            --app "tmp/macos-release-dry-run/VibeTV Control Center.app" \
-            --dmg "tmp/macos-release-dry-run/VibeTV-Control-Center-v${VERSION}.dmg"
-
-          if [[ ! -f release/firmware-versions.json ]]; then
-            echo "error: release/firmware-versions.json is missing" >&2
-            exit 1
-          fi
-
-          python3 - "$VERSION" release/firmware-versions.json > dist/firmware/targets.tsv <<'PY'
-          import json
-          import sys
-
-          release_version = sys.argv[1].strip().lstrip("v")
-          config_path = sys.argv[2]
-
-          with open(config_path, encoding="utf-8") as f:
-              config = json.load(f)
-
-          seen = set()
-          for artifact in config.get("artifacts", []):
-              env_name = str(artifact.get("firmwareEnv", "")).strip()
-              board = str(artifact.get("board", "")).strip()
-              firmware_version = str(artifact.get("firmwareVersion", "")).strip().lstrip("v")
-              if not env_name or not board or not firmware_version:
-                  raise SystemExit("firmware artifacts need firmwareEnv, board, and firmwareVersion")
-              if env_name in seen:
-                  raise SystemExit(f"duplicate firmware env: {env_name}")
-              seen.add(env_name)
-              if firmware_version == release_version:
-                  print(f"notice: firmware {env_name} is intentionally bumped to app release {release_version}", file=sys.stderr)
-              if env_name == "esp8266_smalltv_st7789":
-                  directory = "firmware_esp8266"
-                  asset = f"codexbar-display-firmware-{env_name}-v{firmware_version}.bin.gz"
-              elif env_name == "lilygo_t_display_s3":
-                  directory = "firmware_esp32"
-                  asset = f"codexbar-display-firmware-{env_name}-v{firmware_version}.bin"
-              else:
-                  raise SystemExit(f"unsupported firmware env: {env_name}")
-              print("\t".join([directory, env_name, board, firmware_version, asset]))
-          PY
-
-          while IFS=$'\t' read -r DIR ENV_NAME BOARD FW_VERSION ASSET; do
-            MAX_FLASH_PCT="46"
-            MAX_RAM_PCT="82"
-            MAX_BIN_BYTES="0"
-            MAX_GZIP_BYTES="0"
-            if [[ "${ENV_NAME}" == "esp8266_smalltv_st7789" ]]; then
-              MAX_BIN_BYTES="482000"
-              MAX_GZIP_BYTES="350000"
-            fi
-
-            BUILD_LOG="$(mktemp)"
-            (
-              cd "${DIR}"
-              CODEXBAR_DISPLAY_FW_VERSION="${FW_VERSION}" pio run -e "${ENV_NAME}"
-            ) 2>&1 | tee "${BUILD_LOG}"
-
-            SRC="${DIR}/.pio/build/${ENV_NAME}/firmware.bin"
-            ./scripts/check-firmware-size-budget.sh \
-              "${BUILD_LOG}" \
-              "${SRC}" \
-              "${ENV_NAME}" \
-              "${MAX_FLASH_PCT}" \
-              "${MAX_RAM_PCT}" \
-              "${MAX_BIN_BYTES}" \
-              "${MAX_GZIP_BYTES}"
-            DEST="dist/firmware/${ASSET}"
-            if [[ "${ENV_NAME}" == esp8266_* ]]; then
-              gzip -c -9 "${SRC}" > "${DEST}"
-            else
-              cp "${SRC}" "${DEST}"
-            fi
-          done < dist/firmware/targets.tsv
-
-          VERSION="${VERSION}" python3 - release/firmware-versions.json <<'PY'
-          import hashlib
-          import json
-          import os
-          import sys
-
-          version = os.environ["VERSION"]
-          repo = os.environ.get("GITHUB_REPOSITORY", "DreamyTalesPAN/CodexBar-Display")
-          config_path = sys.argv[1]
-
-          with open(config_path, encoding="utf-8") as f:
-              config = json.load(f)
-
-          manifest = {
-              "schemaVersion": 1,
-              "release": f"v{version}",
-              "protocolVersion": config.get("protocolVersion", 1),
-              "artifacts": [],
-          }
-
-          for artifact in config.get("artifacts", []):
-              env_name = str(artifact.get("firmwareEnv", "")).strip()
-              board = str(artifact.get("board", "")).strip()
-              firmware_version = str(artifact.get("firmwareVersion", "")).strip().lstrip("v")
-              if not env_name or not board or not firmware_version:
-                  raise SystemExit("firmware artifacts need firmwareEnv, board, and firmwareVersion")
-              asset = f"codexbar-display-firmware-{env_name}-v{firmware_version}.bin"
-              if env_name.startswith("esp8266_"):
-                  asset += ".gz"
-              path = f"dist/firmware/{asset}"
-              with open(path, "rb") as f:
-                  sha = hashlib.sha256(f.read()).hexdigest()
-
-              manifest["artifacts"].append(
-                  {
-                      "firmwareEnv": env_name,
-                      "board": board,
-                      "firmwareVersion": firmware_version,
-                      "asset": asset,
-                      "sha256": sha,
-                      "severity": str(artifact.get("severity") or "recommended"),
-                      "message": str(artifact.get("message") or "Firmware update available. Open the VibeTV Mac App."),
-                      "firmwareUrl": f"https://github.com/{repo}/releases/download/v{version}/{asset}",
-                  }
-              )
-
-          for out_path in (
-              f"dist/firmware/firmware-manifest-v{version}.json",
-              "dist/firmware/firmware-manifest.json",
-          ):
-              with open(out_path, "w", encoding="utf-8") as f:
-                  json.dump(manifest, f, indent=2)
-                  f.write("\n")
-          PY
-
-      - name: Download notarized Mac DMG
+      - name: Download validated publish payload and candidate assets
         uses: actions/download-artifact@v4
         with:
-          name: vibetv-control-center-dmg
-          path: dist/macos
+          name: vibetv-validated-publish
+          path: validated
 
-      - name: Require verified Mac DMG
-        run: |
-          test -f dist/macos/VibeTV-Control-Center.dmg
-          test -s dist/macos/appcast.xml
-
-      - name: Build release checksums
-        env:
-          VERSION: ${{ github.ref_name }}
+      - name: Recheck current main after Production approval
         run: |
           set -euo pipefail
+          CURRENT_MAIN_SHA="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" \
+              --jq .object.sha
+          )"
+          [[ "${CURRENT_MAIN_SHA}" == "${SOURCE_SHA}" ]] || {
+            echo "error: main moved from validated ${SOURCE_SHA} to ${CURRENT_MAIN_SHA}; dispatch a new release candidate" >&2
+            exit 1
+          }
 
-          VERSION="${VERSION#v}"
-          (
-            cd dist
-            find . -type f ! -name "checksums-*" -print0 | sort -z | xargs -0 sha256sum > "checksums-v${VERSION}.txt"
+      - name: Recheck unpublished version after Production approval
+        run: |
+          set -euo pipefail
+          ensure_absent() {
+            local endpoint="$1"
+            local label="$2"
+            local error_file
+            error_file="$(mktemp)"
+            if gh api "${endpoint}" >/dev/null 2>"${error_file}"; then
+              echo "error: ${label} already exists" >&2
+              exit 1
+            fi
+            if ! grep -F "HTTP 404" "${error_file}" >/dev/null; then
+              cat "${error_file}" >&2
+              echo "error: could not prove ${label} is absent" >&2
+              exit 1
+            fi
+          }
+          ensure_absent \
+            "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${VERSION}" \
+            "tag v${VERSION}"
+          ensure_absent \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" \
+            "release v${VERSION}"
+
+      - name: Create exact GitHub tag and release without rebuild
+        run: |
+          set -euo pipefail
+          test -s validated/publish-payload.json
+          mapfile -d '' release_files < <(
+            find validated/assets -type f -print0 | sort -z
           )
+          (( ${#release_files[@]} > 0 )) \
+            || { echo "error: validated candidate assets are missing" >&2; exit 1; }
+          gh release create "v${VERSION}" "${release_files[@]}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --target "${SOURCE_SHA}" \
+            --title "v${VERSION}" \
+            --generate-notes
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            dist/install.sh
-            dist/install-control-center-companion.sh
-            dist/companion/*
-            dist/firmware/*.bin
-            dist/firmware/*.bin.gz
-            dist/firmware/firmware-manifest.json
-            dist/firmware/firmware-manifest-*.json
-            dist/macos/*.dmg
-            dist/macos/appcast.xml
-            dist/checksums-*.txt
-
-  verify-release-canary:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+  verify-public-release:
+    needs: publish-release
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: build-and-release
+    permissions:
+      contents: read
     steps:
-      - name: Checkout
+      - name: Checkout exact published source for canary script
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
-      - name: Verify prerelease installs are offered the final release
-        env:
-          VERSION: ${{ github.ref_name }}
-        run: ./scripts/verify-release-canary.sh --version "${VERSION#v}"
+      - name: Verify published release endpoints
+        run: ./scripts/verify-release-canary.sh --version "${{ inputs.version }}"

--- a/docs/vibetv-hosted-gates.md
+++ b/docs/vibetv-hosted-gates.md
@@ -27,6 +27,13 @@ Sparkle metadata, checks the Companion's loopback port `47832`, captures JSON
 and a screenshot, and drives health, render, stream, OTA, and duplicate-OTA
 no-op behavior through the Core branch's `virtual-vibetv` executable.
 
+The guided physical canary uses the customer device's real update path: an
+authenticated OTA update over local WiFi. Customer VibeTV units expose no USB
+data or recovery port, so the canary does not pretend to create a USB backup.
+Before an OTA write it requires the exact device ID and an explicit
+hardware-risk confirmation. If the OTA result is unclear, it stops without a
+retry or automatic rollback; the device may require service or replacement.
+
 ## Current dependency
 
 The current main branch does not yet contain Issue #177 Core's

--- a/docs/vibetv-hosted-gates.md
+++ b/docs/vibetv-hosted-gates.md
@@ -27,12 +27,13 @@ Sparkle metadata, checks the Companion's loopback port `47832`, captures JSON
 and a screenshot, and drives health, render, stream, OTA, and duplicate-OTA
 no-op behavior through the Core branch's `virtual-vibetv` executable.
 
-The guided physical canary uses the customer device's real update path: an
-authenticated OTA update over local WiFi. Customer VibeTV units expose no USB
-data or recovery port, so the canary does not pretend to create a USB backup.
-Before an OTA write it requires the exact device ID and an explicit
-hardware-risk confirmation. If the OTA result is unclear, it stops without a
-retry or automatic rollback; the device may require service or replacement.
+The guided physical canary always uses the device's real update path: an
+authenticated OTA update over local WiFi. Current customer VibeTV units expose
+no USB data or recovery port, so they run the canary without a USB backup.
+Future lab hardware can supply an optional recovery port; the canary then
+creates a full backup before the WiFi OTA. Both paths require the exact device
+ID and an explicit hardware-risk confirmation. If the OTA result is unclear,
+the canary stops without a retry or automatic rollback.
 
 ## Current dependency
 

--- a/scripts/fixtures/release-publish-gate/valid.json
+++ b/scripts/fixtures/release-publish-gate/valid.json
@@ -68,7 +68,7 @@
         "name": "appcast.xml",
         "path": "publish/appcast.xml",
         "sha256": "",
-        "role": "production-appcast",
+        "role": "sparkle-appcast",
         "publish": true
       },
       {

--- a/scripts/fixtures/release-publish-gate/valid.json
+++ b/scripts/fixtures/release-publish-gate/valid.json
@@ -1,0 +1,173 @@
+{
+  "repository": "DreamyTalesPAN/CodexBar-Display",
+  "sourceSha": "0123456789abcdef0123456789abcdef01234567",
+  "version": "1.2.3",
+  "candidateRunId": "12345",
+  "hardwareCanaryRunId": "67890",
+  "now": "2026-07-28T12:00:00Z",
+  "files": {
+    "publish/VibeTV-Control-Center.dmg": "fixture signed dmg\n",
+    "publish/appcast.xml": "<rss><channel><item><enclosure url=\"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.2.3/VibeTV-Control-Center.dmg\" /></item></channel></rss>\n",
+    "publish/install.sh": "#!/usr/bin/env bash\n",
+    "publish/install-control-center-companion.sh": "#!/usr/bin/env bash\n",
+    "publish/codexbar-display-darwin-amd64-v1.2.3": "fixture amd64 companion\n",
+    "publish/codexbar-display-darwin-arm64-v1.2.3": "fixture arm64 companion\n",
+    "publish/firmware.bin": "fixture firmware\n",
+    "publish/firmware-manifest.json": "{\"schemaVersion\":1,\"artifacts\":[{\"asset\":\"firmware.bin\",\"firmwareUrl\":\"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.2.3/firmware.bin\"}]}\n",
+    "publish/firmware-manifest-v1.2.3.json": "{\"schemaVersion\":1,\"artifacts\":[{\"asset\":\"firmware.bin\",\"firmwareUrl\":\"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.2.3/firmware.bin\"}]}\n",
+    "publish/checksums-v1.2.3.txt": "fixture checksums\n",
+    "test/codexbar-display": "fixture test-only universal companion\n",
+    "test/virtual-vibetv": "fixture virtual VibeTV\n"
+  },
+  "candidateRun": {
+    "id": 12345,
+    "conclusion": "success",
+    "event": "workflow_dispatch",
+    "head_sha": "0123456789abcdef0123456789abcdef01234567",
+    "head_branch": "main",
+    "workflow_id": 101,
+    "repository": {
+      "full_name": "DreamyTalesPAN/CodexBar-Display"
+    }
+  },
+  "candidateWorkflow": {
+    "id": 101,
+    "path": ".github/workflows/vibetv-release-candidate.yml"
+  },
+  "hardwareRun": {
+    "id": 67890,
+    "conclusion": "success",
+    "event": "workflow_dispatch",
+    "head_sha": "0123456789abcdef0123456789abcdef01234567",
+    "head_branch": "main",
+    "workflow_id": 202,
+    "repository": {
+      "full_name": "DreamyTalesPAN/CodexBar-Display"
+    }
+  },
+  "hardwareWorkflow": {
+    "id": 202,
+    "path": ".github/workflows/record-hardware-canary.yml"
+  },
+  "candidateManifest": {
+    "schemaVersion": 1,
+    "repository": "DreamyTalesPAN/CodexBar-Display",
+    "sourceSha": "0123456789abcdef0123456789abcdef01234567",
+    "version": "1.2.3",
+    "candidateRunId": "12345",
+    "createdAt": "2026-07-28T08:00:00Z",
+    "artifacts": [
+      {
+        "name": "VibeTV-Control-Center.dmg",
+        "path": "publish/VibeTV-Control-Center.dmg",
+        "sha256": "",
+        "role": "signed-dmg",
+        "publish": true
+      },
+      {
+        "name": "appcast.xml",
+        "path": "publish/appcast.xml",
+        "sha256": "",
+        "role": "production-appcast",
+        "publish": true
+      },
+      {
+        "name": "install.sh",
+        "path": "publish/install.sh",
+        "sha256": "",
+        "role": "installer",
+        "publish": true
+      },
+      {
+        "name": "install-control-center-companion.sh",
+        "path": "publish/install-control-center-companion.sh",
+        "sha256": "",
+        "role": "installer",
+        "publish": true
+      },
+      {
+        "name": "codexbar-display-darwin-amd64-v1.2.3",
+        "path": "publish/codexbar-display-darwin-amd64-v1.2.3",
+        "sha256": "",
+        "role": "companion-amd64",
+        "publish": true
+      },
+      {
+        "name": "codexbar-display-darwin-arm64-v1.2.3",
+        "path": "publish/codexbar-display-darwin-arm64-v1.2.3",
+        "sha256": "",
+        "role": "companion-arm64",
+        "publish": true
+      },
+      {
+        "name": "firmware.bin",
+        "path": "publish/firmware.bin",
+        "sha256": "",
+        "role": "firmware",
+        "publish": true
+      },
+      {
+        "name": "firmware-manifest.json",
+        "path": "publish/firmware-manifest.json",
+        "sha256": "",
+        "role": "firmware-manifest",
+        "publish": true
+      },
+      {
+        "name": "firmware-manifest-v1.2.3.json",
+        "path": "publish/firmware-manifest-v1.2.3.json",
+        "sha256": "",
+        "role": "firmware-manifest",
+        "publish": true
+      },
+      {
+        "name": "checksums-v1.2.3.txt",
+        "path": "publish/checksums-v1.2.3.txt",
+        "sha256": "",
+        "role": "checksums",
+        "publish": true
+      },
+      {
+        "name": "codexbar-display",
+        "path": "test/codexbar-display",
+        "sha256": "",
+        "role": "test-companion",
+        "publish": false
+      },
+      {
+        "name": "virtual-vibetv",
+        "path": "test/virtual-vibetv",
+        "sha256": "",
+        "role": "virtual-vibetv",
+        "publish": false
+      }
+    ],
+    "virtualGate": {
+      "result": "pending",
+      "runId": "12345"
+    }
+  },
+  "candidateResult": {
+    "schemaVersion": 1,
+    "repository": "DreamyTalesPAN/CodexBar-Display",
+    "sourceSha": "0123456789abcdef0123456789abcdef01234567",
+    "version": "1.2.3",
+    "candidateRunId": "12345",
+    "result": "success",
+    "artifactHashes": {}
+  },
+  "hardwareEvidence": {
+    "schemaVersion": 1,
+    "repository": "DreamyTalesPAN/CodexBar-Display",
+    "sourceSha": "0123456789abcdef0123456789abcdef01234567",
+    "version": "1.2.3",
+    "candidateRunId": "12345",
+    "candidateManifestSha256": "",
+    "artifactHashes": {},
+    "timestamps": {
+      "startedAt": "2026-07-28T10:00:00Z",
+      "finishedAt": "2026-07-28T11:00:00Z"
+    },
+    "result": "success"
+  }
+}

--- a/scripts/test-control-center-release-workflow.sh
+++ b/scripts/test-control-center-release-workflow.sh
@@ -5,6 +5,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW="${ROOT}/.github/workflows/release.yml"
 CI_WORKFLOW="${ROOT}/.github/workflows/ci.yml"
 PREVIEW_WORKFLOW="${ROOT}/.github/workflows/validate-macos-dmg.yml"
+PUBLISH_WORKFLOW_TEST="${ROOT}/scripts/test-release-publish-workflow.sh"
+PUBLISH_GATE_TEST="${ROOT}/scripts/test-release-publish-gate.py"
 LOCAL_INSTALLER="${ROOT}/scripts/install-control-center-companion.sh"
 RELEASE_INSTALLER="${ROOT}/scripts/install-control-center-companion-release.sh"
 PUBLIC_INSTALLER="${ROOT}/apps/control-center/public/install-control-center-companion.sh"
@@ -14,15 +16,6 @@ VERIFY_DMG_SCRIPT="${ROOT}/scripts/verify-macos-control-center-dmg.sh"
 die() {
   printf 'error: %s\n' "$*" >&2
   exit 1
-}
-
-job_block() {
-  local job="$1"
-  awk -v job="$job" '
-    $0 == "  " job ":" { in_job = 1; print; next }
-    in_job && $0 ~ /^  [A-Za-z0-9_-]+:/ { exit }
-    in_job { print }
-  ' "$WORKFLOW"
 }
 
 assert_contains() {
@@ -39,55 +32,67 @@ assert_not_contains() {
   [[ "$haystack" != *"$needle"* ]] || die "$message"
 }
 
-line_number() {
-  local needle="$1"
-  grep -nF "$needle" "$WORKFLOW" | head -n1 | cut -d: -f1
-}
-
 installer_line_number() {
   local needle="$1"
   grep -nF "$needle" "$LOCAL_INSTALLER" | head -n1 | cut -d: -f1
 }
 
 main() {
+  [[ -x "$PUBLISH_WORKFLOW_TEST" ]] || die "publish workflow contract test is missing"
+  [[ -f "$PUBLISH_GATE_TEST" ]] || die "publish gate fixture test is missing"
   [[ -f "$WORKFLOW" ]] || die "release workflow is missing"
   [[ -f "$PREVIEW_WORKFLOW" ]] || die "macOS preview workflow is missing"
   [[ -f "$LOCAL_INSTALLER" ]] || die "local Control Center installer is missing"
   [[ -f "$RELEASE_INSTALLER" ]] || die "release Control Center installer is missing"
   [[ -f "$PUBLIC_INSTALLER" ]] || die "public Control Center installer is missing"
-  [[ -x "$SIGNING_SCRIPT" ]] || die "macOS signing/notarization script is missing or not executable"
-  [[ -x "$VERIFY_DMG_SCRIPT" ]] || die "macOS DMG verification script is missing or not executable"
+  [[ -x "$SIGNING_SCRIPT" ]] \
+    || die "macOS signing/notarization script is missing or not executable"
+  [[ -x "$VERIFY_DMG_SCRIPT" ]] \
+    || die "macOS DMG verification script is missing or not executable"
   cmp -s "$RELEASE_INSTALLER" "$PUBLIC_INSTALLER" \
     || die "public Control Center installer must match the release installer"
 
-  local release_job macos_job release_count checksum_line release_line download_dmg_line
-  local build_dmg_line verify_dmg_line upload_dmg_line require_dmg_line
-  local local_installer release_installer local_installer_build_line local_installer_go_build_line
-  local local_static_builder ci_workflow preview_workflow signing_script verify_dmg_plan workflow
+  "$PUBLISH_WORKFLOW_TEST"
+  python3 "$PUBLISH_GATE_TEST"
+
+  local workflow ci_workflow preview_workflow signing_script verify_dmg_plan
+  local local_installer release_installer local_static_builder
   local verify_dmg_open_line verify_syspolicy_line verify_app_spctl_line
-  release_job="$(job_block "build-and-release")"
+  local local_installer_build_line local_installer_go_build_line
+  workflow="$(cat "$WORKFLOW")"
+  ci_workflow="$(cat "$CI_WORKFLOW")"
+  preview_workflow="$(cat "$PREVIEW_WORKFLOW")"
+  signing_script="$(cat "$SIGNING_SCRIPT")"
   local_installer="$(cat "$LOCAL_INSTALLER")"
   release_installer="$(cat "$RELEASE_INSTALLER")"
   local_static_builder="$(cat "$ROOT/apps/control-center/scripts/build-local-static.mjs")"
-  ci_workflow="$(cat "$CI_WORKFLOW")"
-  preview_workflow="$(cat "$PREVIEW_WORKFLOW")"
-  workflow="$(cat "$WORKFLOW")"
-  signing_script="$(cat "$SIGNING_SCRIPT")"
-  verify_dmg_plan="$("$VERIFY_DMG_SCRIPT" --dry-run --dmg "/tmp/VibeTV-Control-Center.dmg")"
-  macos_job="$(job_block "build-macos-dmg")"
+  verify_dmg_plan="$("$VERIFY_DMG_SCRIPT" \
+    --dry-run \
+    --dmg "/tmp/VibeTV-Control-Center.dmg")"
 
-  assert_not_contains "$workflow" "workflow_dispatch:" \
-    "public release workflow must not expose the validation-only trigger"
-  assert_not_contains "$workflow" "validation_version:" \
-    "public release workflow must not accept a validation bundle version"
-  assert_contains "$workflow" "permissions:" \
-    "release workflow must declare least-privilege permissions"
-  assert_contains "$workflow" "contents: read" \
-    "release workflow must keep repository write access out of the build job"
+  # Publication consumes the already signed candidate. Signing secrets and
+  # build tools stay in the separate candidate workflow.
+  for forbidden in \
+    APPLE_SIGNING_CERTIFICATE_P12_BASE64 \
+    APPLE_NOTARY_KEY_P8_BASE64 \
+    SPARKLE_ED25519_PRIVATE_KEY \
+    build-macos-control-center-app.sh \
+    build-macos-control-center-dmg.sh \
+    sign-notarize-macos-control-center.sh \
+    "go build" \
+    "npm ci" \
+    "pio run" \
+    softprops/action-gh-release
+  do
+    assert_not_contains "$workflow" "$forbidden" \
+      "publish workflow must not rebuild or re-sign candidate assets: ${forbidden}"
+  done
 
+  # Preview remains a separate, trusted, read-only path.
   assert_contains "$preview_workflow" "workflow_dispatch:" \
     "preview workflow must remain manually dispatched"
-  assert_contains "$preview_workflow" "github.repository == 'DreamyTalesPAN/CodexBar-Display'" \
+  assert_contains "$preview_workflow" \
+    "github.repository == 'DreamyTalesPAN/CodexBar-Display'" \
     "preview workflow must stay limited to the trusted repository"
   assert_contains "$preview_workflow" "github.ref == 'refs/heads/main'" \
     "preview workflow definition must run only from trusted main"
@@ -103,124 +108,11 @@ main() {
     "preview workflow must not publish a GitHub Release"
   assert_contains "$preview_workflow" "persist-credentials: false" \
     "preview source checkout must not persist GitHub credentials"
+  assert_contains "$preview_workflow" \
+    "ref: 24c3855468991f28ef1af2df905b95944d90985c" \
+    "preview signing job must keep the reviewed nested-Sparkle source"
 
-  assert_contains "$macos_job" "runs-on: macos-15" \
-    "release workflow must pin the customer DMG build to macOS 15"
-  assert_contains "$macos_job" "APPLE_SIGNING_CERTIFICATE_P12_BASE64" \
-    "macOS DMG job must receive the Developer ID signing certificate secret"
-  assert_contains "$macos_job" "APPLE_NOTARY_KEY_P8_BASE64" \
-    "macOS DMG job must receive the Apple notarization key secret"
-  assert_contains "$macos_job" "Validate Apple release secrets" \
-    "macOS DMG job must fail before building when Apple secrets are absent"
-  assert_contains "$macos_job" "if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')" \
-    "macOS DMG job must run only for a public release tag"
-  assert_contains "$macos_job" 'VERSION: ${{ github.ref_name }}' \
-    "macOS DMG job must derive its version from the public release tag"
-  assert_contains "$macos_job" "macOS DMG version must be SemVer x.y.z" \
-    "release DMG build must reject an invalid bundle version"
-  assert_contains "$macos_job" 'Missing required GitHub Actions secret: ${name}' \
-    "macOS DMG job must report missing Apple secrets without exposing their values"
-  for secret in \
-    APPLE_TEAM_ID \
-    APPLE_SIGNING_CERTIFICATE_P12_BASE64 \
-    APPLE_SIGNING_CERTIFICATE_PASSWORD \
-    APPLE_NOTARY_KEY_ID \
-    APPLE_NOTARY_ISSUER_ID \
-    APPLE_NOTARY_KEY_P8_BASE64
-  do
-    assert_contains "$macos_job" "$secret" \
-      "macOS DMG job must validate ${secret}"
-  done
-  assert_contains "$macos_job" "npm run build:local" \
-    "macOS DMG job must build the local Control Center static export"
-  assert_contains "$macos_job" "companion/internal/companionapi/controlcenter_static" \
-    "macOS DMG job must embed the local Control Center static export before building the bundled companion"
-  assert_contains "$macos_job" "cp -R apps/control-center/out-local/. companion/internal/companionapi/controlcenter_static/" \
-    "macOS DMG job must copy the local Control Center static export into the bundled companion"
-  assert_contains "$macos_job" "for ARCH in amd64 arm64" \
-    "macOS DMG job must build both Darwin companion architectures"
-  assert_contains "$macos_job" "lipo -create" \
-    "macOS DMG job must combine the bundled companion binary into a universal binary"
-  assert_contains "$macos_job" "build-macos-control-center-app.sh" \
-    "macOS DMG job must build the real app bundle"
-  assert_contains "$macos_job" "--universal" \
-    "macOS DMG job must build a universal native app shell"
-  assert_contains "$macos_job" "--sign-app-only" \
-    "macOS DMG job must sign the app before creating the DMG"
-  assert_contains "$macos_job" "build-macos-control-center-dmg.sh" \
-    "macOS DMG job must build the real DMG"
-  assert_contains "$macos_job" "--skip-app-sign" \
-    "macOS DMG job must sign and notarize the DMG without re-signing the app copy"
-  assert_contains "$macos_job" "--notary-log" \
-    "macOS DMG job must preserve Apple notarization evidence"
-  assert_contains "$macos_job" "Verify notarized Mac DMG for distribution" \
-    "macOS DMG job must run a separate final distribution gate"
-  assert_contains "$macos_job" "verify-macos-control-center-dmg.sh" \
-    "macOS DMG job must verify the exact DMG that will be uploaded"
-  assert_contains "$macos_job" "Upload notarization evidence" \
-    "macOS DMG job must preserve the Apple notarization log"
-  assert_contains "$macos_job" "VibeTV-Control-Center.dmg" \
-    "macOS DMG job must produce the stable latest-download DMG asset"
-  assert_contains "$macos_job" "-o dist/macos/appcast.xml" \
-    "Sparkle must write the appcast where verification and release upload expect it"
-  assert_not_contains "$macos_job" "-o appcast.xml" \
-    "Sparkle must not write the appcast outside the release artifact directory"
-  assert_contains "$macos_job" "actions/upload-artifact@v4" \
-    "macOS DMG job must upload the notarized DMG for the release job"
-  assert_not_contains "$macos_job" "--dry-run" \
-    "macOS DMG job must run the real signing/notarization path"
-  assert_contains "$release_job" "needs: build-macos-dmg" \
-    "public release job must wait for the notarized Mac DMG"
-  assert_contains "$release_job" "if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')" \
-    "public release job must run only for a release tag"
-  assert_contains "$release_job" "contents: write" \
-    "only the public tag release job may receive repository write access"
-  assert_contains "$release_job" "Build release checksums" \
-    "build-and-release must build release checksums"
-  assert_contains "$release_job" "release/firmware-versions.json" \
-    "release workflow must read explicit firmware versions"
-  assert_contains "$release_job" "dist/install-control-center-companion.sh" \
-    "GitHub Release must include the Mac setup script"
-  assert_contains "$release_job" "npm run build:local" \
-    "release workflow must build the local Control Center static export"
-  assert_contains "$release_job" "companion/internal/companionapi/controlcenter_static" \
-    "release workflow must embed the local Control Center static export"
-  assert_contains "$release_job" "dist/companion/*" \
-    "GitHub Release must include the Mac companion binaries"
-  assert_contains "$release_job" "Download notarized Mac DMG" \
-    "release workflow must download the notarized DMG before checksums"
-  assert_contains "$release_job" "actions/download-artifact@v4" \
-    "release workflow must download the notarized DMG artifact"
-  assert_contains "$release_job" "Require verified Mac DMG" \
-    "release workflow must require the exact stable DMG before checksums"
-  assert_contains "$release_job" "dist/macos/*.dmg" \
-    "GitHub Release must include the notarized Mac DMG"
-  assert_contains "$release_job" "build-macos-control-center-app.sh" \
-    "release workflow must dry-run the macOS app bundle structure"
-  assert_contains "$release_job" "build-macos-control-center-dmg.sh" \
-    "release workflow must dry-run the macOS DMG structure"
-  assert_contains "$release_job" "sign-notarize-macos-control-center.sh" \
-    "release workflow must dry-run the macOS signing/notary plan"
-  assert_contains "$release_job" "tmp/macos-release-dry-run" \
-    "release workflow dry-run artifacts must stay out of dist checksums"
-  assert_contains "$release_job" 'CODEXBAR_DISPLAY_FW_VERSION="${FW_VERSION}"' \
-    "firmware builds must use the explicit firmware version"
-  assert_not_contains "$release_job" 'CODEXBAR_DISPLAY_FW_VERSION="${VERSION}"' \
-    "firmware version must not be derived from the app release tag"
-  assert_not_contains "$release_job" '"firmwareVersion": version' \
-    "firmware manifest versions must not be derived from the app release tag"
-  assert_not_contains "$release_job" "needs: build-companion-pkgs" \
-    "build-and-release must not wait for Mac App PKGs"
-  assert_not_contains "$release_job" "companion-pkgs" \
-    "build-and-release must not reference package artifacts"
-  assert_not_contains "$release_job" "dist/companion-pkg" \
-    "GitHub Release must not include Mac App package assets"
-  assert_not_contains "$release_job" ".pkg" \
-    "GitHub Release must not include Mac App package assets"
-  assert_not_contains "$release_job" "brew " \
-    "GitHub Release must not publish Homebrew assets"
-  assert_not_contains "$(cat "$WORKFLOW")" "build-companion-pkgs:" \
-    "release workflow must not build Mac App packages"
+  # CI still owns the local dry-run and native macOS checks.
   assert_contains "$ci_workflow" "Test macOS Control Center DMG prep" \
     "CI must run the macOS app/DMG dry-run test"
   assert_contains "$ci_workflow" "test-macos-control-center-app-bundle.sh" \
@@ -229,19 +121,33 @@ main() {
     "CI must isolate native Swift checks in a macOS job"
   assert_contains "$ci_workflow" "runs-on: macos-latest" \
     "native Swift and URL-scheme checks must run on macOS"
-  assert_contains "$(cat "$ROOT/apps/control-center/src/app/api/companion/latest/route.ts")" "CONTROL_CENTER_ENABLE_MAC_APP_DMG_DOWNLOAD" \
+
+  assert_contains \
+    "$(cat "$ROOT/apps/control-center/src/app/api/companion/latest/route.ts")" \
+    "CONTROL_CENTER_ENABLE_MAC_APP_DMG_DOWNLOAD" \
     "hosted DMG download must stay behind the server-side feature flag"
-  assert_contains "$(cat "$ROOT/apps/control-center/src/app/api/companion/latest/route.ts")" "VibeTV-Control-Center.dmg" \
+  assert_contains \
+    "$(cat "$ROOT/apps/control-center/src/app/api/companion/latest/route.ts")" \
+    "VibeTV-Control-Center.dmg" \
     "hosted release check must require the exact stable DMG asset name"
-  assert_contains "$(cat "$ROOT/apps/control-center/src/app/api/companion/latest/route.ts")" "verifiedDmgAsset" \
+  assert_contains \
+    "$(cat "$ROOT/apps/control-center/src/app/api/companion/latest/route.ts")" \
+    "verifiedDmgAsset" \
     "hosted release check must verify the GitHub asset before returning its URL"
-  assert_not_contains "$(cat "$ROOT/apps/control-center/src/components/mac-app-install-command.ts")" "releases/latest/download/VibeTV-Control-Center.dmg" \
+  assert_not_contains \
+    "$(cat "$ROOT/apps/control-center/src/components/mac-app-install-command.ts")" \
+    "releases/latest/download/VibeTV-Control-Center.dmg" \
     "hosted setup must not use an unchecked latest-release DMG fallback"
-  assert_contains "$(cat "$ROOT/apps/control-center/src/components/setup-screen.tsx")" "Download Mac App" \
+  assert_contains \
+    "$(cat "$ROOT/apps/control-center/src/components/setup-screen.tsx")" \
+    "Download Mac App" \
     "hosted setup must present the DMG download as the primary Mac App action"
-  assert_contains "$(cat "$ROOT/macos/VibeTVControlCenter/main.swift")" "migration-backups" \
+  assert_contains "$(cat "$ROOT/macos/VibeTVControlCenter/main.swift")" \
+    "migration-backups" \
     "native Mac App must preserve old setup LaunchAgents during migration"
 
+  # Keep direct signing/notarization safety coverage even though publication
+  # no longer signs or rebuilds.
   assert_contains "$signing_script" "--output-format json" \
     "signing script must capture structured notarytool output"
   assert_contains "$signing_script" 'notary_status" != "Accepted"' \
@@ -251,129 +157,94 @@ main() {
   assert_contains "$signing_script" "xcrun stapler validate" \
     "signing script must validate the stapled DMG ticket"
   assert_contains "$signing_script" "syspolicy_check notary-submission" \
-    "signing script must run Apple's pre-notarization system-policy check when available"
+    "signing script must run the modern pre-notarization policy check"
   assert_contains "$signing_script" "--allow-internal-xprotect-preflight-error" \
-    "signing script must expose the narrow validation-only XProtect preflight exception"
-  assert_contains "$macos_job" "--allow-internal-xprotect-preflight-error" \
-    "release workflow must allow only the signing script's exact internal XProtect preflight diagnostic"
+    "signing script must keep the narrow XProtect diagnostic exception"
   assert_contains "$signing_script" "notarization log contains" \
-    "signing script must reject Accepted notarization logs that still contain issues"
+    "Accepted notarization logs with issues must still fail"
   assert_contains "$signing_script" "does not match APPLE_TEAM_ID" \
     "signing script must reject a certificate for the wrong Apple team"
-  assert_contains "$(cat "$PREVIEW_WORKFLOW")" \
-    "ref: 24c3855468991f28ef1af2df905b95944d90985c" \
-    "preview signing job must use the reviewed main commit with nested Sparkle signing"
 
-  assert_contains "$verify_dmg_plan" "hdiutil verify" \
-    "DMG distribution gate must verify the disk image container"
-  assert_contains "$verify_dmg_plan" "codesign --verify --strict" \
-    "DMG distribution gate must verify the DMG signature"
-  assert_contains "$verify_dmg_plan" "xcrun stapler validate" \
-    "DMG distribution gate must validate the stapled notarization ticket"
-  assert_contains "$verify_dmg_plan" "spctl --assess --type open" \
-    "DMG distribution gate must ask Gatekeeper to assess the disk image"
-  assert_contains "$verify_dmg_plan" "hdiutil attach -readonly" \
-    "DMG distribution gate must mount the exact final artifact read-only"
-  assert_contains "$verify_dmg_plan" "spctl --assess --type execute" \
-    "DMG distribution gate must ask Gatekeeper to assess the bundled app"
-  assert_contains "$verify_dmg_plan" "syspolicy_check distribution" \
-    "DMG distribution gate must run Apple's modern mounted-app policy check when available"
+  # Keep the static final-DMG distribution gate and ordering checks.
+  for required in \
+    "hdiutil verify" \
+    "codesign --verify --strict" \
+    "xcrun stapler validate" \
+    "spctl --assess --type open" \
+    "hdiutil attach -readonly" \
+    "spctl --assess --type execute" \
+    "syspolicy_check distribution"
+  do
+    assert_contains "$verify_dmg_plan" "$required" \
+      "DMG distribution gate is missing: ${required}"
+  done
+  verify_dmg_open_line="$(
+    printf '%s\n' "$verify_dmg_plan" |
+      grep -nF "spctl --assess --type open" |
+      cut -d: -f1
+  )"
+  verify_syspolicy_line="$(
+    printf '%s\n' "$verify_dmg_plan" |
+      grep -nF "syspolicy_check distribution" |
+      cut -d: -f1
+  )"
+  verify_app_spctl_line="$(
+    printf '%s\n' "$verify_dmg_plan" |
+      grep -nF "spctl --assess --type execute" |
+      cut -d: -f1
+  )"
+  (( verify_dmg_open_line < verify_syspolicy_line &&
+    verify_syspolicy_line < verify_app_spctl_line )) \
+    || die "mounted-app policy checks are in the wrong order"
 
-  verify_dmg_open_line="$(printf '%s\n' "$verify_dmg_plan" | grep -nF "spctl --assess --type open" | cut -d: -f1)"
-  verify_syspolicy_line="$(printf '%s\n' "$verify_dmg_plan" | grep -nF "syspolicy_check distribution" | cut -d: -f1)"
-  verify_app_spctl_line="$(printf '%s\n' "$verify_dmg_plan" | grep -nF "spctl --assess --type execute" | cut -d: -f1)"
-  [[ -n "$verify_dmg_open_line" && -n "$verify_syspolicy_line" && -n "$verify_app_spctl_line" ]] \
-    || die "DMG distribution gate order markers are incomplete"
-  (( verify_dmg_open_line < verify_syspolicy_line && verify_syspolicy_line < verify_app_spctl_line )) \
-    || die "mounted-app syspolicy check must run after DMG assessment and before legacy app assessment"
-
-  release_count="$(grep -cF "softprops/action-gh-release@v2" "$WORKFLOW")"
-  [[ "$release_count" == "1" ]] \
-    || die "release workflow must have exactly one public GitHub Release creation step"
-
-  checksum_line="$(line_number "Build release checksums")"
-  release_line="$(line_number "Create GitHub Release")"
-  download_dmg_line="$(line_number "Download notarized Mac DMG")"
-  build_dmg_line="$(line_number "Build signed and notarized Mac DMG")"
-  verify_dmg_line="$(line_number "Verify notarized Mac DMG for distribution")"
-  upload_dmg_line="$(line_number "Upload notarized Mac DMG")"
-  require_dmg_line="$(line_number "Require verified Mac DMG")"
-  local_build_line="$(line_number "npm run build:local")"
-  companion_build_line="$(line_number "go build")"
-  [[ -n "$checksum_line" && -n "$release_line" && -n "$download_dmg_line" ]] \
-    || die "release workflow must build checksums before creating the release"
-  (( download_dmg_line < checksum_line )) \
-    || die "notarized DMG must be downloaded before release checksums are built"
-  (( build_dmg_line < verify_dmg_line && verify_dmg_line < upload_dmg_line )) \
-    || die "the final DMG must be notarized and verified before artifact upload"
-  (( download_dmg_line < require_dmg_line && require_dmg_line < checksum_line )) \
-    || die "the downloaded verified DMG must be required before release checksums"
-  (( checksum_line < release_line )) \
-    || die "release checksums must be built before creating the release"
-  [[ -n "$local_build_line" && -n "$companion_build_line" ]] \
-    || die "release workflow must build local Control Center before companion binaries"
-  (( local_build_line < companion_build_line )) \
-    || die "local Control Center static export must be embedded before Go binaries are built"
-
+  # Keep installer/customer-path safety coverage.
   assert_contains "$local_installer" "npm run build:local" \
     "local installer must build the local Control Center static export"
   assert_contains "$local_installer" "controlcenter_static" \
     "local installer must embed the local Control Center static export"
   local_installer_build_line="$(installer_line_number "npm run build:local")"
   local_installer_go_build_line="$(installer_line_number "go build")"
-  [[ -n "$local_installer_build_line" && -n "$local_installer_go_build_line" ]] \
-    || die "local installer must build local Control Center before companion binary"
   (( local_installer_build_line < local_installer_go_build_line )) \
-    || die "local installer must embed local Control Center before Go binary is built"
-  assert_contains "$local_static_builder" "http://127.0.0.1:47832/theme-packs/vibetv-theme-packs.json" \
-    "local static Control Center must resolve theme packs from the local Companion"
-  assert_contains "$local_static_builder" "dist\", \"theme-packs" \
-    "local static Control Center must embed built theme-pack downloads"
-  assert_contains "$release_installer" "fetch_dev_source_ref" \
-    "Preview setup must discover the deployed commit instead of installing the latest release"
-  assert_contains "$release_installer" "build_source_binary" \
-    "Preview setup must build the Mac App from the deployed source ref"
-  assert_contains "$release_installer" "/api/deployment" \
-    "Preview setup must read deployment metadata from the hosted app"
-  assert_contains "$release_installer" "verify_control_center_available" \
-    "installer must verify the local Control Center before opening it"
-  assert_contains "$release_installer" "verify_local_service_stable" \
-    "installer must verify the local service stays stable before opening it"
-  assert_contains "$release_installer" "ThrottleInterval" \
-    "installer LaunchAgent must throttle crash restart loops"
-  assert_contains "$release_installer" 'DISPLAY_DAEMON_LOG_ERR="${INSTALL_LOG_DIR}/daemon.err.log"' \
-    "installer must keep daemon logs in the customer support log folder"
-  assert_contains "$release_installer" "VIBETV" \
-    "installer must show a simple VIBETV customer-facing heading"
-  assert_contains "$release_installer" "INSTALL_LOG_PATH" \
-    "installer must write technical details to a support log"
-  assert_contains "$release_installer" "Support log:" \
-    "installer must tell customers where the support log is"
-  assert_contains "$release_installer" "--verbose" \
-    "installer must offer a verbose debug mode"
-  assert_contains "$release_installer" "VIBETV_VERBOSE" \
-    "installer must support verbose mode through the environment"
-  assert_contains "$release_installer" "step_start" \
-    "installer must show customer-friendly setup steps"
-  assert_contains "$release_installer" "run_quiet" \
-    "installer must hide noisy command output by default"
-  assert_contains "$release_installer" "run_quiet npm ci" \
-    "Preview setup must hide npm install output by default"
-  assert_contains "$release_installer" "run_quiet npm run build:local" \
-    "Preview setup must hide Control Center build output by default"
-  assert_contains "$release_installer" 'run_quiet "$BIN_PATH" install-update' \
-    "installer must hide firmware update command output by default"
+    || die "local installer must embed local Control Center before Go build"
+  assert_contains "$local_static_builder" \
+    "http://127.0.0.1:47832/theme-packs/vibetv-theme-packs.json" \
+    "local static Control Center must use the local Companion theme catalog"
+  assert_contains "$local_static_builder" 'dist", "theme-packs' \
+    "local static Control Center must embed theme-pack downloads"
 
-  # Firmware update copy reaches customers through the manifest message, so it
-  # must name the VibeTV Mac App instead of sending them to a hosted URL.
+  for required in \
+    fetch_dev_source_ref \
+    build_source_binary \
+    /api/deployment \
+    verify_control_center_available \
+    verify_local_service_stable \
+    ThrottleInterval \
+    VIBETV \
+    INSTALL_LOG_PATH \
+    "Support log:" \
+    --verbose \
+    VIBETV_VERBOSE \
+    step_start \
+    run_quiet \
+    "run_quiet npm ci" \
+    "run_quiet npm run build:local"
+  do
+    assert_contains "$release_installer" "$required" \
+      "release installer safety contract is missing: ${required}"
+  done
+  assert_contains "$release_installer" \
+    'DISPLAY_DAEMON_LOG_ERR="${INSTALL_LOG_DIR}/daemon.err.log"' \
+    "installer must keep daemon logs in the support log folder"
+  assert_contains "$release_installer" \
+    'run_quiet "$BIN_PATH" install-update' \
+    "installer must hide firmware update noise by default"
+
   local firmware_versions
   firmware_versions="$(cat "${ROOT}/release/firmware-versions.json")"
   assert_not_contains "$firmware_versions" "vibetv.shop" \
     "firmware update messages must not send customers to a hosted URL"
   assert_contains "$firmware_versions" "VibeTV Mac App" \
     "firmware update messages must name the VibeTV Mac App"
-  assert_not_contains "$(grep '"message"' "$WORKFLOW")" "vibetv.shop" \
-    "release workflow firmware message fallback must not send customers to a hosted URL"
 
   printf 'control-center release workflow test passed\n'
 }

--- a/scripts/test-hardware-release-canary.sh
+++ b/scripts/test-hardware-release-canary.sh
@@ -114,7 +114,10 @@ PY
   grep -F -- '--confirm-power-cycle-10s' "${CANARY}" >/dev/null || die "canary lacks explicit power-cycle confirmation"
   grep -F 'write_evidence unknown' "${CANARY}" >/dev/null || die "canary lacks unknown-write evidence"
   grep -F "role']=='companion'" "${CANARY}" >/dev/null || die "canary does not select the candidate companion role"
-  grep -F 'esp8266-backup.sh' "${CANARY}" >/dev/null || die "canary does not create the required full USB backup"
+  if grep -F -- '--recovery-port' "${CANARY}" >/dev/null || grep -F 'esp8266-backup.sh' "${CANARY}" >/dev/null; then
+    die "customer hardware canary must not require a nonexistent USB recovery path"
+  fi
+  grep -F 'WiFi-only' "${CANARY}" >/dev/null || die "canary does not disclose the WiFi-only update risk"
   grep -F 'vibetv-hardware-canary' "${WORKFLOW}" >/dev/null || die "workflow uses the wrong evidence artifact name"
   grep -F 'semver_compare' "${CANARY}" >/dev/null || die "canary does not compare firmware versions as SemVer"
   grep -F 'candidate-firmware-manifest.json' "${CANARY}" >/dev/null || die "canary does not create a local absolute firmware manifest"
@@ -128,8 +131,9 @@ PY
   grep -F 'gh api user --jq .login' "${CANARY}" >/dev/null || die "canary does not resolve a GitHub actor"
   grep -F 'wait_for_resume_health' "${CANARY}" >/dev/null || die "resume does not bound hello and health polling"
   grep -F 'daemon --transport wifi --target "$TARGET" --once' "${CANARY}" >/dev/null || die "resume does not rerun the candidate daemon"
-  grep -F 'esp8266-smalltv-st7789' "${CANARY}" >/dev/null || die "canary does not gate ESP8266 backup by board"
-  grep -F 'no recovery/backup path is implemented' "${CANARY}" >/dev/null || die "canary does not fail closed for unsupported firmware boards"
+  grep -F 'esp8266-smalltv-st7789' "${CANARY}" >/dev/null || die "canary does not gate firmware writes by supported board"
+  grep -F 'firmware write blocked for unsupported board' "${CANARY}" >/dev/null || die "canary does not fail closed for unsupported firmware boards"
+  grep -F 'exact --confirm-device-id and --confirm-hardware-write-risk' "${CANARY}" >/dev/null || die "canary does not require exact device and risk confirmation"
   if grep -F 'resume read-only' "${CANARY}" >/dev/null; then die "resume is misleadingly labelled read-only despite its frame send"; fi
 }
 

--- a/scripts/test-hardware-release-canary.sh
+++ b/scripts/test-hardware-release-canary.sh
@@ -27,7 +27,7 @@ make_candidate() {
   printf '<appcast/>\n' >"${dir}/macos/appcast.xml"
   printf 'virtual VibeTV fixture\n' >"${dir}/virtual/virtual-vibetv"
   cat >"${dir}/firmware/firmware-manifest.json" <<'JSON'
-{"schemaVersion":1,"artifacts":[{"board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.1","firmwareUrl":"firmware/firmware.bin","sha256":"placeholder"}]}
+{"schemaVersion":1,"artifacts":[{"board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.1","asset":"firmware/firmware.bin","firmwareUrl":"https://example.invalid/firmware.bin","sha256":"placeholder"}]}
 JSON
   local firmware_hash manifest_hash companion_hash
   firmware_hash="$(sha256 "${dir}/firmware/firmware.bin")"
@@ -43,7 +43,7 @@ PY
   manifest_hash="$(sha256 "${dir}/firmware/firmware-manifest.json")"
   companion_hash="$(sha256 "${dir}/companion/codexbar-display")"
   cat >"${dir}/candidate-manifest.json" <<JSON
-{"schemaVersion":1,"repository":"DreamyTalesPAN/CodexBar-Display","sourceSha":"0123456789abcdef0123456789abcdef01234567","version":"1.0.1","candidateRunId":"123","createdAt":"2026-07-28T00:00:00Z","artifacts":[{"name":"signed-dmg","path":"macos/VibeTV-Control-Center.dmg","sha256":"$(sha256 "${dir}/macos/VibeTV-Control-Center.dmg")","role":"signed-dmg"},{"name":"sparkle-appcast","path":"macos/appcast.xml","sha256":"$(sha256 "${dir}/macos/appcast.xml")","role":"sparkle-appcast"},{"name":"candidate-companion","path":"companion/codexbar-display","sha256":"${companion_hash}","role":"companion"},{"name":"virtual-vibetv","path":"virtual/virtual-vibetv","sha256":"$(sha256 "${dir}/virtual/virtual-vibetv")","role":"virtual-vibetv"},{"name":"firmware-manifest","path":"firmware/firmware-manifest.json","sha256":"${manifest_hash}","role":"firmware-manifest"},{"name":"firmware-image","path":"firmware/firmware.bin","sha256":"${firmware_hash}","role":"firmware"}],"virtualGate":{"result":"pending","runId":"123"}}
+{"schemaVersion":1,"repository":"DreamyTalesPAN/CodexBar-Display","sourceSha":"0123456789abcdef0123456789abcdef01234567","version":"1.0.1","candidateRunId":"123","createdAt":"2026-07-28T00:00:00Z","artifacts":[{"name":"signed-dmg","path":"macos/VibeTV-Control-Center.dmg","sha256":"$(sha256 "${dir}/macos/VibeTV-Control-Center.dmg")","role":"signed-dmg","publish":true},{"name":"sparkle-appcast","path":"macos/appcast.xml","sha256":"$(sha256 "${dir}/macos/appcast.xml")","role":"sparkle-appcast","publish":true},{"name":"candidate-companion","path":"companion/codexbar-display","sha256":"${companion_hash}","role":"companion","publish":true},{"name":"virtual-vibetv","path":"virtual/virtual-vibetv","sha256":"$(sha256 "${dir}/virtual/virtual-vibetv")","role":"virtual-vibetv","publish":false},{"name":"firmware-manifest","path":"firmware/firmware-manifest.json","sha256":"${manifest_hash}","role":"firmware-manifest","publish":true},{"name":"firmware-image","path":"firmware/firmware.bin","sha256":"${firmware_hash}","role":"firmware","publish":true}],"virtualGate":{"result":"pending","runId":"123"}}
 JSON
 }
 
@@ -122,6 +122,9 @@ PY
   grep -F 'headBranch' "${WORKFLOW}" >/dev/null || die "workflow does not check candidate main branch"
   grep -F 'workflow_dispatch' "${WORKFLOW}" >/dev/null || die "workflow does not check candidate dispatch event"
   grep -F 'actor' "${WORKFLOW}" >/dev/null || die "workflow does not bind evidence actor"
+  grep -F 'serve/candidate' "${CANARY}" >/dev/null || die "canary does not use a separate serve symlink"
+  grep -F 'candidateRunId' "${CANARY}" >/dev/null || die "pending state does not retain candidate run identity"
+  grep -F 'gh api user --jq .login' "${CANARY}" >/dev/null || die "canary does not resolve a GitHub actor"
 }
 
 main "$@"

--- a/scripts/test-hardware-release-canary.sh
+++ b/scripts/test-hardware-release-canary.sh
@@ -127,6 +127,9 @@ PY
   grep -F 'gh api user --jq .login' "${CANARY}" >/dev/null || die "canary does not resolve a GitHub actor"
   grep -F 'wait_for_resume_health' "${CANARY}" >/dev/null || die "resume does not bound hello and health polling"
   grep -F 'daemon --transport wifi --target "$TARGET" --once' "${CANARY}" >/dev/null || die "resume does not rerun the candidate daemon"
+  grep -F 'esp8266-smalltv-st7789' "${CANARY}" >/dev/null || die "canary does not gate ESP8266 backup by board"
+  grep -F 'no recovery/backup path is implemented' "${CANARY}" >/dev/null || die "canary does not fail closed for unsupported firmware boards"
+  if grep -F 'resume read-only' "${CANARY}" >/dev/null; then die "resume is misleadingly labelled read-only despite its frame send"; fi
 }
 
 main "$@"

--- a/scripts/test-hardware-release-canary.sh
+++ b/scripts/test-hardware-release-canary.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CANARY="${ROOT}/scripts/test-physical-release-canary.sh"
+VALIDATOR="${ROOT}/scripts/validate-hardware-canary.py"
+WORKFLOW="${ROOT}/.github/workflows/record-hardware-canary.yml"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+sha256() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+make_candidate() {
+  local dir="$1"
+  mkdir -p "${dir}/companion" "${dir}/firmware" "${dir}/macos" "${dir}/virtual"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"${dir}/companion/codexbar-display"
+  chmod +x "${dir}/companion/codexbar-display"
+  printf 'virtual firmware\n' >"${dir}/firmware/firmware.bin"
+  printf 'signed DMG fixture\n' >"${dir}/macos/VibeTV-Control-Center.dmg"
+  printf '<appcast/>\n' >"${dir}/macos/appcast.xml"
+  printf 'virtual VibeTV fixture\n' >"${dir}/virtual/virtual-vibetv"
+  cat >"${dir}/firmware/firmware-manifest.json" <<'JSON'
+{"schemaVersion":1,"artifacts":[{"board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.1","firmwareUrl":"firmware/firmware.bin","sha256":"placeholder"}]}
+JSON
+  local firmware_hash manifest_hash companion_hash
+  firmware_hash="$(sha256 "${dir}/firmware/firmware.bin")"
+  python3 - "${dir}/firmware/firmware-manifest.json" "${firmware_hash}" <<'PY'
+import json, sys
+path, digest = sys.argv[1:]
+with open(path, encoding="utf-8") as f:
+    body = json.load(f)
+body["artifacts"][0]["sha256"] = digest
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(body, f, separators=(",", ":"))
+PY
+  manifest_hash="$(sha256 "${dir}/firmware/firmware-manifest.json")"
+  companion_hash="$(sha256 "${dir}/companion/codexbar-display")"
+  cat >"${dir}/candidate-manifest.json" <<JSON
+{"schemaVersion":1,"repository":"DreamyTalesPAN/CodexBar-Display","sourceSha":"0123456789abcdef0123456789abcdef01234567","version":"1.0.1","candidateRunId":"123","createdAt":"2026-07-28T00:00:00Z","artifacts":[{"name":"signed-dmg","path":"macos/VibeTV-Control-Center.dmg","sha256":"$(sha256 "${dir}/macos/VibeTV-Control-Center.dmg")","role":"signed-dmg"},{"name":"sparkle-appcast","path":"macos/appcast.xml","sha256":"$(sha256 "${dir}/macos/appcast.xml")","role":"sparkle-appcast"},{"name":"candidate-companion","path":"companion/codexbar-display","sha256":"${companion_hash}","role":"companion"},{"name":"virtual-vibetv","path":"virtual/virtual-vibetv","sha256":"$(sha256 "${dir}/virtual/virtual-vibetv")","role":"virtual-vibetv"},{"name":"firmware-manifest","path":"firmware/firmware-manifest.json","sha256":"${manifest_hash}","role":"firmware-manifest"},{"name":"firmware-image","path":"firmware/firmware.bin","sha256":"${firmware_hash}","role":"firmware"}],"virtualGate":{"result":"pending","runId":"123"}}
+JSON
+}
+
+make_evidence() {
+  local candidate="$1"
+  local evidence="$2"
+  python3 - "${candidate}" "${evidence}" <<'PY'
+import hashlib, json, pathlib, sys
+root, output = map(pathlib.Path, sys.argv[1:]); manifest = json.loads((root / 'candidate-manifest.json').read_text())
+hashes = {item['path']: hashlib.sha256((root / item['path']).read_bytes()).hexdigest() for item in manifest['artifacts']}
+json.dump({'schemaVersion':1,'repository':manifest['repository'],'sourceSha':manifest['sourceSha'],'version':manifest['version'],'candidateRunId':manifest['candidateRunId'],'candidateManifestSha256':hashlib.sha256((root/'candidate-manifest.json').read_bytes()).hexdigest(),'artifactHashes':hashes,'device':{'deviceId':'vibetv-test-1','board':'esp8266-smalltv-st7789','firmwareBefore':'1.0.0','firmwareAfter':'1.0.1'},'checks':{'candidateVerified':True,'hello':True,'health':True,'daemonRender':True},'timestamps':{'startedAt':'2026-07-28T00:00:00Z','finishedAt':'2026-07-28T00:01:00Z'},'actor':'test','result':'success'}, output.open('w'), separators=(',',':'))
+PY
+}
+
+make_candidate_result() {
+  local candidate="$1"
+  local result_dir="$2"
+  mkdir -p "${result_dir}"
+  python3 - "${candidate}" "${result_dir}/candidate-result.json" <<'PY'
+import hashlib, json, pathlib, sys
+root, output = map(pathlib.Path, sys.argv[1:])
+manifest = json.loads((root / "candidate-manifest.json").read_text())
+hashes = {item["path"]: hashlib.sha256((root / item["path"]).read_bytes()).hexdigest() for item in manifest["artifacts"]}
+json.dump({"schemaVersion": 1, "repository": manifest["repository"], "sourceSha": manifest["sourceSha"], "version": manifest["version"], "candidateRunId": manifest["candidateRunId"], "result": "success", "artifactHashes": hashes}, output.open("w"), separators=(",", ":"))
+PY
+}
+
+main() {
+  [[ -x "${CANARY}" ]] || die "physical canary script is missing or not executable"
+  [[ -x "${VALIDATOR}" ]] || die "hardware canary validator is missing or not executable"
+  [[ -f "${WORKFLOW}" ]] || die "hardware canary workflow is missing"
+
+  local candidate="${TMP}/candidate"
+  make_candidate "${candidate}"
+  local plan
+  plan="$("${CANARY}" --candidate-dir "${candidate}" --target "http://127.0.0.1:9" --expected-device-id "vibetv-test-1" --output-dir "${TMP}/output" --dry-run)"
+  [[ "${plan}" == *"DRY RUN: no network, launchctl, or hardware command will run"* ]] || die "dry run did not state its no-side-effect contract"
+  [[ "${plan}" == *"candidate verified"* ]] || die "dry run did not verify the candidate fixture"
+  [[ ! -e "${TMP}/output/hardware-canary.json" ]] || die "dry run must not write evidence"
+
+  "${VALIDATOR}" candidate --candidate-dir "${candidate}" >/dev/null
+  local evidence="${TMP}/hardware-canary.json"
+  make_evidence "${candidate}" "${evidence}"
+  local candidate_result="${TMP}/candidate-result"
+  make_candidate_result "${candidate}" "${candidate_result}"
+  "${VALIDATOR}" candidate-result --candidate-dir "${candidate}" --result "${candidate_result}/candidate-result.json" >/dev/null
+  "${VALIDATOR}" evidence --candidate-dir "${candidate}" --evidence "${evidence}" >/dev/null
+  python3 - "${evidence}" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path, encoding="utf-8") as f:
+    body = json.load(f)
+body["artifactHashes"]["firmware/firmware.bin"] = "0" * 64
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(body, f)
+PY
+  if "${VALIDATOR}" evidence --candidate-dir "${candidate}" --evidence "${evidence}" >/dev/null 2>&1; then
+    die "validator accepted evidence with a mismatched artifact hash"
+  fi
+
+  grep -F 'name: CODEX Record VibeTV Hardware Canary' "${WORKFLOW}" >/dev/null || die "workflow name is missing"
+  grep -F 'evidence_base64' "${WORKFLOW}" >/dev/null || die "workflow input is missing"
+  grep -F 'validate-hardware-canary.py evidence' "${WORKFLOW}" >/dev/null || die "workflow does not reuse the validator"
+  grep -F 'validate-hardware-canary.py candidate-result' "${WORKFLOW}" >/dev/null || die "workflow does not validate the candidate result artifact"
+  grep -F 'CODEX VibeTV Hardware Canary' "${WORKFLOW}" >/dev/null || die "workflow status context is missing"
+  grep -F -- '--confirm-render-visible' "${CANARY}" >/dev/null || die "canary lacks explicit visual confirmation"
+  grep -F -- '--confirm-power-cycle-10s' "${CANARY}" >/dev/null || die "canary lacks explicit power-cycle confirmation"
+  grep -F 'write_evidence unknown' "${CANARY}" >/dev/null || die "canary lacks unknown-write evidence"
+  grep -F "role']=='companion'" "${CANARY}" >/dev/null || die "canary does not select the candidate companion role"
+  grep -F 'esp8266-backup.sh' "${CANARY}" >/dev/null || die "canary does not create the required full USB backup"
+  grep -F 'vibetv-hardware-canary' "${WORKFLOW}" >/dev/null || die "workflow uses the wrong evidence artifact name"
+}
+
+main "$@"

--- a/scripts/test-hardware-release-canary.sh
+++ b/scripts/test-hardware-release-canary.sh
@@ -115,6 +115,13 @@ PY
   grep -F "role']=='companion'" "${CANARY}" >/dev/null || die "canary does not select the candidate companion role"
   grep -F 'esp8266-backup.sh' "${CANARY}" >/dev/null || die "canary does not create the required full USB backup"
   grep -F 'vibetv-hardware-canary' "${WORKFLOW}" >/dev/null || die "workflow uses the wrong evidence artifact name"
+  grep -F 'semver_compare' "${CANARY}" >/dev/null || die "canary does not compare firmware versions as SemVer"
+  grep -F 'candidate-firmware-manifest.json' "${CANARY}" >/dev/null || die "canary does not create a local absolute firmware manifest"
+  grep -F -- '--resume' "${CANARY}" >/dev/null || die "canary lacks the read-only power-cycle resume phase"
+  grep -F 'sent frame ->' "${CANARY}" >/dev/null || die "canary does not require daemon frame-send evidence"
+  grep -F 'headBranch' "${WORKFLOW}" >/dev/null || die "workflow does not check candidate main branch"
+  grep -F 'workflow_dispatch' "${WORKFLOW}" >/dev/null || die "workflow does not check candidate dispatch event"
+  grep -F 'actor' "${WORKFLOW}" >/dev/null || die "workflow does not bind evidence actor"
 }
 
 main "$@"

--- a/scripts/test-hardware-release-canary.sh
+++ b/scripts/test-hardware-release-canary.sh
@@ -125,6 +125,8 @@ PY
   grep -F 'serve/candidate' "${CANARY}" >/dev/null || die "canary does not use a separate serve symlink"
   grep -F 'candidateRunId' "${CANARY}" >/dev/null || die "pending state does not retain candidate run identity"
   grep -F 'gh api user --jq .login' "${CANARY}" >/dev/null || die "canary does not resolve a GitHub actor"
+  grep -F 'wait_for_resume_health' "${CANARY}" >/dev/null || die "resume does not bound hello and health polling"
+  grep -F 'daemon --transport wifi --target "$TARGET" --once' "${CANARY}" >/dev/null || die "resume does not rerun the candidate daemon"
 }
 
 main "$@"

--- a/scripts/test-hardware-release-canary.sh
+++ b/scripts/test-hardware-release-canary.sh
@@ -73,6 +73,7 @@ PY
 
 main() {
   [[ -x "${CANARY}" ]] || die "physical canary script is missing or not executable"
+  bash -n "${CANARY}" || die "physical canary script has invalid Bash syntax"
   [[ -x "${VALIDATOR}" ]] || die "hardware canary validator is missing or not executable"
   [[ -f "${WORKFLOW}" ]] || die "hardware canary workflow is missing"
 

--- a/scripts/test-hardware-release-canary.sh
+++ b/scripts/test-hardware-release-canary.sh
@@ -114,10 +114,10 @@ PY
   grep -F -- '--confirm-power-cycle-10s' "${CANARY}" >/dev/null || die "canary lacks explicit power-cycle confirmation"
   grep -F 'write_evidence unknown' "${CANARY}" >/dev/null || die "canary lacks unknown-write evidence"
   grep -F "role']=='companion'" "${CANARY}" >/dev/null || die "canary does not select the candidate companion role"
-  if grep -F -- '--recovery-port' "${CANARY}" >/dev/null || grep -F 'esp8266-backup.sh' "${CANARY}" >/dev/null; then
-    die "customer hardware canary must not require a nonexistent USB recovery path"
-  fi
-  grep -F 'WiFi-only' "${CANARY}" >/dev/null || die "canary does not disclose the WiFi-only update risk"
+  grep -F -- '--recovery-port' "${CANARY}" >/dev/null || die "canary lacks optional future lab USB recovery"
+  grep -F 'if [[ -n "$RECOVERY_PORT" ]]' "${CANARY}" >/dev/null || die "USB recovery must remain optional"
+  grep -F 'esp8266-backup.sh' "${CANARY}" >/dev/null || die "lab recovery path does not create a full USB backup"
+  grep -F 'this VibeTV has no USB recovery path' "${CANARY}" >/dev/null || die "canary does not disclose the current WiFi-only update risk"
   grep -F 'vibetv-hardware-canary' "${WORKFLOW}" >/dev/null || die "workflow uses the wrong evidence artifact name"
   grep -F 'semver_compare' "${CANARY}" >/dev/null || die "canary does not compare firmware versions as SemVer"
   grep -F 'candidate-firmware-manifest.json' "${CANARY}" >/dev/null || die "canary does not create a local absolute firmware manifest"

--- a/scripts/test-macos-control-center-app-bundle.sh
+++ b/scripts/test-macos-control-center-app-bundle.sh
@@ -1022,14 +1022,12 @@ PY
     || die "CodexBar distribution version must stay pinned"
   grep -qF 'SHA256="958c4b3fc64367d833b6e26df98d262b16384a52dcf6b8181f9b98091505671f"' "${ROOT}/scripts/fetch-codexbar.sh" \
     || die "CodexBar distribution checksum must stay pinned"
-  grep -qF 'verify-bundled-codexbar.sh' "${ROOT}/.github/workflows/release.yml" \
-    || die "release workflow must verify the bundled CodexBar payload"
-  grep -qF 'generate_appcast' "${ROOT}/.github/workflows/release.yml" \
-    || die "release workflow must generate a Sparkle appcast"
-  grep -qF 'sparkle:edSignature=' "${ROOT}/.github/workflows/release.yml" \
-    || die "release workflow must verify the appcast signature"
-  grep -qF 'SPARKLE_ED25519_PRIVATE_KEY' "${ROOT}/.github/workflows/release.yml" \
-    || die "release workflow must source the Sparkle private key from Actions secrets"
+  grep -qF 'verify-bundled-codexbar.sh' "${ROOT}/.github/workflows/validate-macos-dmg.yml" \
+    || die "the signed DMG workflow must verify the bundled CodexBar payload"
+  ! grep -Eq \
+    'APPLE_SIGNING_CERTIFICATE|APPLE_NOTARY|SPARKLE_ED25519_PRIVATE_KEY|generate_appcast' \
+    "${ROOT}/.github/workflows/release.yml" \
+    || die "publish workflow must consume signed candidate assets without signing or appcast secrets"
 
   grep -qF "com.codexbar-display.daemon" "${ROOT}/macos/VibeTVControlCenter/main.swift" \
     || die "native app shell must detect the old LaunchAgent"

--- a/scripts/test-physical-release-canary.sh
+++ b/scripts/test-physical-release-canary.sh
@@ -44,7 +44,7 @@ if [[ -n "$RESUME_STATE" ]]; then
 import json,sys
 s=json.load(open(sys.argv[1])); print(s.get('candidateDir',''),s.get('candidateRunId',''),s['firmwareBefore'])
 PY
-)"
+)
 fi
 if [[ -n "$CANDIDATE_RUN_ID" ]]; then
   gh run download "$CANDIDATE_RUN_ID" --repo "$REPO" --name vibetv-release-candidate --dir "$work/candidate"

--- a/scripts/test-physical-release-canary.sh
+++ b/scripts/test-physical-release-canary.sh
@@ -7,14 +7,17 @@ REPO="DreamyTalesPAN/CodexBar-Display"
 CANDIDATE_RUN_ID=""; CANDIDATE_DIR=""; TARGET=""; EXPECTED_DEVICE_ID=""; OUTPUT_DIR=""
 RECOVERY_PORT=""; CONFIRM_DEVICE_ID=""; CONFIRM_WRITE_RISK=""; DRY_RUN=0
 CONFIRM_RENDER=""; CONFIRM_POWER_CYCLE=""; ACTOR="${USER:-unknown}"
+RESUME_STATE=""
 
 usage() { echo "usage: $0 (--candidate-run-id ID|--candidate-dir DIR) --target URL --expected-device-id ID --output-dir DIR [--recovery-port PORT --confirm-device-id ID --confirm-hardware-write-risk] [--dry-run]" >&2; exit 2; }
 die() { echo "error: $*" >&2; exit 1; }
 while [[ $# -gt 0 ]]; do case "$1" in
   --candidate-run-id) CANDIDATE_RUN_ID="${2:-}"; shift 2;; --candidate-dir) CANDIDATE_DIR="${2:-}"; shift 2;; --target) TARGET="${2:-}"; shift 2;; --expected-device-id) EXPECTED_DEVICE_ID="${2:-}"; shift 2;; --output-dir) OUTPUT_DIR="${2:-}"; shift 2;;
-  --recovery-port) RECOVERY_PORT="${2:-}"; shift 2;; --confirm-device-id) CONFIRM_DEVICE_ID="${2:-}"; shift 2;; --confirm-hardware-write-risk) CONFIRM_WRITE_RISK=1; shift;; --confirm-render-visible) CONFIRM_RENDER=1; shift;; --confirm-power-cycle-10s) CONFIRM_POWER_CYCLE=1; shift;; --actor) ACTOR="${2:-}"; shift 2;; --dry-run) DRY_RUN=1; shift;; *) usage;; esac; done
+  --recovery-port) RECOVERY_PORT="${2:-}"; shift 2;; --confirm-device-id) CONFIRM_DEVICE_ID="${2:-}"; shift 2;; --confirm-hardware-write-risk) CONFIRM_WRITE_RISK=1; shift;; --confirm-render-visible) CONFIRM_RENDER=1; shift;; --confirm-power-cycle-10s) CONFIRM_POWER_CYCLE=1; shift;; --actor) ACTOR="${2:-}"; shift 2;; --resume) RESUME_STATE="${2:-}"; shift 2;; --dry-run) DRY_RUN=1; shift;; *) usage;; esac; done
 [[ -n "$TARGET" && -n "$EXPECTED_DEVICE_ID" && -n "$OUTPUT_DIR" ]] || usage
-[[ -n "$CANDIDATE_RUN_ID" || -n "$CANDIDATE_DIR" ]] && [[ -z "$CANDIDATE_RUN_ID" || -z "$CANDIDATE_DIR" ]] || usage
+if [[ -z "$RESUME_STATE" ]]; then
+  [[ -n "$CANDIDATE_RUN_ID" || -n "$CANDIDATE_DIR" ]] && [[ -z "$CANDIDATE_RUN_ID" || -z "$CANDIDATE_DIR" ]] || usage
+fi
 if (( DRY_RUN )); then
   [[ -n "$CANDIDATE_DIR" ]] && "$VALIDATOR" candidate --candidate-dir "$CANDIDATE_DIR" >/dev/null
   echo "DRY RUN: no network, launchctl, or hardware command will run"
@@ -23,7 +26,26 @@ if (( DRY_RUN )); then
   exit 0
 fi
 
+semver_compare() {
+  python3 - "$1" "$2" <<'PY'
+import re,sys
+def parse(value):
+ m=re.fullmatch(r'v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?', value.strip())
+ if not m: raise SystemExit('invalid SemVer: '+value)
+ return tuple(map(int,m.group(1,2,3))), m.group(4) or ''
+a,b=parse(sys.argv[1]),parse(sys.argv[2])
+print(1 if a[0]>b[0] or (a[0]==b[0] and ((not a[1] and b[1]) or a[1]>b[1])) else 0)
+PY
+}
+
 work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+if [[ -n "$RESUME_STATE" ]]; then
+  CANDIDATE_DIR="$(python3 - "$RESUME_STATE" <<'PY'
+import json,sys
+print(json.load(open(sys.argv[1]))['candidateDir'])
+PY
+)"
+fi
 if [[ -n "$CANDIDATE_RUN_ID" ]]; then
   gh run download "$CANDIDATE_RUN_ID" --repo "$REPO" --name vibetv-release-candidate --dir "$work/candidate"
   gh run download "$CANDIDATE_RUN_ID" --repo "$REPO" --name vibetv-release-candidate-result --dir "$work/candidate-result"
@@ -69,13 +91,28 @@ body=json.load(open(sys.argv[1])); board=sys.argv[2]
 print(next(a['firmwareVersion'] for a in body['artifacts'] if a.get('board') == board))
 PY
 )"
-if [[ "$before" != "$candidate_version" ]]; then
+if [[ -n "$RESUME_STATE" ]]; then
+  [[ -f "$RESUME_STATE" ]] || die "pending state is missing: $RESUME_STATE"
+  [[ -n "$CONFIRM_RENDER" && -n "$CONFIRM_POWER_CYCLE" ]] || die "resume requires --confirm-render-visible and --confirm-power-cycle-10s"
+  python3 - "$RESUME_STATE" "$TARGET" "$EXPECTED_DEVICE_ID" "$board" "$candidate_version" "$health" <<'PY'
+import json,sys
+state,target,device,board,version,health=sys.argv[1:]
+s=json.load(open(state)); h=json.loads(health)
+assert s['target']==target and s['deviceId']==device and s['board']==board and s['firmware']==version
+assert h.get('ok') is True and h.get('display',{}).get('themeSpec',{}).get('renderOk') is True
+PY
+  write_evidence success "$before" "$before"
+  echo "Evidence written: $OUTPUT_DIR/hardware-canary.json"
+  exit 0
+fi
+if [[ "$(semver_compare "$candidate_version" "$before")" == 1 ]]; then
   [[ -n "$RECOVERY_PORT" && "$CONFIRM_DEVICE_ID" == "$EXPECTED_DEVICE_ID" && -n "$CONFIRM_WRITE_RISK" ]] || die "firmware write requires --recovery-port, exact --confirm-device-id, and --confirm-hardware-write-risk"
   mkdir -p "$OUTPUT_DIR"
   "${ROOT}/scripts/esp8266-backup.sh" "$RECOVERY_PORT" "$OUTPUT_DIR/usb-backup.bin" 0x400000
   cp "$firmware_manifest" "$OUTPUT_DIR/candidate-firmware-manifest.json"
 fi
-python3 -m http.server 0 --directory "$CANDIDATE_DIR" >"$work/http.log" 2>&1 & server_pid=$!
+ln -s "$CANDIDATE_DIR" "$work/candidate"
+python3 -u -m http.server 0 --directory "$work" >"$work/http.log" 2>&1 & server_pid=$!
 trap 'kill "$server_pid" 2>/dev/null || true; rm -rf "$work"' EXIT
 port="$(python3 -u - "$work/http.log" <<'PY'
 import sys,time,re
@@ -88,18 +125,30 @@ for _ in range(100):
 PY
 )"
 [[ -n "$port" ]] || die "local candidate manifest server did not start"
-write_started=1
-on_write_error() {
+local_manifest="$work/candidate-firmware-manifest.json"
+python3 - "$firmware_manifest" "$local_manifest" "$port" <<'PY'
+import json,sys
+src,out,port=sys.argv[1:]; body=json.load(open(src))
+for artifact in body['artifacts']:
+ artifact['firmwareUrl']='http://127.0.0.1:%s/candidate/%s' % (port, artifact['firmwareUrl'].lstrip('/'))
+json.dump(body,open(out,'w'),separators=(',',':'))
+PY
+cp "$local_manifest" "$OUTPUT_DIR/candidate-firmware-manifest.json"
+if ! "$companion" install-update --target "$TARGET" --manifest-url "http://127.0.0.1:$port/${local_manifest#$work/}" --skip-launchagent-pause; then
   write_evidence unknown "$before" "" || true
   echo "OTA outcome unknown: STOP. Read-only diagnosis only; no retry or rollback. Recovery: $companion restore-known-good --port $RECOVERY_PORT" >&2
-}
-trap 'on_write_error' ERR
-"$companion" install-update --target "$TARGET" --manifest-url "http://127.0.0.1:$port/${firmware_manifest#$CANDIDATE_DIR/}" --skip-launchagent-pause
-"$companion" daemon --transport wifi --target "$TARGET" --once
+  exit 1
+fi
+if ! daemon_output="$("$companion" daemon --transport wifi --target "$TARGET" --once 2>&1)" || [[ "$daemon_output" != *"sent frame ->"* ]]; then
+  write_evidence blocked "$before" "" || true
+  echo "daemon/render failed; evidence is blocked and no OTA retry or rollback will run" >&2
+  exit 1
+fi
 echo "Manual checks required: visually confirm one rendered frame, then power-cycle VibeTV for 10 seconds and confirm it returns."
-[[ -n "$CONFIRM_RENDER" && -n "$CONFIRM_POWER_CYCLE" ]] || die "recording success evidence requires --confirm-render-visible and --confirm-power-cycle-10s"
-after_hello="$(curl -fsS "$TARGET/hello")"
-after="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["firmware"])' "$after_hello")"
-write_evidence success "$before" "$after"
-echo "Evidence written: $OUTPUT_DIR/hardware-canary.json"
-echo "Record with: gh workflow run record-hardware-canary.yml --ref main -f evidence_base64=$(base64 < "$OUTPUT_DIR/hardware-canary.json" | tr -d '\n')"
+pending="$OUTPUT_DIR/hardware-canary-pending.json"
+mkdir -p "$OUTPUT_DIR"
+python3 - "$pending" "$TARGET" "$EXPECTED_DEVICE_ID" "$board" "$candidate_version" "$CANDIDATE_DIR" <<'PY'
+import json,sys
+json.dump(dict(target=sys.argv[2],deviceId=sys.argv[3],board=sys.argv[4],firmware=sys.argv[5],candidateDir=sys.argv[6]),open(sys.argv[1],'w'))
+PY
+echo "Power-cycle VibeTV for 10 seconds, then resume read-only: $0 --resume $pending --target $TARGET --expected-device-id $EXPECTED_DEVICE_ID --output-dir $OUTPUT_DIR --confirm-render-visible --confirm-power-cycle-10s"

--- a/scripts/test-physical-release-canary.sh
+++ b/scripts/test-physical-release-canary.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATOR="${ROOT}/scripts/validate-hardware-canary.py"
+REPO="DreamyTalesPAN/CodexBar-Display"
+CANDIDATE_RUN_ID=""; CANDIDATE_DIR=""; TARGET=""; EXPECTED_DEVICE_ID=""; OUTPUT_DIR=""
+RECOVERY_PORT=""; CONFIRM_DEVICE_ID=""; CONFIRM_WRITE_RISK=""; DRY_RUN=0
+CONFIRM_RENDER=""; CONFIRM_POWER_CYCLE=""; ACTOR="${USER:-unknown}"
+
+usage() { echo "usage: $0 (--candidate-run-id ID|--candidate-dir DIR) --target URL --expected-device-id ID --output-dir DIR [--recovery-port PORT --confirm-device-id ID --confirm-hardware-write-risk] [--dry-run]" >&2; exit 2; }
+die() { echo "error: $*" >&2; exit 1; }
+while [[ $# -gt 0 ]]; do case "$1" in
+  --candidate-run-id) CANDIDATE_RUN_ID="${2:-}"; shift 2;; --candidate-dir) CANDIDATE_DIR="${2:-}"; shift 2;; --target) TARGET="${2:-}"; shift 2;; --expected-device-id) EXPECTED_DEVICE_ID="${2:-}"; shift 2;; --output-dir) OUTPUT_DIR="${2:-}"; shift 2;;
+  --recovery-port) RECOVERY_PORT="${2:-}"; shift 2;; --confirm-device-id) CONFIRM_DEVICE_ID="${2:-}"; shift 2;; --confirm-hardware-write-risk) CONFIRM_WRITE_RISK=1; shift;; --confirm-render-visible) CONFIRM_RENDER=1; shift;; --confirm-power-cycle-10s) CONFIRM_POWER_CYCLE=1; shift;; --actor) ACTOR="${2:-}"; shift 2;; --dry-run) DRY_RUN=1; shift;; *) usage;; esac; done
+[[ -n "$TARGET" && -n "$EXPECTED_DEVICE_ID" && -n "$OUTPUT_DIR" ]] || usage
+[[ -n "$CANDIDATE_RUN_ID" || -n "$CANDIDATE_DIR" ]] && [[ -z "$CANDIDATE_RUN_ID" || -z "$CANDIDATE_DIR" ]] || usage
+if (( DRY_RUN )); then
+  [[ -n "$CANDIDATE_DIR" ]] && "$VALIDATOR" candidate --candidate-dir "$CANDIDATE_DIR" >/dev/null
+  echo "DRY RUN: no network, launchctl, or hardware command will run"
+  echo "candidate verified${CANDIDATE_DIR:+: ${CANDIDATE_DIR}}"
+  echo "plan: read-only /hello and /health; exact candidate daemon render; firmware write only with recovery port and both confirmations"
+  exit 0
+fi
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+if [[ -n "$CANDIDATE_RUN_ID" ]]; then
+  gh run download "$CANDIDATE_RUN_ID" --repo "$REPO" --name vibetv-release-candidate --dir "$work/candidate"
+  gh run download "$CANDIDATE_RUN_ID" --repo "$REPO" --name vibetv-release-candidate-result --dir "$work/candidate-result"
+  CANDIDATE_DIR="$work/candidate"
+  "$VALIDATOR" candidate-result --candidate-dir "$CANDIDATE_DIR" --result "$work/candidate-result/candidate-result.json" >/dev/null
+fi
+"$VALIDATOR" candidate --candidate-dir "$CANDIDATE_DIR" >/dev/null
+manifest="$CANDIDATE_DIR/candidate-manifest.json"
+read_json() { python3 - "$manifest" "$1" <<'PY'
+import json,sys
+b=json.load(open(sys.argv[1])); q=sys.argv[2]
+if q=='companion': print(next(x['path'] for x in b['artifacts'] if x['role']=='companion'))
+elif q=='firmware-manifest': print(next(x['path'] for x in b['artifacts'] if x['role']=='firmware-manifest'))
+elif q=='version': print(b['version'])
+PY
+}
+companion="$CANDIDATE_DIR/$(read_json companion)"; firmware_manifest="$CANDIDATE_DIR/$(read_json firmware-manifest)"
+write_evidence() {
+  local result="$1" before_value="$2" after_value="$3"
+  mkdir -p "$OUTPUT_DIR"
+  python3 - "$manifest" "$CANDIDATE_DIR" "$OUTPUT_DIR/hardware-canary.json" "$EXPECTED_DEVICE_ID" "$board" "$before_value" "$after_value" "$ACTOR" "$result" <<'PY'
+import hashlib,json,sys,datetime,pathlib
+manifest,root,out,device,board,before,after,actor,result=sys.argv[1:]
+b=json.load(open(manifest)); root=pathlib.Path(root)
+hashes={a['path']: hashlib.sha256((root/a['path']).read_bytes()).hexdigest() for a in b['artifacts']}
+now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace('+00:00','Z')
+e={'schemaVersion':1,'repository':b['repository'],'sourceSha':b['sourceSha'],'version':b['version'],'candidateRunId':b['candidateRunId'],'candidateManifestSha256':hashlib.sha256(pathlib.Path(manifest).read_bytes()).hexdigest(),'artifactHashes':hashes,'device':{'deviceId':device,'board':board,'firmwareBefore':before,'firmwareAfter':after},'checks':{'candidateVerified':True,'hello':True,'health':True,'daemonRender':result=='success'},'timestamps':{'startedAt':now,'finishedAt':now},'actor':actor,'result':result}
+json.dump(e,open(out,'w'),separators=(',',':'))
+PY
+}
+hello="$(curl -fsS "$TARGET/hello")"; health="$(curl -fsS "$TARGET/health")"
+read -r board before < <(python3 - "$hello" "$health" "$EXPECTED_DEVICE_ID" <<'PY'
+import json,sys
+h=json.loads(sys.argv[1]); x=json.loads(sys.argv[2]); w=sys.argv[3]
+assert h.get('deviceId') == w and h.get('board')
+assert x.get('ok') is True
+print(h['board'], h['firmware'])
+PY
+)
+candidate_version="$(python3 - "$firmware_manifest" "$board" <<'PY'
+import json,sys
+body=json.load(open(sys.argv[1])); board=sys.argv[2]
+print(next(a['firmwareVersion'] for a in body['artifacts'] if a.get('board') == board))
+PY
+)"
+if [[ "$before" != "$candidate_version" ]]; then
+  [[ -n "$RECOVERY_PORT" && "$CONFIRM_DEVICE_ID" == "$EXPECTED_DEVICE_ID" && -n "$CONFIRM_WRITE_RISK" ]] || die "firmware write requires --recovery-port, exact --confirm-device-id, and --confirm-hardware-write-risk"
+  mkdir -p "$OUTPUT_DIR"
+  "${ROOT}/scripts/esp8266-backup.sh" "$RECOVERY_PORT" "$OUTPUT_DIR/usb-backup.bin" 0x400000
+  cp "$firmware_manifest" "$OUTPUT_DIR/candidate-firmware-manifest.json"
+fi
+python3 -m http.server 0 --directory "$CANDIDATE_DIR" >"$work/http.log" 2>&1 & server_pid=$!
+trap 'kill "$server_pid" 2>/dev/null || true; rm -rf "$work"' EXIT
+port="$(python3 -u - "$work/http.log" <<'PY'
+import sys,time,re
+for _ in range(100):
+ try:
+  s=open(sys.argv[1]).read(); m=re.search(r'port (\d+)',s)
+  if m: print(m.group(1)); break
+ except FileNotFoundError: pass
+ time.sleep(.05)
+PY
+)"
+[[ -n "$port" ]] || die "local candidate manifest server did not start"
+write_started=1
+on_write_error() {
+  write_evidence unknown "$before" "" || true
+  echo "OTA outcome unknown: STOP. Read-only diagnosis only; no retry or rollback. Recovery: $companion restore-known-good --port $RECOVERY_PORT" >&2
+}
+trap 'on_write_error' ERR
+"$companion" install-update --target "$TARGET" --manifest-url "http://127.0.0.1:$port/${firmware_manifest#$CANDIDATE_DIR/}" --skip-launchagent-pause
+"$companion" daemon --transport wifi --target "$TARGET" --once
+echo "Manual checks required: visually confirm one rendered frame, then power-cycle VibeTV for 10 seconds and confirm it returns."
+[[ -n "$CONFIRM_RENDER" && -n "$CONFIRM_POWER_CYCLE" ]] || die "recording success evidence requires --confirm-render-visible and --confirm-power-cycle-10s"
+after_hello="$(curl -fsS "$TARGET/hello")"
+after="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["firmware"])' "$after_hello")"
+write_evidence success "$before" "$after"
+echo "Evidence written: $OUTPUT_DIR/hardware-canary.json"
+echo "Record with: gh workflow run record-hardware-canary.yml --ref main -f evidence_base64=$(base64 < "$OUTPUT_DIR/hardware-canary.json" | tr -d '\n')"

--- a/scripts/test-physical-release-canary.sh
+++ b/scripts/test-physical-release-canary.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VALIDATOR="${ROOT}/scripts/validate-hardware-canary.py"
 REPO="DreamyTalesPAN/CodexBar-Display"
 CANDIDATE_RUN_ID=""; CANDIDATE_DIR=""; TARGET=""; EXPECTED_DEVICE_ID=""; OUTPUT_DIR=""
-RECOVERY_PORT=""; CONFIRM_DEVICE_ID=""; CONFIRM_WRITE_RISK=""; DRY_RUN=0
+CONFIRM_DEVICE_ID=""; CONFIRM_WRITE_RISK=""; DRY_RUN=0
 CONFIRM_RENDER=""; CONFIRM_POWER_CYCLE=""; ACTOR=""
 RESUME_STATE=""
 
-usage() { echo "usage: $0 (--candidate-run-id ID|--candidate-dir DIR) --target URL --expected-device-id ID --output-dir DIR [--recovery-port PORT --confirm-device-id ID --confirm-hardware-write-risk] [--dry-run]" >&2; exit 2; }
+usage() { echo "usage: $0 (--candidate-run-id ID|--candidate-dir DIR) --target URL --expected-device-id ID --output-dir DIR [--confirm-device-id ID --confirm-hardware-write-risk] [--dry-run]" >&2; exit 2; }
 die() { echo "error: $*" >&2; exit 1; }
 while [[ $# -gt 0 ]]; do case "$1" in
   --candidate-run-id) CANDIDATE_RUN_ID="${2:-}"; shift 2;; --candidate-dir) CANDIDATE_DIR="${2:-}"; shift 2;; --target) TARGET="${2:-}"; shift 2;; --expected-device-id) EXPECTED_DEVICE_ID="${2:-}"; shift 2;; --output-dir) OUTPUT_DIR="${2:-}"; shift 2;;
-  --recovery-port) RECOVERY_PORT="${2:-}"; shift 2;; --confirm-device-id) CONFIRM_DEVICE_ID="${2:-}"; shift 2;; --confirm-hardware-write-risk) CONFIRM_WRITE_RISK=1; shift;; --confirm-render-visible) CONFIRM_RENDER=1; shift;; --confirm-power-cycle-10s) CONFIRM_POWER_CYCLE=1; shift;; --actor) ACTOR="${2:-}"; shift 2;; --resume) RESUME_STATE="${2:-}"; shift 2;; --dry-run) DRY_RUN=1; shift;; *) usage;; esac; done
+  --confirm-device-id) CONFIRM_DEVICE_ID="${2:-}"; shift 2;; --confirm-hardware-write-risk) CONFIRM_WRITE_RISK=1; shift;; --confirm-render-visible) CONFIRM_RENDER=1; shift;; --confirm-power-cycle-10s) CONFIRM_POWER_CYCLE=1; shift;; --actor) ACTOR="${2:-}"; shift 2;; --resume) RESUME_STATE="${2:-}"; shift 2;; --dry-run) DRY_RUN=1; shift;; *) usage;; esac; done
 [[ -n "$TARGET" && -n "$EXPECTED_DEVICE_ID" && -n "$OUTPUT_DIR" ]] || usage
 if [[ -z "$RESUME_STATE" ]]; then
   [[ -n "$CANDIDATE_RUN_ID" || -n "$CANDIDATE_DIR" ]] && [[ -z "$CANDIDATE_RUN_ID" || -z "$CANDIDATE_DIR" ]] || usage
@@ -22,7 +22,7 @@ if (( DRY_RUN )); then
   [[ -n "$CANDIDATE_DIR" ]] && "$VALIDATOR" candidate --candidate-dir "$CANDIDATE_DIR" >/dev/null
   echo "DRY RUN: no network, launchctl, or hardware command will run"
   echo "candidate verified${CANDIDATE_DIR:+: ${CANDIDATE_DIR}}"
-  echo "plan: read-only /hello and /health; exact candidate daemon render; firmware write only with recovery port and both confirmations"
+  echo "plan: read-only /hello and /health; exact candidate daemon render; WiFi OTA only with exact device ID and explicit hardware-risk confirmation"
   exit 0
 fi
 
@@ -133,10 +133,10 @@ PY
   exit 0
 fi
 if [[ "$(semver_compare "$candidate_version" "$before")" == 1 ]]; then
-  [[ "$board" == "esp8266-smalltv-st7789" ]] || die "firmware write blocked for board $board: no recovery/backup path is implemented"
-  [[ -n "$RECOVERY_PORT" && "$CONFIRM_DEVICE_ID" == "$EXPECTED_DEVICE_ID" && -n "$CONFIRM_WRITE_RISK" ]] || die "firmware write requires --recovery-port, exact --confirm-device-id, and --confirm-hardware-write-risk"
+  [[ "$board" == "esp8266-smalltv-st7789" ]] || die "firmware write blocked for unsupported board $board"
+  [[ "$CONFIRM_DEVICE_ID" == "$EXPECTED_DEVICE_ID" && -n "$CONFIRM_WRITE_RISK" ]] || die "WiFi firmware write requires exact --confirm-device-id and --confirm-hardware-write-risk"
+  echo "WARNING: VibeTV firmware updates are WiFi-only. There is no USB backup or automatic rollback; an interrupted OTA may require service or device replacement." >&2
   mkdir -p "$OUTPUT_DIR"
-  "${ROOT}/scripts/esp8266-backup.sh" "$RECOVERY_PORT" "$OUTPUT_DIR/usb-backup.bin" 0x400000
   cp "$firmware_manifest" "$OUTPUT_DIR/candidate-firmware-manifest.json"
 fi
 mkdir -p "$work/serve"
@@ -167,7 +167,7 @@ PY
 cp "$local_manifest" "$OUTPUT_DIR/candidate-firmware-manifest.json"
 if ! "$companion" install-update --target "$TARGET" --manifest-url "http://127.0.0.1:$port/${local_manifest#$work/}" --skip-launchagent-pause; then
   write_evidence unknown "$before" "" || true
-  echo "OTA outcome unknown: STOP. Read-only diagnosis only; no retry or rollback. Recovery: $companion restore-known-good --port $RECOVERY_PORT" >&2
+  echo "OTA outcome unknown: STOP. Read-only diagnosis only; no retry or automatic rollback. The WiFi-only device may require service or replacement." >&2
   exit 1
 fi
 if ! daemon_output="$("$companion" daemon --transport wifi --target "$TARGET" --once 2>&1)" || [[ "$daemon_output" != *"sent frame ->"* ]]; then

--- a/scripts/test-physical-release-canary.sh
+++ b/scripts/test-physical-release-canary.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VALIDATOR="${ROOT}/scripts/validate-hardware-canary.py"
 REPO="DreamyTalesPAN/CodexBar-Display"
 CANDIDATE_RUN_ID=""; CANDIDATE_DIR=""; TARGET=""; EXPECTED_DEVICE_ID=""; OUTPUT_DIR=""
-CONFIRM_DEVICE_ID=""; CONFIRM_WRITE_RISK=""; DRY_RUN=0
+RECOVERY_PORT=""; CONFIRM_DEVICE_ID=""; CONFIRM_WRITE_RISK=""; DRY_RUN=0
 CONFIRM_RENDER=""; CONFIRM_POWER_CYCLE=""; ACTOR=""
 RESUME_STATE=""
 
-usage() { echo "usage: $0 (--candidate-run-id ID|--candidate-dir DIR) --target URL --expected-device-id ID --output-dir DIR [--confirm-device-id ID --confirm-hardware-write-risk] [--dry-run]" >&2; exit 2; }
+usage() { echo "usage: $0 (--candidate-run-id ID|--candidate-dir DIR) --target URL --expected-device-id ID --output-dir DIR [--recovery-port PORT] [--confirm-device-id ID --confirm-hardware-write-risk] [--dry-run]" >&2; exit 2; }
 die() { echo "error: $*" >&2; exit 1; }
 while [[ $# -gt 0 ]]; do case "$1" in
   --candidate-run-id) CANDIDATE_RUN_ID="${2:-}"; shift 2;; --candidate-dir) CANDIDATE_DIR="${2:-}"; shift 2;; --target) TARGET="${2:-}"; shift 2;; --expected-device-id) EXPECTED_DEVICE_ID="${2:-}"; shift 2;; --output-dir) OUTPUT_DIR="${2:-}"; shift 2;;
-  --confirm-device-id) CONFIRM_DEVICE_ID="${2:-}"; shift 2;; --confirm-hardware-write-risk) CONFIRM_WRITE_RISK=1; shift;; --confirm-render-visible) CONFIRM_RENDER=1; shift;; --confirm-power-cycle-10s) CONFIRM_POWER_CYCLE=1; shift;; --actor) ACTOR="${2:-}"; shift 2;; --resume) RESUME_STATE="${2:-}"; shift 2;; --dry-run) DRY_RUN=1; shift;; *) usage;; esac; done
+  --recovery-port) RECOVERY_PORT="${2:-}"; shift 2;; --confirm-device-id) CONFIRM_DEVICE_ID="${2:-}"; shift 2;; --confirm-hardware-write-risk) CONFIRM_WRITE_RISK=1; shift;; --confirm-render-visible) CONFIRM_RENDER=1; shift;; --confirm-power-cycle-10s) CONFIRM_POWER_CYCLE=1; shift;; --actor) ACTOR="${2:-}"; shift 2;; --resume) RESUME_STATE="${2:-}"; shift 2;; --dry-run) DRY_RUN=1; shift;; *) usage;; esac; done
 [[ -n "$TARGET" && -n "$EXPECTED_DEVICE_ID" && -n "$OUTPUT_DIR" ]] || usage
 if [[ -z "$RESUME_STATE" ]]; then
   [[ -n "$CANDIDATE_RUN_ID" || -n "$CANDIDATE_DIR" ]] && [[ -z "$CANDIDATE_RUN_ID" || -z "$CANDIDATE_DIR" ]] || usage
@@ -22,7 +22,7 @@ if (( DRY_RUN )); then
   [[ -n "$CANDIDATE_DIR" ]] && "$VALIDATOR" candidate --candidate-dir "$CANDIDATE_DIR" >/dev/null
   echo "DRY RUN: no network, launchctl, or hardware command will run"
   echo "candidate verified${CANDIDATE_DIR:+: ${CANDIDATE_DIR}}"
-  echo "plan: read-only /hello and /health; exact candidate daemon render; WiFi OTA only with exact device ID and explicit hardware-risk confirmation"
+  echo "plan: read-only /hello and /health; exact candidate daemon render; WiFi OTA with exact device ID and explicit hardware-risk confirmation; optional USB backup for future lab hardware"
   exit 0
 fi
 
@@ -135,8 +135,13 @@ fi
 if [[ "$(semver_compare "$candidate_version" "$before")" == 1 ]]; then
   [[ "$board" == "esp8266-smalltv-st7789" ]] || die "firmware write blocked for unsupported board $board"
   [[ "$CONFIRM_DEVICE_ID" == "$EXPECTED_DEVICE_ID" && -n "$CONFIRM_WRITE_RISK" ]] || die "WiFi firmware write requires exact --confirm-device-id and --confirm-hardware-write-risk"
-  echo "WARNING: VibeTV firmware updates are WiFi-only. There is no USB backup or automatic rollback; an interrupted OTA may require service or device replacement." >&2
   mkdir -p "$OUTPUT_DIR"
+  if [[ -n "$RECOVERY_PORT" ]]; then
+    echo "Lab recovery: creating a full USB backup before the WiFi OTA." >&2
+    "${ROOT}/scripts/esp8266-backup.sh" "$RECOVERY_PORT" "$OUTPUT_DIR/usb-backup.bin" 0x400000
+  else
+    echo "WARNING: this VibeTV has no USB recovery path. There is no backup or automatic rollback; an interrupted OTA may require service or device replacement." >&2
+  fi
   cp "$firmware_manifest" "$OUTPUT_DIR/candidate-firmware-manifest.json"
 fi
 mkdir -p "$work/serve"
@@ -167,7 +172,11 @@ PY
 cp "$local_manifest" "$OUTPUT_DIR/candidate-firmware-manifest.json"
 if ! "$companion" install-update --target "$TARGET" --manifest-url "http://127.0.0.1:$port/${local_manifest#$work/}" --skip-launchagent-pause; then
   write_evidence unknown "$before" "" || true
-  echo "OTA outcome unknown: STOP. Read-only diagnosis only; no retry or automatic rollback. The WiFi-only device may require service or replacement." >&2
+  if [[ -n "$RECOVERY_PORT" ]]; then
+    echo "OTA outcome unknown: STOP. Read-only diagnosis only; no retry. The saved USB backup is available for a separately approved recovery." >&2
+  else
+    echo "OTA outcome unknown: STOP. Read-only diagnosis only; no retry or automatic rollback. This WiFi-only device may require service or replacement." >&2
+  fi
   exit 1
 fi
 if ! daemon_output="$("$companion" daemon --transport wifi --target "$TARGET" --once 2>&1)" || [[ "$daemon_output" != *"sent frame ->"* ]]; then

--- a/scripts/test-physical-release-canary.sh
+++ b/scripts/test-physical-release-canary.sh
@@ -78,7 +78,28 @@ e={'schemaVersion':1,'repository':b['repository'],'sourceSha':b['sourceSha'],'ve
 json.dump(e,open(out,'w'),separators=(',',':'))
 PY
 }
-hello="$(curl -fsS "$TARGET/hello")"; health="$(curl -fsS "$TARGET/health")"
+wait_for_resume_health() {
+  local deadline=$((SECONDS + 90)) state="$1"
+  while (( SECONDS < deadline )); do
+    local next_hello next_health
+    if next_hello="$(curl -fsS --max-time 3 "$TARGET/hello" 2>/dev/null)" && next_health="$(curl -fsS --max-time 3 "$TARGET/health" 2>/dev/null)" &&
+      python3 - "$state" "$next_hello" "$next_health" <<'PY'
+import json,sys
+s=json.load(open(sys.argv[1])); h=json.loads(sys.argv[2]); x=json.loads(sys.argv[3])
+assert h.get('deviceId') == s['deviceId'] and h.get('board') == s['board'] and h.get('firmware') == s['firmware']
+assert x.get('ok') is True and x.get('display',{}).get('themeSpec',{}).get('renderOk') is True
+PY
+    then RESUME_HELLO="$next_hello"; RESUME_HEALTH="$next_health"; return 0; fi
+    sleep 1
+  done
+  return 1
+}
+if [[ -n "$RESUME_STATE" ]]; then
+  wait_for_resume_health "$RESUME_STATE" || die "resume timed out after 90 seconds waiting for /hello and /health"
+  hello="$RESUME_HELLO"; health="$RESUME_HEALTH"
+else
+  hello="$(curl -fsS --max-time 5 "$TARGET/hello")"; health="$(curl -fsS --max-time 5 "$TARGET/health")"
+fi
 read -r board before < <(python3 - "$hello" "$health" "$EXPECTED_DEVICE_ID" <<'PY'
 import json,sys
 h=json.loads(sys.argv[1]); x=json.loads(sys.argv[2]); w=sys.argv[3]
@@ -103,6 +124,10 @@ s=json.load(open(state)); h=json.loads(health)
 assert s['target']==target and s['deviceId']==device and s['board']==board and s['firmware']==version
 assert h.get('ok') is True and h.get('display',{}).get('themeSpec',{}).get('renderOk') is True
 PY
+  if ! resume_daemon_output="$("$companion" daemon --transport wifi --target "$TARGET" --once 2>&1)" || [[ "$resume_daemon_output" != *"sent frame ->"* ]]; then
+    write_evidence blocked "${EVIDENCE_BEFORE:-$before}" "$before" || true
+    die "resume daemon/render failed; success evidence was not written"
+  fi
   write_evidence success "${EVIDENCE_BEFORE:-$before}" "$before"
   echo "Evidence written: $OUTPUT_DIR/hardware-canary.json"
   exit 0

--- a/scripts/test-physical-release-canary.sh
+++ b/scripts/test-physical-release-canary.sh
@@ -133,6 +133,7 @@ PY
   exit 0
 fi
 if [[ "$(semver_compare "$candidate_version" "$before")" == 1 ]]; then
+  [[ "$board" == "esp8266-smalltv-st7789" ]] || die "firmware write blocked for board $board: no recovery/backup path is implemented"
   [[ -n "$RECOVERY_PORT" && "$CONFIRM_DEVICE_ID" == "$EXPECTED_DEVICE_ID" && -n "$CONFIRM_WRITE_RISK" ]] || die "firmware write requires --recovery-port, exact --confirm-device-id, and --confirm-hardware-write-risk"
   mkdir -p "$OUTPUT_DIR"
   "${ROOT}/scripts/esp8266-backup.sh" "$RECOVERY_PORT" "$OUTPUT_DIR/usb-backup.bin" 0x400000
@@ -181,4 +182,4 @@ python3 - "$pending" "$TARGET" "$EXPECTED_DEVICE_ID" "$board" "$candidate_versio
 import json,sys
 json.dump(dict(target=sys.argv[2],deviceId=sys.argv[3],board=sys.argv[4],firmware=sys.argv[5],candidateDir=sys.argv[6],candidateRunId=sys.argv[7],firmwareBefore=sys.argv[8]),open(sys.argv[1],'w'))
 PY
-echo "Power-cycle VibeTV for 10 seconds, then resume read-only: $0 --resume $pending --target $TARGET --expected-device-id $EXPECTED_DEVICE_ID --output-dir $OUTPUT_DIR --confirm-render-visible --confirm-power-cycle-10s"
+echo "Power-cycle VibeTV for 10 seconds, then resume without another firmware write: $0 --resume $pending --target $TARGET --expected-device-id $EXPECTED_DEVICE_ID --output-dir $OUTPUT_DIR --confirm-render-visible --confirm-power-cycle-10s"

--- a/scripts/test-physical-release-canary.sh
+++ b/scripts/test-physical-release-canary.sh
@@ -6,7 +6,7 @@ VALIDATOR="${ROOT}/scripts/validate-hardware-canary.py"
 REPO="DreamyTalesPAN/CodexBar-Display"
 CANDIDATE_RUN_ID=""; CANDIDATE_DIR=""; TARGET=""; EXPECTED_DEVICE_ID=""; OUTPUT_DIR=""
 RECOVERY_PORT=""; CONFIRM_DEVICE_ID=""; CONFIRM_WRITE_RISK=""; DRY_RUN=0
-CONFIRM_RENDER=""; CONFIRM_POWER_CYCLE=""; ACTOR="${USER:-unknown}"
+CONFIRM_RENDER=""; CONFIRM_POWER_CYCLE=""; ACTOR=""
 RESUME_STATE=""
 
 usage() { echo "usage: $0 (--candidate-run-id ID|--candidate-dir DIR) --target URL --expected-device-id ID --output-dir DIR [--recovery-port PORT --confirm-device-id ID --confirm-hardware-write-risk] [--dry-run]" >&2; exit 2; }
@@ -40,9 +40,9 @@ PY
 
 work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
 if [[ -n "$RESUME_STATE" ]]; then
-  CANDIDATE_DIR="$(python3 - "$RESUME_STATE" <<'PY'
+  read -r CANDIDATE_DIR CANDIDATE_RUN_ID EVIDENCE_BEFORE < <(python3 - "$RESUME_STATE" <<'PY'
 import json,sys
-print(json.load(open(sys.argv[1]))['candidateDir'])
+s=json.load(open(sys.argv[1])); print(s.get('candidateDir',''),s.get('candidateRunId',''),s['firmwareBefore'])
 PY
 )"
 fi
@@ -52,6 +52,8 @@ if [[ -n "$CANDIDATE_RUN_ID" ]]; then
   CANDIDATE_DIR="$work/candidate"
   "$VALIDATOR" candidate-result --candidate-dir "$CANDIDATE_DIR" --result "$work/candidate-result/candidate-result.json" >/dev/null
 fi
+mkdir -p "$OUTPUT_DIR"
+if [[ -z "$ACTOR" ]]; then ACTOR="$(gh api user --jq .login)"; fi
 "$VALIDATOR" candidate --candidate-dir "$CANDIDATE_DIR" >/dev/null
 manifest="$CANDIDATE_DIR/candidate-manifest.json"
 read_json() { python3 - "$manifest" "$1" <<'PY'
@@ -101,7 +103,7 @@ s=json.load(open(state)); h=json.loads(health)
 assert s['target']==target and s['deviceId']==device and s['board']==board and s['firmware']==version
 assert h.get('ok') is True and h.get('display',{}).get('themeSpec',{}).get('renderOk') is True
 PY
-  write_evidence success "$before" "$before"
+  write_evidence success "${EVIDENCE_BEFORE:-$before}" "$before"
   echo "Evidence written: $OUTPUT_DIR/hardware-canary.json"
   exit 0
 fi
@@ -111,8 +113,9 @@ if [[ "$(semver_compare "$candidate_version" "$before")" == 1 ]]; then
   "${ROOT}/scripts/esp8266-backup.sh" "$RECOVERY_PORT" "$OUTPUT_DIR/usb-backup.bin" 0x400000
   cp "$firmware_manifest" "$OUTPUT_DIR/candidate-firmware-manifest.json"
 fi
-ln -s "$CANDIDATE_DIR" "$work/candidate"
-python3 -u -m http.server 0 --directory "$work" >"$work/http.log" 2>&1 & server_pid=$!
+mkdir -p "$work/serve"
+ln -s "$CANDIDATE_DIR" "$work/serve/candidate"
+python3 -u -m http.server 0 --directory "$work/serve" >"$work/http.log" 2>&1 & server_pid=$!
 trap 'kill "$server_pid" 2>/dev/null || true; rm -rf "$work"' EXIT
 port="$(python3 -u - "$work/http.log" <<'PY'
 import sys,time,re
@@ -126,11 +129,13 @@ PY
 )"
 [[ -n "$port" ]] || die "local candidate manifest server did not start"
 local_manifest="$work/candidate-firmware-manifest.json"
-python3 - "$firmware_manifest" "$local_manifest" "$port" <<'PY'
+python3 - "$firmware_manifest" "$manifest" "$local_manifest" "$port" <<'PY'
 import json,sys
-src,out,port=sys.argv[1:]; body=json.load(open(src))
+src,candidate,out,port=sys.argv[1:]; body=json.load(open(src)); candidate=json.load(open(candidate))
 for artifact in body['artifacts']:
- artifact['firmwareUrl']='http://127.0.0.1:%s/candidate/%s' % (port, artifact['firmwareUrl'].lstrip('/'))
+ match=next((x['path'] for x in candidate['artifacts'] if x['role']=='firmware' and x['path'].endswith(artifact.get('asset','').lstrip('/'))),None)
+ if not match: raise SystemExit('candidate firmware artifact missing for '+artifact.get('board',''))
+ artifact['firmwareUrl']='http://127.0.0.1:%s/candidate/%s' % (port, match)
 json.dump(body,open(out,'w'),separators=(',',':'))
 PY
 cp "$local_manifest" "$OUTPUT_DIR/candidate-firmware-manifest.json"
@@ -147,8 +152,8 @@ fi
 echo "Manual checks required: visually confirm one rendered frame, then power-cycle VibeTV for 10 seconds and confirm it returns."
 pending="$OUTPUT_DIR/hardware-canary-pending.json"
 mkdir -p "$OUTPUT_DIR"
-python3 - "$pending" "$TARGET" "$EXPECTED_DEVICE_ID" "$board" "$candidate_version" "$CANDIDATE_DIR" <<'PY'
+python3 - "$pending" "$TARGET" "$EXPECTED_DEVICE_ID" "$board" "$candidate_version" "$CANDIDATE_DIR" "$CANDIDATE_RUN_ID" "$before" <<'PY'
 import json,sys
-json.dump(dict(target=sys.argv[2],deviceId=sys.argv[3],board=sys.argv[4],firmware=sys.argv[5],candidateDir=sys.argv[6]),open(sys.argv[1],'w'))
+json.dump(dict(target=sys.argv[2],deviceId=sys.argv[3],board=sys.argv[4],firmware=sys.argv[5],candidateDir=sys.argv[6],candidateRunId=sys.argv[7],firmwareBefore=sys.argv[8]),open(sys.argv[1],'w'))
 PY
 echo "Power-cycle VibeTV for 10 seconds, then resume read-only: $0 --resume $pending --target $TARGET --expected-device-id $EXPECTED_DEVICE_ID --output-dir $OUTPUT_DIR --confirm-render-visible --confirm-power-cycle-10s"

--- a/scripts/test-release-publish-gate.py
+++ b/scripts/test-release-publish-gate.py
@@ -200,6 +200,76 @@ class PublishGateFixtureTests(unittest.TestCase):
         self.assertTrue(VALIDATOR.is_file(), "publish-gate validator is missing")
 
     @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_hosted_candidate_fixture_contract_is_accepted(self) -> None:
+        manifest_artifacts = self.fixture["candidateManifest"]["artifacts"]
+        artifacts = {
+            item["name"]: (item["path"], item["role"], item["publish"])
+            for item in manifest_artifacts
+        }
+        self.assertEqual(len(artifacts), len(manifest_artifacts))
+        self.assertEqual(
+            artifacts,
+            {
+                "VibeTV-Control-Center.dmg": (
+                    "publish/VibeTV-Control-Center.dmg",
+                    "signed-dmg",
+                    True,
+                ),
+                "appcast.xml": (
+                    "publish/appcast.xml",
+                    "sparkle-appcast",
+                    True,
+                ),
+                "install.sh": ("publish/install.sh", "installer", True),
+                "install-control-center-companion.sh": (
+                    "publish/install-control-center-companion.sh",
+                    "installer",
+                    True,
+                ),
+                "codexbar-display-darwin-amd64-v1.2.3": (
+                    "publish/codexbar-display-darwin-amd64-v1.2.3",
+                    "companion-amd64",
+                    True,
+                ),
+                "codexbar-display-darwin-arm64-v1.2.3": (
+                    "publish/codexbar-display-darwin-arm64-v1.2.3",
+                    "companion-arm64",
+                    True,
+                ),
+                "firmware.bin": ("publish/firmware.bin", "firmware", True),
+                "firmware-manifest.json": (
+                    "publish/firmware-manifest.json",
+                    "firmware-manifest",
+                    True,
+                ),
+                "firmware-manifest-v1.2.3.json": (
+                    "publish/firmware-manifest-v1.2.3.json",
+                    "firmware-manifest",
+                    True,
+                ),
+                "checksums-v1.2.3.txt": (
+                    "publish/checksums-v1.2.3.txt",
+                    "checksums",
+                    True,
+                ),
+                "codexbar-display": (
+                    "test/codexbar-display",
+                    "test-companion",
+                    False,
+                ),
+                "virtual-vibetv": (
+                    "test/virtual-vibetv",
+                    "virtual-vibetv",
+                    False,
+                ),
+            },
+        )
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
     def test_valid_fixture_produces_payload_and_exact_asset_copy(self) -> None:
         result = self._run()
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -255,7 +325,7 @@ class PublishGateFixtureTests(unittest.TestCase):
         self.assertIn("firmware", result.stderr)
 
     @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
-    def test_rejects_wrong_production_appcast_url(self) -> None:
+    def test_rejects_wrong_sparkle_appcast_url(self) -> None:
         self._replace_asset_and_rebind(
             "publish/appcast.xml",
             '<rss><channel><item><enclosure url="https://example.com/wrong.dmg" /></item></channel></rss>\n',

--- a/scripts/test-release-publish-gate.py
+++ b/scripts/test-release-publish-gate.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Fixture tests for the immutable VibeTV publish gate."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts/validate-release-publish-gate.py"
+FIXTURE = ROOT / "scripts/fixtures/release-publish-gate/valid.json"
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class PublishGateFixtureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.case_root = Path(self.temp.name)
+        self.fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        self.paths = self._materialize(copy.deepcopy(self.fixture))
+
+    def _write_json(self, name: str, body: dict) -> Path:
+        path = self.case_root / name
+        path.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+        return path
+
+    def _materialize(self, fixture: dict) -> dict[str, Path]:
+        candidate_dir = self.case_root / "candidate"
+        candidate_dir.mkdir()
+        for relative, contents in fixture["files"].items():
+            path = candidate_dir / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(contents, encoding="utf-8")
+
+        hashes = {
+            item["path"]: sha256(candidate_dir / item["path"])
+            for item in fixture["candidateManifest"]["artifacts"]
+        }
+        for item in fixture["candidateManifest"]["artifacts"]:
+            item["sha256"] = hashes[item["path"]]
+        manifest = self._write_json(
+            "candidate-manifest.json", fixture["candidateManifest"]
+        )
+        (candidate_dir / "candidate-manifest.json").write_bytes(manifest.read_bytes())
+
+        fixture["candidateResult"]["artifactHashes"] = hashes
+        fixture["hardwareEvidence"]["artifactHashes"] = hashes
+        fixture["hardwareEvidence"]["candidateManifestSha256"] = sha256(
+            candidate_dir / "candidate-manifest.json"
+        )
+
+        return {
+            "candidate_dir": candidate_dir,
+            "candidate_run": self._write_json("candidate-run.json", fixture["candidateRun"]),
+            "candidate_workflow": self._write_json(
+                "candidate-workflow.json", fixture["candidateWorkflow"]
+            ),
+            "candidate_result": self._write_json(
+                "candidate-result.json", fixture["candidateResult"]
+            ),
+            "hardware_run": self._write_json("hardware-run.json", fixture["hardwareRun"]),
+            "hardware_workflow": self._write_json(
+                "hardware-workflow.json", fixture["hardwareWorkflow"]
+            ),
+            "hardware_evidence": self._write_json(
+                "hardware-canary.json", fixture["hardwareEvidence"]
+            ),
+            "output": self.case_root / "publish/publish-payload.json",
+            "copy_dir": self.case_root / "publish/assets",
+        }
+
+    def _command(self, **overrides: str) -> list[str]:
+        values = {
+            "repository": self.fixture["repository"],
+            "source_sha": self.fixture["sourceSha"],
+            "version": self.fixture["version"],
+            "candidate_run_id": self.fixture["candidateRunId"],
+            "hardware_canary_run_id": self.fixture["hardwareCanaryRunId"],
+            "now": self.fixture["now"],
+        }
+        values.update(overrides)
+        return [
+            "python3",
+            str(VALIDATOR),
+            "preflight",
+            "--repository",
+            values["repository"],
+            "--source-sha",
+            values["source_sha"],
+            "--version",
+            values["version"],
+            "--candidate-run-id",
+            values["candidate_run_id"],
+            "--candidate-run",
+            str(self.paths["candidate_run"]),
+            "--candidate-workflow",
+            str(self.paths["candidate_workflow"]),
+            "--candidate-dir",
+            str(self.paths["candidate_dir"]),
+            "--candidate-result",
+            str(self.paths["candidate_result"]),
+            "--hardware-canary-run-id",
+            values["hardware_canary_run_id"],
+            "--hardware-run",
+            str(self.paths["hardware_run"]),
+            "--hardware-workflow",
+            str(self.paths["hardware_workflow"]),
+            "--hardware-evidence",
+            str(self.paths["hardware_evidence"]),
+            "--now",
+            values["now"],
+            "--output",
+            str(self.paths["output"]),
+            "--copy-dir",
+            str(self.paths["copy_dir"]),
+        ]
+
+    def _run(self, **overrides: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            self._command(**overrides),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def _rewrite(self, key: str, mutate) -> None:
+        path = self.paths[key]
+        body = json.loads(path.read_text(encoding="utf-8"))
+        mutate(body)
+        path.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+
+    def _rewrite_manifest_and_rebind(self, mutate) -> None:
+        manifest_path = self.paths["candidate_dir"] / "candidate-manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        mutate(manifest)
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
+        evidence_path = self.paths["hardware_evidence"]
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        evidence["candidateManifestSha256"] = sha256(manifest_path)
+        evidence_path.write_text(
+            json.dumps(evidence, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def _remove_manifest_artifact_and_rebind(self, name: str) -> None:
+        manifest_path = self.paths["candidate_dir"] / "candidate-manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        removed = next(
+            item for item in manifest["artifacts"] if item["name"] == name
+        )
+        manifest["artifacts"] = [
+            item for item in manifest["artifacts"] if item["name"] != name
+        ]
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
+        for key in ("candidate_result", "hardware_evidence"):
+            path = self.paths[key]
+            body = json.loads(path.read_text(encoding="utf-8"))
+            body["artifactHashes"].pop(removed["path"])
+            if key == "hardware_evidence":
+                body["candidateManifestSha256"] = sha256(manifest_path)
+            path.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+
+    def _replace_asset_and_rebind(self, relative: str, contents: str) -> None:
+        asset = self.paths["candidate_dir"] / relative
+        asset.write_text(contents, encoding="utf-8")
+        new_hash = sha256(asset)
+
+        manifest_path = self.paths["candidate_dir"] / "candidate-manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        for item in manifest["artifacts"]:
+            if item["path"] == relative:
+                item["sha256"] = new_hash
+                break
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
+
+        for key in ("candidate_result", "hardware_evidence"):
+            path = self.paths[key]
+            body = json.loads(path.read_text(encoding="utf-8"))
+            body["artifactHashes"][relative] = new_hash
+            if key == "hardware_evidence":
+                body["candidateManifestSha256"] = sha256(manifest_path)
+            path.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+
+    def test_validator_exists(self) -> None:
+        self.assertTrue(VALIDATOR.is_file(), "publish-gate validator is missing")
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_valid_fixture_produces_payload_and_exact_asset_copy(self) -> None:
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(self.paths["output"].read_text(encoding="utf-8"))
+        self.assertEqual(payload["tag"], "v1.2.3")
+        self.assertEqual(payload["sourceSha"], self.fixture["sourceSha"])
+        copied = sorted(
+            str(path.relative_to(self.paths["copy_dir"]))
+            for path in self.paths["copy_dir"].rglob("*")
+            if path.is_file()
+        )
+        expected = sorted(
+            item["path"]
+            for item in self.fixture["candidateManifest"]["artifacts"]
+            if item["publish"]
+        )
+        self.assertEqual(copied, expected)
+        self.assertNotIn("test/virtual-vibetv", copied)
+        self.assertNotIn("test/codexbar-display", copied)
+        self.assertTrue(all(item["publish"] for item in payload["artifacts"]))
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_rejects_missing_required_public_asset_scope(self) -> None:
+        self._remove_manifest_artifact_and_rebind("install.sh")
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("publish scope", result.stderr)
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_rejects_test_only_artifact_marked_for_publish(self) -> None:
+        self._rewrite_manifest_and_rebind(
+            lambda manifest: next(
+                item
+                for item in manifest["artifacts"]
+                if item["name"] == "virtual-vibetv"
+            ).update(publish=True)
+        )
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be under publish/", result.stderr)
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_rejects_firmware_artifact_excluded_from_publish(self) -> None:
+        self._rewrite_manifest_and_rebind(
+            lambda manifest: next(
+                item
+                for item in manifest["artifacts"]
+                if item["name"] == "firmware.bin"
+            ).update(publish=False)
+        )
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("firmware", result.stderr)
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_rejects_wrong_production_appcast_url(self) -> None:
+        self._replace_asset_and_rebind(
+            "publish/appcast.xml",
+            '<rss><channel><item><enclosure url="https://example.com/wrong.dmg" /></item></channel></rss>\n',
+        )
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("appcast enclosure URL", result.stderr)
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_rejects_wrong_firmware_manifest_url(self) -> None:
+        self._replace_asset_and_rebind(
+            "publish/firmware-manifest.json",
+            '{"schemaVersion":1,"artifacts":[{"asset":"firmware.bin","firmwareUrl":"https://example.com/firmware.bin"}]}\n',
+        )
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("firmwareUrl", result.stderr)
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_rejects_non_semver_release_version(self) -> None:
+        result = self._run(version="1.2")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("SemVer", result.stderr)
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_rejects_candidate_result_that_is_not_success(self) -> None:
+        self._rewrite("candidate_result", lambda body: body.update(result="failure"))
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate result", result.stderr)
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_rejects_changed_candidate_asset(self) -> None:
+        (self.paths["candidate_dir"] / "publish/firmware.bin").write_text(
+            "changed after manifest\n", encoding="utf-8"
+        )
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("sha256", result.stderr)
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_rejects_hardware_result_other_than_success(self) -> None:
+        self._rewrite("hardware_evidence", lambda body: body.update(result="passed"))
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("hardware evidence result", result.stderr)
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_rejects_hardware_evidence_older_than_seven_days(self) -> None:
+        result = self._run(now="2026-08-04T11:00:01Z")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("older than 7 days", result.stderr)
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_rejects_wrong_candidate_workflow(self) -> None:
+        self._rewrite(
+            "candidate_workflow",
+            lambda body: body.update(path=".github/workflows/release.yml"),
+        )
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate workflow", result.stderr)
+
+    @unittest.skipUnless(VALIDATOR.is_file(), "validator not implemented yet")
+    def test_rejects_hardware_hashes_that_differ_from_candidate(self) -> None:
+        self._rewrite(
+            "hardware_evidence",
+            lambda body: body["artifactHashes"].update(
+                {"publish/firmware.bin": "0" * 64}
+            ),
+        )
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("hardware artifact hashes", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-release-publish-workflow.sh
+++ b/scripts/test-release-publish-workflow.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="${ROOT}/.github/workflows/release.yml"
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+job_block() {
+  local job="$1"
+  awk -v job="$job" '
+    $0 == "  " job ":" { in_job = 1; print; next }
+    in_job && $0 ~ /^  [A-Za-z0-9_-]+:/ { exit }
+    in_job { print }
+  ' "$WORKFLOW"
+}
+
+input_block() {
+  local input="$1"
+  awk -v input="$input" '
+    $0 == "      " input ":" { in_input = 1; print; next }
+    in_input && $0 ~ /^      [A-Za-z0-9_-]+:/ { exit }
+    in_input && $0 ~ /^[^ ]/ { exit }
+    in_input { print }
+  ' "$WORKFLOW"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="$3"
+  [[ "$haystack" == *"$needle"* ]] || die "$message"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="$3"
+  [[ "$haystack" != *"$needle"* ]] || die "$message"
+}
+
+main() {
+  [[ -f "$WORKFLOW" ]] || die "release workflow is missing"
+  local workflow preflight publish verify
+  workflow="$(cat "$WORKFLOW")"
+  preflight="$(job_block preflight)"
+  publish="$(job_block publish-release)"
+  verify="$(job_block verify-public-release)"
+
+  assert_contains "$workflow" "name: CODEX Publish VibeTV Release" \
+    "publish workflow must use the CODEX release name"
+  assert_contains "$workflow" "workflow_dispatch:" \
+    "publish workflow must be manually dispatched"
+  assert_not_contains "$workflow" "push:" \
+    "a pushed tag or branch must never trigger publication"
+  for input in version candidate_run_id hardware_canary_run_id; do
+    local block
+    block="$(input_block "$input")"
+    assert_contains "$block" "required: true" \
+      "input ${input} must be required"
+    assert_contains "$block" "type: string" \
+      "input ${input} must use an explicit string contract"
+  done
+
+  assert_contains "$workflow" "contents: read" \
+    "workflow default permissions must be read-only"
+  assert_contains "$workflow" "actions: read" \
+    "preflight needs read-only Actions access"
+  assert_not_contains "$preflight" "contents: write" \
+    "preflight must not receive repository write access"
+  assert_contains "$preflight" "github.ref == 'refs/heads/main'" \
+    "preflight must run from trusted main"
+  assert_contains "$preflight" "gh run download" \
+    "preflight must download evidence by run id"
+  for artifact in \
+    vibetv-release-candidate \
+    vibetv-release-candidate-result \
+    vibetv-hardware-canary
+  do
+    assert_contains "$preflight" "--name ${artifact}" \
+      "preflight must download ${artifact}"
+  done
+  assert_contains "$preflight" ".github/workflows/vibetv-release-candidate.yml" \
+    "preflight must bind the candidate run to its trusted workflow"
+  assert_contains "$preflight" ".github/workflows/record-hardware-canary.yml" \
+    "preflight must bind the hardware run to its trusted workflow"
+  assert_contains "$preflight" "validate-release-publish-gate.py preflight" \
+    "preflight must use the tested JSON validator"
+  assert_contains "$preflight" "git/ref/tags/v" \
+    "preflight must reject an existing release tag"
+  assert_contains "$preflight" "releases/tags/v" \
+    "preflight must reject an existing GitHub Release"
+  assert_contains "$preflight" "name: vibetv-validated-publish" \
+    "preflight must upload one validated internal publish artifact"
+
+  assert_contains "$publish" "environment: Production" \
+    "write access must remain behind Production approval"
+  assert_contains "$publish" "contents: write" \
+    "publish job alone needs repository write access"
+  assert_contains "$publish" "name: vibetv-validated-publish" \
+    "publish job must download only the validated internal artifact"
+  assert_contains "$publish" "gh release create" \
+    "publish job must create the tag and release"
+  assert_contains "$publish" '--target "${SOURCE_SHA}"' \
+    "release tag must target the validated source SHA"
+  assert_contains "$publish" "git/ref/heads/main" \
+    "publish job must re-read current main after Production approval"
+  assert_contains "$publish" 'CURRENT_MAIN_SHA' \
+    "publish job must compare current main with the validated source SHA"
+  assert_not_contains "$publish" "actions/checkout" \
+    "publish job must not checkout or rebuild source"
+  assert_not_contains "$publish" "go build" \
+    "publish job must not rebuild Go assets"
+  assert_not_contains "$publish" "npm " \
+    "publish job must not rebuild web assets"
+  assert_not_contains "$publish" "platformio" \
+    "publish job must not rebuild firmware"
+  assert_not_contains "$publish" "git tag" \
+    "publish job must not create an unvalidated local tag"
+  assert_not_contains "$publish" "git push" \
+    "publish job must not push a manually assembled tag"
+
+  assert_contains "$verify" "needs: publish-release" \
+    "public verification must wait for publication"
+  assert_contains "$verify" "verify-release-canary.sh" \
+    "public verification must reuse the existing release canary"
+  assert_not_contains "$verify" "contents: write" \
+    "public verification must remain read-only"
+  [[ "$(grep -cF "contents: write" "$WORKFLOW")" == "1" ]] \
+    || die "only publish-release may receive contents: write"
+
+  [[ "$(grep -cF "gh release create" "$WORKFLOW")" == "1" ]] \
+    || die "workflow must contain exactly one release creation command"
+
+  printf 'release publish workflow contract passed\n'
+}
+
+main "$@"

--- a/scripts/validate-hardware-canary.py
+++ b/scripts/validate-hardware-canary.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Validate immutable VibeTV release-candidate bundles and canary evidence."""
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+REQUIRED_ROLES = {"signed-dmg", "sparkle-appcast", "companion", "firmware-manifest", "firmware", "virtual-vibetv"}
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+SHA1 = re.compile(r"^[0-9a-f]{40}$")
+
+def fail(message):
+    raise ValueError(message)
+
+def read_json(path):
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"read JSON {path}: {exc}")
+
+def digest(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+def safe_file(root, relative):
+    if not isinstance(relative, str) or not relative or Path(relative).is_absolute() or ".." in Path(relative).parts:
+        fail("artifact path must be a non-empty relative path")
+    path = (root / relative).resolve()
+    if root.resolve() not in path.parents or not path.is_file():
+        fail(f"candidate artifact missing: {relative}")
+    return path
+
+def candidate(root):
+    root = Path(root).resolve()
+    body = read_json(root / "candidate-manifest.json")
+    for key in ("schemaVersion", "repository", "sourceSha", "version", "candidateRunId", "createdAt", "artifacts", "virtualGate"):
+        if key not in body:
+            fail(f"candidate manifest missing {key}")
+    if body["schemaVersion"] != 1 or not isinstance(body["repository"], str) or not SHA1.fullmatch(str(body["sourceSha"])):
+        fail("invalid candidate schema, repository, or sourceSha")
+    if not isinstance(body["candidateRunId"], str) or not body["candidateRunId"].strip() or not isinstance(body["artifacts"], list):
+        fail("invalid candidateRunId or artifacts")
+    gate = body["virtualGate"]
+    if not isinstance(gate, dict) or gate.get("result") != "pending" or str(gate.get("runId")) != str(body["candidateRunId"]):
+        fail("candidate virtualGate must remain pending for the matching run")
+    seen_paths, roles, hashes = set(), set(), {}
+    for item in body["artifacts"]:
+        if not isinstance(item, dict): fail("candidate artifact must be an object")
+        for key in ("name", "path", "sha256", "role"):
+            if not isinstance(item.get(key), str) or not item[key].strip(): fail(f"candidate artifact missing {key}")
+        if item["path"] in seen_paths or not SHA256.fullmatch(item["sha256"].lower()): fail("duplicate artifact path or invalid sha256")
+        seen_paths.add(item["path"]); roles.add(item["role"])
+        actual = digest(safe_file(root, item["path"]))
+        if actual != item["sha256"].lower(): fail(f"candidate artifact sha256 mismatch: {item['path']}")
+        hashes[item["path"]] = actual
+    if not REQUIRED_ROLES.issubset(roles): fail("candidate is missing required artifact roles")
+    return body, hashes
+
+def evidence(root, path):
+    manifest, hashes = candidate(root)
+    body = read_json(path)
+    for key in ("schemaVersion", "repository", "sourceSha", "version", "candidateRunId", "candidateManifestSha256", "artifactHashes", "device", "checks", "timestamps", "actor", "result"):
+        if key not in body: fail(f"evidence missing {key}")
+    if body["schemaVersion"] != 1 or body["result"] not in {"success", "blocked", "unknown"}: fail("invalid evidence schema or result")
+    for key in ("repository", "sourceSha", "version", "candidateRunId"):
+        if str(body[key]) != str(manifest[key]): fail(f"evidence {key} does not match candidate")
+    if body["candidateManifestSha256"] != digest(Path(root) / "candidate-manifest.json"): fail("evidence candidate manifest hash mismatch")
+    if body["artifactHashes"] != hashes: fail("evidence artifact hashes do not match candidate")
+    device = body["device"]
+    if not isinstance(device, dict) or not all(isinstance(device.get(k), str) for k in ("deviceId", "board", "firmwareBefore", "firmwareAfter")): fail("invalid evidence device")
+    checks = body["checks"]
+    if not isinstance(checks, dict) or not all(isinstance(v, bool) for v in checks.values()): fail("invalid evidence checks")
+    if body["result"] == "success" and not all(checks.get(k) is True for k in ("candidateVerified", "hello", "health", "daemonRender")): fail("success evidence lacks required checks")
+    return body
+
+def candidate_result(root, path):
+    manifest, hashes = candidate(root)
+    body = read_json(path)
+    for key in ("schemaVersion", "repository", "sourceSha", "version", "candidateRunId", "result", "artifactHashes"):
+        if key not in body: fail(f"candidate result missing {key}")
+    if body["schemaVersion"] != 1 or body["result"] != "success": fail("candidate result is not successful")
+    for key in ("repository", "sourceSha", "version", "candidateRunId"):
+        if str(body[key]) != str(manifest[key]): fail(f"candidate result {key} does not match candidate")
+    if body["artifactHashes"] != hashes: fail("candidate result artifact hashes do not match candidate")
+    return body
+
+def main():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("candidate", "candidate-result", "evidence"):
+        p = sub.add_parser(name); p.add_argument("--candidate-dir", required=True)
+        if name == "evidence": p.add_argument("--evidence", required=True)
+        if name == "candidate-result": p.add_argument("--result", required=True)
+    args = parser.parse_args()
+    if args.command == "candidate": result = candidate(args.candidate_dir)[0]
+    elif args.command == "candidate-result": result = candidate_result(args.candidate_dir, args.result)
+    else: result = evidence(args.candidate_dir, args.evidence)
+    print(json.dumps(result, sort_keys=True))
+
+if __name__ == "__main__":
+    try: main()
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr); sys.exit(1)

--- a/scripts/validate-hardware-canary.py
+++ b/scripts/validate-hardware-canary.py
@@ -53,6 +53,7 @@ def candidate(root):
         if not isinstance(item, dict): fail("candidate artifact must be an object")
         for key in ("name", "path", "sha256", "role"):
             if not isinstance(item.get(key), str) or not item[key].strip(): fail(f"candidate artifact missing {key}")
+        if not isinstance(item.get("publish"), bool): fail("candidate artifact publish must be boolean")
         if item["path"] in seen_paths or not SHA256.fullmatch(item["sha256"].lower()): fail("duplicate artifact path or invalid sha256")
         seen_paths.add(item["path"]); roles.add(item["role"])
         actual = digest(safe_file(root, item["path"]))

--- a/scripts/validate-release-publish-gate.py
+++ b/scripts/validate-release-publish-gate.py
@@ -291,22 +291,22 @@ def validate_publish_scope(
         item
         for item in published
         if item["name"] == "appcast.xml"
-        and item["role"] == "production-appcast"
+        and item["role"] == "sparkle-appcast"
     ]
     if len(appcast_items) != 1:
-        fail("candidate publish scope must identify one production appcast")
+        fail("candidate publish scope must identify one Sparkle appcast")
     appcast = safe_artifact(candidate_dir, appcast_items[0]["path"])
     try:
         root = ET.parse(appcast).getroot()
     except (ET.ParseError, OSError) as exc:
-        fail(f"production appcast is invalid XML: {exc}")
+        fail(f"Sparkle appcast is invalid XML: {exc}")
     enclosure_urls = [
         element.attrib.get("url")
         for element in root.iter()
         if element.tag.rsplit("}", 1)[-1] == "enclosure"
     ]
     if not enclosure_urls or any(not url for url in enclosure_urls):
-        fail("production appcast must contain enclosure URL values")
+        fail("Sparkle appcast must contain enclosure URL values")
     for url in enclosure_urls:
         asset = url.removeprefix(release_prefix) if url else ""
         if (

--- a/scripts/validate-release-publish-gate.py
+++ b/scripts/validate-release-publish-gate.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""Validate exact VibeTV release evidence and freeze publishable assets."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import re
+import shutil
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+SEMVER = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+)
+SHA1 = re.compile(r"^[0-9a-f]{40}$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+CANDIDATE_WORKFLOW = ".github/workflows/vibetv-release-candidate.yml"
+HARDWARE_WORKFLOW = ".github/workflows/record-hardware-canary.yml"
+MAX_EVIDENCE_AGE = dt.timedelta(days=7)
+
+
+class GateError(ValueError):
+    """A release-gate contract was not satisfied."""
+
+
+def fail(message: str) -> None:
+    raise GateError(message)
+
+
+def read_json(path: str | Path, label: str) -> dict:
+    try:
+        body = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"cannot read {label}: {exc}")
+    if not isinstance(body, dict):
+        fail(f"{label} must be a JSON object")
+    return body
+
+
+def write_json(path: Path, body: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def digest(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            hasher.update(block)
+    return hasher.hexdigest()
+
+
+def timestamp(value: object, label: str) -> dt.datetime:
+    if not isinstance(value, str) or not value:
+        fail(f"{label} must be an ISO-8601 timestamp")
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = dt.datetime.fromisoformat(normalized)
+    except ValueError:
+        fail(f"{label} must be an ISO-8601 timestamp")
+    if parsed.tzinfo is None:
+        fail(f"{label} must include a timezone")
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def required(body: dict, keys: tuple[str, ...], label: str) -> None:
+    for key in keys:
+        if key not in body:
+            fail(f"{label} missing {key}")
+
+
+def exact_identity(
+    body: dict,
+    *,
+    repository: str,
+    source_sha: str,
+    version: str,
+    candidate_run_id: str,
+    label: str,
+) -> None:
+    expected = {
+        "repository": repository,
+        "sourceSha": source_sha,
+        "version": version,
+        "candidateRunId": candidate_run_id,
+    }
+    for key, value in expected.items():
+        if str(body.get(key, "")) != value:
+            fail(f"{label} {key} does not match the requested candidate")
+
+
+def validate_run(
+    run: dict,
+    workflow: dict,
+    *,
+    run_id: str,
+    repository: str,
+    source_sha: str,
+    workflow_path: str,
+    label: str,
+) -> None:
+    if str(run.get("id", "")) != run_id:
+        fail(f"{label} run id does not match the dispatch input")
+    if run.get("conclusion") != "success":
+        fail(f"{label} workflow conclusion is not success")
+    if run.get("event") != "workflow_dispatch":
+        fail(f"{label} run was not manually dispatched")
+    if run.get("head_sha") != source_sha or run.get("head_branch") != "main":
+        fail(f"{label} run is not for the current main SHA")
+    run_repository = run.get("repository")
+    if (
+        not isinstance(run_repository, dict)
+        or run_repository.get("full_name") != repository
+    ):
+        fail(f"{label} run repository does not match")
+    if str(run.get("workflow_id", "")) != str(workflow.get("id", "")):
+        fail(f"{label} run workflow id does not match its workflow metadata")
+    if workflow.get("path") != workflow_path:
+        fail(f"{label} workflow path must be {workflow_path}")
+
+
+def safe_artifact(candidate_dir: Path, relative: object) -> Path:
+    if (
+        not isinstance(relative, str)
+        or not relative
+        or "\n" in relative
+        or "\r" in relative
+        or "\\" in relative
+    ):
+        fail("candidate artifact path must be a safe non-empty relative path")
+    relative_path = Path(relative)
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        fail("candidate artifact path must stay inside the candidate bundle")
+    root = candidate_dir.resolve()
+    path = (root / relative_path).resolve()
+    if root not in path.parents or not path.is_file():
+        fail(f"candidate artifact is missing or unsafe: {relative}")
+    return path
+
+
+def validate_candidate(
+    candidate_dir: Path,
+    *,
+    repository: str,
+    source_sha: str,
+    version: str,
+    candidate_run_id: str,
+) -> tuple[dict, dict[str, str], list[dict]]:
+    manifest_path = candidate_dir / "candidate-manifest.json"
+    manifest = read_json(manifest_path, "candidate manifest")
+    required(
+        manifest,
+        (
+            "schemaVersion",
+            "repository",
+            "sourceSha",
+            "version",
+            "candidateRunId",
+            "createdAt",
+            "artifacts",
+            "virtualGate",
+        ),
+        "candidate manifest",
+    )
+    if manifest["schemaVersion"] != 1:
+        fail("candidate manifest schemaVersion must be 1")
+    exact_identity(
+        manifest,
+        repository=repository,
+        source_sha=source_sha,
+        version=version,
+        candidate_run_id=candidate_run_id,
+        label="candidate manifest",
+    )
+    timestamp(manifest["createdAt"], "candidate manifest createdAt")
+    gate = manifest["virtualGate"]
+    if (
+        not isinstance(gate, dict)
+        or gate.get("result") != "pending"
+        or str(gate.get("runId", "")) != candidate_run_id
+    ):
+        fail("candidate manifest virtualGate must remain pending for candidate run")
+    artifacts = manifest["artifacts"]
+    if not isinstance(artifacts, list) or not artifacts:
+        fail("candidate manifest artifacts must be a non-empty array")
+
+    hashes: dict[str, str] = {}
+    names: set[str] = set()
+    for item in artifacts:
+        if not isinstance(item, dict):
+            fail("candidate manifest artifact must be an object")
+        required(
+            item,
+            ("name", "path", "sha256", "role", "publish"),
+            "candidate artifact",
+        )
+        name = item["name"]
+        relative = item["path"]
+        expected_hash = item["sha256"]
+        role = item["role"]
+        if not all(
+            isinstance(value, str) and value
+            for value in (name, relative, expected_hash, role)
+        ):
+            fail("candidate artifact fields must be non-empty strings")
+        if not isinstance(item["publish"], bool):
+            fail("candidate artifact publish must be a boolean")
+        required_prefix = "publish/" if item["publish"] else "test/"
+        if not relative.startswith(required_prefix):
+            fail(
+                f"candidate artifact {relative} must be under {required_prefix}"
+            )
+        if name != Path(relative).name or name in names:
+            fail("candidate artifact names must be unique path basenames")
+        if relative in hashes:
+            fail("candidate artifact paths must be unique")
+        if not SHA256.fullmatch(expected_hash):
+            fail(f"candidate artifact sha256 is invalid: {relative}")
+        actual_hash = digest(safe_artifact(candidate_dir, relative))
+        if actual_hash != expected_hash:
+            fail(f"candidate artifact sha256 mismatch: {relative}")
+        names.add(name)
+        hashes[relative] = actual_hash
+    publish_artifacts = validate_publish_scope(
+        candidate_dir,
+        artifacts,
+        repository=repository,
+        version=version,
+    )
+    return manifest, hashes, publish_artifacts
+
+
+def validate_publish_scope(
+    candidate_dir: Path,
+    artifacts: list[dict],
+    *,
+    repository: str,
+    version: str,
+) -> list[dict]:
+    published = [item for item in artifacts if item["publish"] is True]
+    published_names = {item["name"] for item in published}
+    required_names = {
+        "VibeTV-Control-Center.dmg",
+        "appcast.xml",
+        "install.sh",
+        "install-control-center-companion.sh",
+        f"codexbar-display-darwin-amd64-v{version}",
+        f"codexbar-display-darwin-arm64-v{version}",
+        "firmware-manifest.json",
+        f"firmware-manifest-v{version}.json",
+        f"checksums-v{version}.txt",
+    }
+    missing = sorted(required_names - published_names)
+    if missing:
+        fail(f"candidate publish scope is missing required assets: {', '.join(missing)}")
+
+    firmware_artifacts = [
+        item
+        for item in artifacts
+        if item["role"].startswith("firmware")
+        or item["name"].startswith("firmware-")
+    ]
+    if not any(
+        item["publish"] is True and item["role"] == "firmware"
+        for item in firmware_artifacts
+    ):
+        fail("candidate publish scope must include at least one firmware artifact")
+    unpublished_firmware = [
+        item["name"] for item in firmware_artifacts if item["publish"] is not True
+    ]
+    if unpublished_firmware:
+        fail(
+            "candidate publish scope excludes firmware assets: "
+            + ", ".join(sorted(unpublished_firmware))
+        )
+
+    for item in artifacts:
+        if item["role"] in {"virtual-vibetv", "test-companion", "universal-companion"}:
+            if item["publish"] is not False:
+                fail(f"test-only artifact must have publish=false: {item['name']}")
+
+    release_prefix = (
+        f"https://github.com/{repository}/releases/download/v{version}/"
+    )
+    appcast_items = [
+        item
+        for item in published
+        if item["name"] == "appcast.xml"
+        and item["role"] == "production-appcast"
+    ]
+    if len(appcast_items) != 1:
+        fail("candidate publish scope must identify one production appcast")
+    appcast = safe_artifact(candidate_dir, appcast_items[0]["path"])
+    try:
+        root = ET.parse(appcast).getroot()
+    except (ET.ParseError, OSError) as exc:
+        fail(f"production appcast is invalid XML: {exc}")
+    enclosure_urls = [
+        element.attrib.get("url")
+        for element in root.iter()
+        if element.tag.rsplit("}", 1)[-1] == "enclosure"
+    ]
+    if not enclosure_urls or any(not url for url in enclosure_urls):
+        fail("production appcast must contain enclosure URL values")
+    for url in enclosure_urls:
+        asset = url.removeprefix(release_prefix) if url else ""
+        if (
+            not url
+            or url != release_prefix + asset
+            or asset not in published_names
+            or "/" in asset
+        ):
+            fail(f"appcast enclosure URL is not the exact release asset URL: {url}")
+
+    manifest_items = [
+        item
+        for item in published
+        if item["role"] == "firmware-manifest"
+        or item["name"].startswith("firmware-manifest")
+    ]
+    for item in manifest_items:
+        body = read_json(
+            safe_artifact(candidate_dir, item["path"]),
+            f"firmware manifest {item['name']}",
+        )
+        entries = body.get("artifacts")
+        if not isinstance(entries, list) or not entries:
+            fail(f"firmware manifest {item['name']} has no artifacts")
+        for entry in entries:
+            if not isinstance(entry, dict):
+                fail(f"firmware manifest {item['name']} artifact must be an object")
+            asset = entry.get("asset")
+            url = entry.get("firmwareUrl")
+            if (
+                not isinstance(asset, str)
+                or asset not in published_names
+                or url != release_prefix + asset
+            ):
+                fail(
+                    f"firmwareUrl in {item['name']} is not the exact release asset URL"
+                )
+    return published
+
+
+def validate_result(
+    path: Path,
+    *,
+    repository: str,
+    source_sha: str,
+    version: str,
+    candidate_run_id: str,
+    hashes: dict[str, str],
+) -> dict:
+    result = read_json(path, "candidate result")
+    required(
+        result,
+        (
+            "schemaVersion",
+            "repository",
+            "sourceSha",
+            "version",
+            "candidateRunId",
+            "result",
+            "artifactHashes",
+        ),
+        "candidate result",
+    )
+    if result["schemaVersion"] != 1 or result["result"] != "success":
+        fail("candidate result must have schemaVersion 1 and result success")
+    exact_identity(
+        result,
+        repository=repository,
+        source_sha=source_sha,
+        version=version,
+        candidate_run_id=candidate_run_id,
+        label="candidate result",
+    )
+    if result["artifactHashes"] != hashes:
+        fail("candidate result artifact hashes do not match candidate manifest")
+    return result
+
+
+def validate_hardware(
+    path: Path,
+    *,
+    repository: str,
+    source_sha: str,
+    version: str,
+    candidate_run_id: str,
+    manifest_path: Path,
+    hashes: dict[str, str],
+    now: dt.datetime,
+) -> dict:
+    evidence = read_json(path, "hardware evidence")
+    required(
+        evidence,
+        (
+            "schemaVersion",
+            "repository",
+            "sourceSha",
+            "version",
+            "candidateRunId",
+            "candidateManifestSha256",
+            "artifactHashes",
+            "timestamps",
+            "result",
+        ),
+        "hardware evidence",
+    )
+    if evidence["schemaVersion"] != 1:
+        fail("hardware evidence schemaVersion must be 1")
+    if evidence["result"] != "success":
+        fail("hardware evidence result must be success")
+    exact_identity(
+        evidence,
+        repository=repository,
+        source_sha=source_sha,
+        version=version,
+        candidate_run_id=candidate_run_id,
+        label="hardware evidence",
+    )
+    if evidence["candidateManifestSha256"] != digest(manifest_path):
+        fail("hardware candidate manifest sha256 does not match")
+    if evidence["artifactHashes"] != hashes:
+        fail("hardware artifact hashes do not match candidate manifest")
+    timestamps = evidence["timestamps"]
+    if not isinstance(timestamps, dict):
+        fail("hardware timestamps must be an object")
+    started = timestamp(timestamps.get("startedAt"), "hardware startedAt")
+    finished = timestamp(timestamps.get("finishedAt"), "hardware finishedAt")
+    if started > finished:
+        fail("hardware evidence finishedAt precedes startedAt")
+    if finished > now:
+        fail("hardware evidence finishedAt is in the future")
+    if now - finished > MAX_EVIDENCE_AGE:
+        fail("hardware evidence is older than 7 days")
+    return evidence
+
+
+def copy_artifacts(
+    candidate_dir: Path, copy_dir: Path, publish_artifacts: list[dict]
+) -> None:
+    if copy_dir.exists() and any(copy_dir.iterdir()):
+        fail("publish asset directory must be empty")
+    copy_dir.mkdir(parents=True, exist_ok=True)
+    for item in publish_artifacts:
+        source = safe_artifact(candidate_dir, item["path"])
+        destination = copy_dir / item["path"]
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+
+def preflight(args: argparse.Namespace) -> None:
+    if not SEMVER.fullmatch(args.version):
+        fail("release version must be SemVer x.y.z without a leading v")
+    if not SHA1.fullmatch(args.source_sha):
+        fail("source SHA must be a lowercase 40-character Git SHA")
+    if not args.candidate_run_id.isdigit() or not args.hardware_canary_run_id.isdigit():
+        fail("run ids must contain digits only")
+    now = (
+        timestamp(args.now, "validation time")
+        if args.now
+        else dt.datetime.now(dt.timezone.utc)
+    )
+
+    candidate_run = read_json(args.candidate_run, "candidate run")
+    candidate_workflow = read_json(args.candidate_workflow, "candidate workflow")
+    validate_run(
+        candidate_run,
+        candidate_workflow,
+        run_id=args.candidate_run_id,
+        repository=args.repository,
+        source_sha=args.source_sha,
+        workflow_path=CANDIDATE_WORKFLOW,
+        label="candidate",
+    )
+    hardware_run = read_json(args.hardware_run, "hardware run")
+    hardware_workflow = read_json(args.hardware_workflow, "hardware workflow")
+    validate_run(
+        hardware_run,
+        hardware_workflow,
+        run_id=args.hardware_canary_run_id,
+        repository=args.repository,
+        source_sha=args.source_sha,
+        workflow_path=HARDWARE_WORKFLOW,
+        label="hardware",
+    )
+
+    candidate_dir = Path(args.candidate_dir).resolve()
+    manifest, hashes, publish_artifacts = validate_candidate(
+        candidate_dir,
+        repository=args.repository,
+        source_sha=args.source_sha,
+        version=args.version,
+        candidate_run_id=args.candidate_run_id,
+    )
+    result_path = Path(args.candidate_result)
+    validate_result(
+        result_path,
+        repository=args.repository,
+        source_sha=args.source_sha,
+        version=args.version,
+        candidate_run_id=args.candidate_run_id,
+        hashes=hashes,
+    )
+    evidence_path = Path(args.hardware_evidence)
+    validate_hardware(
+        evidence_path,
+        repository=args.repository,
+        source_sha=args.source_sha,
+        version=args.version,
+        candidate_run_id=args.candidate_run_id,
+        manifest_path=candidate_dir / "candidate-manifest.json",
+        hashes=hashes,
+        now=now,
+    )
+
+    copy_dir = Path(args.copy_dir)
+    copy_artifacts(candidate_dir, copy_dir, publish_artifacts)
+    payload = {
+        "schemaVersion": 1,
+        "repository": args.repository,
+        "sourceSha": args.source_sha,
+        "version": args.version,
+        "tag": f"v{args.version}",
+        "candidateRunId": args.candidate_run_id,
+        "hardwareCanaryRunId": args.hardware_canary_run_id,
+        "candidateManifestSha256": digest(
+            candidate_dir / "candidate-manifest.json"
+        ),
+        "candidateResultSha256": digest(result_path),
+        "hardwareEvidenceSha256": digest(evidence_path),
+        "validatedAt": now.isoformat().replace("+00:00", "Z"),
+        "artifacts": publish_artifacts,
+    }
+    write_json(Path(args.output), payload)
+    print(json.dumps(payload, sort_keys=True))
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser()
+    commands = root.add_subparsers(dest="command", required=True)
+    command = commands.add_parser("preflight")
+    command.add_argument("--repository", required=True)
+    command.add_argument("--source-sha", required=True)
+    command.add_argument("--version", required=True)
+    command.add_argument("--candidate-run-id", required=True)
+    command.add_argument("--candidate-run", required=True)
+    command.add_argument("--candidate-workflow", required=True)
+    command.add_argument("--candidate-dir", required=True)
+    command.add_argument("--candidate-result", required=True)
+    command.add_argument("--hardware-canary-run-id", required=True)
+    command.add_argument("--hardware-run", required=True)
+    command.add_argument("--hardware-workflow", required=True)
+    command.add_argument("--hardware-evidence", required=True)
+    command.add_argument("--now")
+    command.add_argument("--output", required=True)
+    command.add_argument("--copy-dir", required=True)
+    command.set_defaults(handler=preflight)
+    return root
+
+
+def main() -> None:
+    args = parser().parse_args()
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except GateError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Stack 3/3 — physical canary and publish lock

Part of #177. Base: #298.

This PR turns the release rule into a technical lock:

- guided physical VibeTV canary bound to the exact candidate run, SHA, manifest, hashes, device ID, board, firmware, and operator;
- current customer hardware uses authenticated WiFi OTA with exact-device and hardware-risk confirmation; future USB-capable lab hardware may optionally create a full recovery backup before the WiFi OTA;
- explicit render confirmation plus a real power cycle, bounded return checks, and a second candidate render after restart;
- immutable hardware evidence recorded as `CODEX VibeTV Hardware Canary`;
- manual publish workflow that accepts only matching successful candidate and hardware runs, waits for `Production` approval, rechecks `main`, and publishes the already-tested assets without rebuilding.

## Verification

- hardware-canary contract and Bash syntax tests;
- 15 publish-gate fixture tests, including bad hashes, stale evidence, wrong URLs, missing assets, and test-only assets;
- release workflow, macOS bundle, hosted gate, `actionlint`, full Go tests, Go vet, and diff checks on the complete stack;
- manual branch preview on VibeTV `5863327`: signed DMG `99.0.128` at source `577460f`, WiFi OTA from `1.0.39-dev` to `1.0.40-dev`, matched Synthwave ThemeSpec/assets, healthy stream, and matching Claude `5%` / `18%` values in the Mac App and on the physical display.

The manual preview validates this branch but does not replace the immutable
post-merge release-candidate canary. No Production approval, tag, release, or
public deployment was executed.
