### PR TITLE
Fix VibeTV hosted gate review findings

### DIFF
--- a/.github/workflows/vibetv-merge-gate.yml
+++ b/.github/workflows/vibetv-merge-gate.yml
@@ -189,7 +189,7 @@ jobs:
           set -euo pipefail
           version="$(cat tmp/vibetv-merge/version.txt)"
           sparkle_dir="$(./scripts/fetch-sparkle.sh)"
-          printf '%s' "$SPARKLE_ED25519_PRIVATE_KEY" | "$sparkle_dir/bin/generate_appcast" --ed-key-file - --maximum-deltas 0 --link https://app.vibetv.shop -o dist/macos/appcast.xml dist/macos
+          printf '%s' "$SPARKLE_ED25519_PRIVATE_KEY" | "$sparkle_dir/bin/generate_appcast" --ed-key-file - --maximum-deltas 0 --link https://app.vibetv.shop --download-url-prefix "https://github.com/${REPOSITORY}/releases/download/v${version}/" -o dist/macos/appcast.xml dist/macos
           python3 - "$SOURCE_SHA" "$version" "$REPOSITORY" "$CANDIDATE_RUN_ID" dist/macos/candidate-manifest.json <<'PY'
           import datetime, hashlib, json, sys
           sha, version, repository, run_id, output = sys.argv[1:]
@@ -214,19 +214,17 @@ jobs:
               json.dump(manifest, destination, indent=2)
               destination.write("\n")
           PY
+          mkdir -p tmp/vibetv-merge/candidate
+          cp dist/macos/VibeTV-Control-Center.dmg dist/macos/appcast.xml dist/macos/candidate-manifest.json \
+            tmp/vibetv-merge/virtual-vibetv tmp/vibetv-merge/codexbar-display \
+            tmp/vibetv-merge/firmware.bin tmp/vibetv-merge/firmware-manifest.json \
+            tmp/vibetv-merge/candidate/
 
       - name: Upload signed merge candidate
         uses: actions/upload-artifact@v4
         with:
           name: CODEX-vibetv-merge-candidate-${{ github.run_id }}
-          path: |
-            dist/macos/VibeTV-Control-Center.dmg
-            dist/macos/appcast.xml
-            dist/macos/candidate-manifest.json
-            tmp/vibetv-merge/virtual-vibetv
-            tmp/vibetv-merge/codexbar-display
-            tmp/vibetv-merge/firmware.bin
-            tmp/vibetv-merge/firmware-manifest.json
+          path: tmp/vibetv-merge/candidate
           retention-days: 7
           compression-level: 0
 
@@ -273,6 +271,8 @@ jobs:
         with:
           name: CODEX-vibetv-merge-baselines-${{ github.run_id }}
           path: baselines
+      - name: Restore candidate executable permissions
+        run: chmod +x candidate/virtual-vibetv candidate/codexbar-display
       - name: Download frozen public baseline when required
         if: matrix.state != 'clean_os'
         run: |

--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -158,7 +158,8 @@ jobs:
           mkdir -p tmp/vibetv-rc/publish/macos
           cp dist/macos/VibeTV-Control-Center.dmg tmp/vibetv-rc/publish/macos/VibeTV-Control-Center.dmg
           printf '%s' "$SPARKLE_ED25519_PRIVATE_KEY" | "$sparkle_dir/bin/generate_appcast" --ed-key-file - --maximum-deltas 0 --link https://app.vibetv.shop --download-url-prefix "https://github.com/${REPOSITORY}/releases/download/v${version}/" -o tmp/vibetv-rc/publish/macos/appcast.xml tmp/vibetv-rc/publish/macos
-          (cd tmp/vibetv-rc/publish && find . -type f -print0 | sort -z | xargs -0 shasum -a 256 > "checksums-v${version}.txt")
+          checksums="checksums-v${version}.txt"
+          (cd tmp/vibetv-rc/publish && find . -type f ! -name "$checksums" -print0 | sort -z | xargs -0 shasum -a 256 > "$checksums")
           (cd tmp/vibetv-rc/publish && shasum -a 256 -c "checksums-v${version}.txt")
           python3 - "$source_sha" "$version" "$REPOSITORY" "$CANDIDATE_RUN_ID" tmp/vibetv-rc/candidate-manifest.json tmp/vibetv-rc <<'PY'
           import datetime, hashlib, json, sys
@@ -248,6 +249,8 @@ jobs:
         with:
           name: CODEX-vibetv-rc-baselines-${{ github.run_id }}
           path: baselines
+      - name: Restore candidate executable permissions
+        run: chmod +x candidate/test/virtual-vibetv candidate/test/codexbar-display
       - name: Download frozen public baseline when required
         if: matrix.state != 'clean_os'
         run: |
@@ -257,9 +260,9 @@ jobs:
           print("DMG_URL=" + shlex.quote(baseline["dmgUrl"]))
           print("APPCAST_URL=" + shlex.quote(baseline["appcastUrl"]))
           PY
-          cp "baselines/${{ matrix.state }}.dmg" baseline.dmg
-          cp "baselines/${{ matrix.state }}.appcast.xml" baseline-appcast.xml
-          cp "baselines/${{ matrix.state }}.firmware-manifest.json" baseline-firmware-manifest.json
+          cp "baselines/baselines/${{ matrix.state }}.dmg" baseline.dmg
+          cp "baselines/baselines/${{ matrix.state }}.appcast.xml" baseline-appcast.xml
+          cp "baselines/baselines/${{ matrix.state }}.firmware-manifest.json" baseline-firmware-manifest.json
           shasum -a 256 baseline.dmg baseline-appcast.xml
       - name: Run full direct hosted macOS guest matrix
         run: |
@@ -271,7 +274,7 @@ jobs:
             baseline_args=(--baseline-dmg baseline.dmg --baseline-appcast baseline-appcast.xml)
             current_firmware="$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("baseline-firmware-manifest.json"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789"))')"
           fi
-          ./scripts/test-vibetv-hosted-guest.sh --dmg candidate/publish/macos/VibeTV-Control-Center.dmg --appcast candidate/publish/macos/appcast.xml --virtual-vibetv candidate/test/virtual-vibetv --companion candidate/test/codexbar-display --firmware candidate/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("release/firmware-versions.json"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789")').bin.gz --firmware-manifest candidate/publish/firmware/firmware-manifest.json --current-firmware "$current_firmware" --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
+          ./scripts/test-vibetv-hosted-guest.sh --dmg candidate/publish/macos/VibeTV-Control-Center.dmg --appcast candidate/publish/macos/appcast.xml --virtual-vibetv candidate/test/virtual-vibetv --companion candidate/test/codexbar-display --firmware candidate/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("release/firmware-versions.json"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789"))').bin.gz --firmware-manifest candidate/publish/firmware/firmware-manifest.json --current-firmware "$current_firmware" --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/companion/cmd/codexbar-display/virtual_vibetv_test.go
+++ b/companion/cmd/codexbar-display/virtual_vibetv_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -25,7 +26,7 @@ func TestRunInstallUpdateUsesDedicatedRawOTAAndDoesNotFlashAlreadyCurrentDevice(
 	t.Setenv("HOME", t.TempDir())
 	firmwareHTTPVerifyPollInterval = time.Millisecond
 
-	image := []byte("virtual raw OTA candidate")
+	image := bytes.Repeat([]byte{0xa5}, 2*otaRawAckBlockBytes+17)
 	cfg := virtualvibetv.DefaultConfig()
 	cfg.HTTPListenAddr, cfg.RawOTAListenAddr = "127.0.0.1:0", "127.0.0.1:0"
 	cfg.RebootUnavailableRequests = 0

--- a/companion/internal/virtualvibetv/server.go
+++ b/companion/internal/virtualvibetv/server.go
@@ -320,6 +320,10 @@ func (s *Server) handleFrame(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(w, r) {
 		return
 	}
+	if s.cfg.StreamRestartFails {
+		s.respond(w, r, http.StatusServiceUnavailable, "display stream unavailable", "stream restart failed")
+		return
+	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, 4097))
 	if err != nil || len(body) == 0 || len(body) > 4096 || !json.Valid(body) {
 		s.respond(w, r, http.StatusBadRequest, "invalid frame", "invalid frame")

--- a/companion/internal/virtualvibetv/server_test.go
+++ b/companion/internal/virtualvibetv/server_test.go
@@ -6,7 +6,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/transport"
 )
 
 func TestStartServesCompanionAndRawOTAOnSeparateListeners(t *testing.T) {
@@ -108,7 +111,14 @@ func TestScenariosExposeRequiredFailureStates(t *testing.T) {
 		{
 			name: "stream restart failure",
 			cfg:  func(cfg *Config) { cfg.StreamRestartFails = true },
-			want: func(t *testing.T, _ *Server, baseURL string) { assertHealth(t, baseURL, true, true, false) },
+			want: func(t *testing.T, _ *Server, baseURL string) {
+				assertHealth(t, baseURL, true, true, false)
+				t.Setenv("CODEXBAR_DISPLAY_DEVICE_TOKEN", DefaultConfig().PairingToken)
+				err := transport.NewWiFiTransportWithClient(http.DefaultClient).SendLine(baseURL, []byte(`{"version":1}`))
+				if err == nil || !strings.Contains(err.Error(), "status=503") {
+					t.Fatalf("real WiFi frame path did not observe stream failure: %v", err)
+				}
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/scripts/build-sparkle-cli.sh
+++ b/scripts/build-sparkle-cli.sh
@@ -13,6 +13,7 @@ work="$(mktemp -d "${TMPDIR:-/tmp}/sparkle-cli.XXXXXX")"; trap 'rm -rf "$work"' 
 git init -q "$work/source"
 git -C "$work/source" remote add origin "$REPOSITORY"
 git -C "$work/source" fetch -q --depth=1 origin "$COMMIT"
+git -C "$work/source" checkout -q --detach FETCH_HEAD
 [[ "$(git -C "$work/source" rev-parse HEAD)" == "$COMMIT" ]] || { echo 'error: Sparkle source commit mismatch' >&2; exit 1; }
 xcodebuild -project "$work/source/Sparkle.xcodeproj" -scheme sparkle-cli -configuration Release -derivedDataPath "$work/derived" CODE_SIGNING_ALLOWED=NO build >/dev/null
 cli="$(find "$work/derived" -type f -path '*/sparkle.app/Contents/MacOS/sparkle' -print -quit)"

--- a/scripts/extract-vibetv-candidate-app.sh
+++ b/scripts/extract-vibetv-candidate-app.sh
@@ -23,6 +23,7 @@ done
 
 python3 - "$ARCHIVE" "$OUTPUT" <<'PY'
 import pathlib
+import posixpath
 import shutil
 import sys
 import tarfile
@@ -41,7 +42,12 @@ with tarfile.open(archive, "r:gz") as candidate:
             raise SystemExit(f"unsafe candidate archive path: {member.name}")
         if not path.parts or path.parts[0] != expected_root:
             raise SystemExit(f"unexpected candidate archive root: {member.name}")
-        if not (member.isdir() or member.isfile()):
+        if member.issym():
+            link = pathlib.PurePosixPath(member.linkname)
+            resolved = pathlib.PurePosixPath(posixpath.normpath(str(path.parent / link)))
+            if not member.linkname or link.is_absolute() or not resolved.parts or resolved.parts[0] != expected_root:
+                raise SystemExit(f"unsafe candidate archive symlink: {member.name} -> {member.linkname}")
+        elif not (member.isdir() or member.isfile()):
             raise SystemExit(f"candidate archive contains a non-regular entry: {member.name}")
     output.mkdir(parents=True)
     candidate.extractall(output)

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -83,9 +83,12 @@ with tarfile.open(sys.argv[1], "w:gz") as archive:
     member.linkname = "../../../../escape"
     archive.addfile(member)
 PY
-  if "$EXTRACTOR" --archive "$work/unsafe-link.tar.gz" --output "$work/unsafe-link" >/dev/null 2>&1; then
+  local unsafe_link_error
+  if unsafe_link_error="$("$EXTRACTOR" --archive "$work/unsafe-link.tar.gz" --output "$work/unsafe-link" 2>&1)"; then
     die "escaping candidate archive symlink was accepted"
   fi
+  [[ "$unsafe_link_error" == *"unsafe candidate archive symlink"* ]] \
+    || die "escaping symlink test failed for the wrong reason: $unsafe_link_error"
 }
 
 main() {

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -176,6 +176,22 @@ main() {
     'guest test must require a replacement Candidate process after Sparkle'
   assert_contains "$GUEST_TEST" 'gzip -cd' \
     'guest test must hash the raw firmware bytes sent through OTA'
+  assert_contains "$GUEST_TEST" 'if gzip -t "$FIRMWARE"' \
+    'guest test must accept both compressed release firmware and raw merge firmware'
+  assert_contains "$MERGE_WORKFLOW" '--download-url-prefix "https://github.com/${REPOSITORY}/releases/download/v${version}/"' \
+    'merge appcast must use a GitHub enclosure URL that the guest can rewrite'
+  assert_contains "$MERGE_WORKFLOW" 'path: tmp/vibetv-merge/candidate' \
+    'merge candidate must be uploaded from one artifact root'
+  assert_contains "$MERGE_WORKFLOW" 'chmod +x candidate/virtual-vibetv candidate/codexbar-display' \
+    'merge guest must restore executable bits lost by artifact download'
+  assert_contains "$RC_WORKFLOW" 'chmod +x candidate/test/virtual-vibetv candidate/test/codexbar-display' \
+    'release guest must restore executable bits lost by artifact download'
+  assert_contains "$RC_WORKFLOW" 'baselines/baselines/${{ matrix.state }}.dmg' \
+    'release guest must read frozen baselines from the downloaded artifact layout'
+  assert_contains "$RC_WORKFLOW" '! -name "$checksums"' \
+    'release checksum generation must exclude the checksum manifest itself'
+  assert_contains "$SPARKLE_BUILDER" 'checkout -q --detach FETCH_HEAD' \
+    'Sparkle builder must check out the pinned fetched source before verification'
   assert_contains "$RC_WORKFLOW" 'artifactHashes": {item["path"]' \
     'candidate result must expose publish validators a path-to-hash map'
   assert_contains "$RC_WORKFLOW" 'check-firmware-size-budget.sh' \

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -47,12 +47,16 @@ assert_safe_app_extractor() {
   work="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-hosted-gate.XXXXXX")"
   trap 'rm -rf "${work:-}"' RETURN
 
-  mkdir -p "$work/safe/VibeTV Control Center.app/Contents"
+  mkdir -p "$work/safe/VibeTV Control Center.app/Contents/Frameworks/Test.framework/Versions/B/Resources"
   printf '<plist version="1.0"><dict/></plist>\n' > "$work/safe/VibeTV Control Center.app/Contents/Info.plist"
+  ln -s B "$work/safe/VibeTV Control Center.app/Contents/Frameworks/Test.framework/Versions/Current"
+  ln -s Versions/Current/Resources "$work/safe/VibeTV Control Center.app/Contents/Frameworks/Test.framework/Resources"
   COPYFILE_DISABLE=1 tar -czf "$work/safe.tar.gz" -C "$work/safe" "VibeTV Control Center.app"
   "$EXTRACTOR" --archive "$work/safe.tar.gz" --output "$work/extracted" >/dev/null
   [[ -f "$work/extracted/VibeTV Control Center.app/Contents/Info.plist" ]] \
     || die "safe candidate archive was not extracted"
+  [[ -d "$work/extracted/VibeTV Control Center.app/Contents/Frameworks/Test.framework/Resources" ]] \
+    || die "safe framework symlinks were not preserved"
 
   python3 - "$work/unsafe.tar.gz" <<'PY'
 import io
@@ -67,6 +71,20 @@ with tarfile.open(sys.argv[1], "w:gz") as archive:
 PY
   if "$EXTRACTOR" --archive "$work/unsafe.tar.gz" --output "$work/unsafe" >/dev/null 2>&1; then
     die "unsafe candidate archive path was accepted"
+  fi
+
+  python3 - "$work/unsafe-link.tar.gz" <<'PY'
+import sys
+import tarfile
+
+with tarfile.open(sys.argv[1], "w:gz") as archive:
+    member = tarfile.TarInfo("VibeTV Control Center.app/Contents/Frameworks/escape")
+    member.type = tarfile.SYMTYPE
+    member.linkname = "../../../../escape"
+    archive.addfile(member)
+PY
+  if "$EXTRACTOR" --archive "$work/unsafe-link.tar.gz" --output "$work/unsafe-link" >/dev/null 2>&1; then
+    die "escaping candidate archive symlink was accepted"
   fi
 }
 

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -132,7 +132,12 @@ def key(value): return tuple(int(part) for part in value.split('-')[0].split('.'
 print(1 if key(sys.argv[2]) > key(sys.argv[1]) else 0)
 PY
 )"
-RAW_FIRMWARE="$WORK/firmware.bin"; gzip -cd "$FIRMWARE" > "$RAW_FIRMWARE"
+RAW_FIRMWARE="$WORK/firmware.bin"
+if gzip -t "$FIRMWARE" 2>/dev/null; then
+  gzip -cd "$FIRMWARE" > "$RAW_FIRMWARE"
+else
+  cp "$FIRMWARE" "$RAW_FIRMWARE"
+fi
 firmware_sha="$(shasum -a 256 "$RAW_FIRMWARE" | awk '{print $1}')"
 "$VIRTUAL_VIBETV" --addr 127.0.0.1:47834 --raw-addr 127.0.0.1:8081 --firmware "$CURRENT_FIRMWARE" --candidate-firmware "$candidate_firmware" --expected-firmware-sha256 "$firmware_sha" > "$OUTPUT/virtual-vibetv.log" 2>&1 & VIRTUAL_PID=$!
 for _ in $(seq 1 30); do curl --fail --silent "$SERVER_URL/firmware-manifest.json" >/dev/null && curl --fail --silent http://127.0.0.1:47834/health > "$OUTPUT/virtual-health-before.json" && break; sleep 1; done


### PR DESCRIPTION
## What changed

- make the Virtual VibeTV stream-failure scenario fail through the real WiFi frame path
- exercise multi-block raw OTA behavior
- repair merge/release artifact paths, executable permissions, firmware decompression, Sparkle checkout, appcast URLs, checksum generation, and the candidate firmware expression
- extend hosted-gate contract coverage for every repaired failure

## Why

Non-blocking Codex review comments identified paths where the hosted VibeTV laboratory could report green locally while the real GitHub-hosted macOS matrix would fail or miss a simulated stream failure.

## Validation

- `cd companion && go test ./...`
- `./scripts/test-vibetv-hosted-gates.sh`
- Bash syntax checks for the modified scripts
- YAML parse checks for both modified workflows
- `git diff --check`