### PR TITLE
Add safe bootstrap path for VibeTV gate repairs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Test agent git guardrails
         run: ./scripts/test-agent-git-guardrails.sh
 
+      - name: Test hosted VibeTV gate contracts
+        run: ./scripts/test-vibetv-hosted-gates.sh
+
       - name: Check ESP8266 soak gate
         run: ./scripts/check-esp8266-soak-gate.sh
 

--- a/.github/workflows/vibetv-gate-repair.yml
+++ b/.github/workflows/vibetv-gate-repair.yml
@@ -1,0 +1,129 @@
+name: CODEX Test VibeTV Gate Repair
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Open gate-repair pull request number to test
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codex-vibetv-gate-repair-${{ inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  resolve-pr:
+    if: >-
+      github.repository == 'DreamyTalesPAN/CodexBar-Display' &&
+      github.ref == 'refs/heads/main' &&
+      (github.actor == github.repository_owner || github.actor == 'marcus7989')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      base_sha: ${{ steps.pr.outputs.base_sha }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+    steps:
+      - id: pr
+        name: Resolve exact open PR commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || { echo 'invalid PR number' >&2; exit 1; }
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > pr.json
+          python3 - "$GITHUB_OUTPUT" pr.json "$GITHUB_REPOSITORY" <<'PY'
+          import json
+          import sys
+
+          output, source, repository = sys.argv[1:]
+          value = json.load(open(source, encoding="utf-8"))
+          if value.get("state") != "open" or value.get("base", {}).get("ref") != "main":
+              raise SystemExit("PR must be open against main")
+          if value.get("head", {}).get("repo", {}).get("full_name") != repository:
+              raise SystemExit("gate repair PR must come from this repository")
+          base_sha = str(value.get("base", {}).get("sha", "")).strip()
+          head_sha = str(value.get("head", {}).get("sha", "")).strip()
+          if len(base_sha) != 40 or len(head_sha) != 40:
+              raise SystemExit("PR has no immutable 40-character commit SHAs")
+          with open(output, "a", encoding="utf-8") as destination:
+              destination.write(f"base_sha={base_sha}\nhead_sha={head_sha}\n")
+          PY
+
+  verify-scope:
+    needs: resolve-pr
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted main scope policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch exact untrusted commits without checkout
+        env:
+          BASE_SHA: ${{ needs.resolve-pr.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.resolve-pr.outputs.head_sha }}
+        run: git fetch --no-tags origin "$BASE_SHA" "$HEAD_SHA"
+
+      - name: Reject product or release changes
+        env:
+          BASE_SHA: ${{ needs.resolve-pr.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.resolve-pr.outputs.head_sha }}
+        run: ./scripts/check-vibetv-gate-repair-scope.sh "$BASE_SHA" "$HEAD_SHA"
+
+  test-repair:
+    needs: [resolve-pr, verify-scope]
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - name: Checkout exact untrusted gate repair without persisted credentials
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-pr.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: companion/go.mod
+          cache-dependency-path: companion/go.sum
+
+      - name: Test hosted gate contracts
+        run: ./scripts/test-vibetv-hosted-gates.sh
+
+      - name: Test Virtual VibeTV behavior
+        working-directory: companion
+        run: go test ./internal/virtualvibetv ./cmd/codexbar-display
+
+  report-status:
+    if: always() && needs.resolve-pr.result == 'success'
+    needs: [resolve-pr, verify-scope, test-repair]
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Publish stable gate-repair commit status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ needs.resolve-pr.outputs.head_sha }}
+          SCOPE_RESULT: ${{ needs.verify-scope.result }}
+          TEST_RESULT: ${{ needs.test-repair.result }}
+        run: |
+          set -euo pipefail
+          state=success
+          description='Secrets-free VibeTV gate repair check passed'
+          if [[ "$SCOPE_RESULT" != success || "$TEST_RESULT" != success ]]; then
+            state=failure
+            description='Secrets-free VibeTV gate repair check failed'
+          fi
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+            -f state="$state" -f context='CODEX VibeTV Gate Repair' -f description="$description" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/scripts/check-vibetv-gate-repair-scope.sh
+++ b/scripts/check-vibetv-gate-repair-scope.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ $# -eq 2 ]] || die "usage: $0 <base-sha> <head-sha>"
+BASE_SHA="$1"
+HEAD_SHA="$2"
+
+for sha in "$BASE_SHA" "$HEAD_SHA"; do
+  [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || die "invalid commit SHA: $sha"
+  git cat-file -e "${sha}^{commit}" 2>/dev/null || die "commit is unavailable: $sha"
+done
+
+changed_paths="$(git diff --name-only --diff-filter=ACDMRTUXB "$BASE_SHA" "$HEAD_SHA")"
+[[ -n "$changed_paths" ]] || die "gate repair has no changed files"
+
+blocked_paths=""
+while IFS= read -r path; do
+  case "$path" in
+    .github/workflows/ci.yml | \
+    .github/workflows/vibetv-gate-repair.yml | \
+    .github/workflows/vibetv-merge-gate.yml | \
+    .github/workflows/vibetv-release-candidate.yml | \
+    scripts/check-vibetv-gate-repair-scope.sh | \
+    scripts/test-vibetv-hosted-gates.sh | \
+    scripts/test-vibetv-hosted-guest.sh | \
+    scripts/extract-vibetv-candidate-app.sh | \
+    scripts/build-sparkle-cli.sh | \
+    companion/internal/virtualvibetv/* | \
+    companion/cmd/virtual-vibetv/* | \
+    companion/cmd/codexbar-display/virtual_vibetv_test.go)
+      ;;
+    *)
+      blocked_paths+="${path}"$'\n'
+      ;;
+  esac
+done <<< "$changed_paths"
+
+[[ -z "$blocked_paths" ]] || die "gate repair changes product or release code outside the safe scope:
+${blocked_paths%$'\n'}"
+
+printf 'Gate repair scope is safe:\n%s\n' "$changed_paths"

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -5,6 +5,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CI_WORKFLOW="${ROOT}/.github/workflows/ci.yml"
 MERGE_WORKFLOW="${ROOT}/.github/workflows/vibetv-merge-gate.yml"
 RC_WORKFLOW="${ROOT}/.github/workflows/vibetv-release-candidate.yml"
+GATE_REPAIR_WORKFLOW="${ROOT}/.github/workflows/vibetv-gate-repair.yml"
+GATE_REPAIR_SCOPE="${ROOT}/scripts/check-vibetv-gate-repair-scope.sh"
 EXTRACTOR="${ROOT}/scripts/extract-vibetv-candidate-app.sh"
 GUEST_TEST="${ROOT}/scripts/test-vibetv-hosted-guest.sh"
 SPARKLE_BUILDER="${ROOT}/scripts/build-sparkle-cli.sh"
@@ -70,10 +72,45 @@ PY
   fi
 }
 
+assert_gate_repair_scope() {
+  local work base_sha allowed_sha blocked_sha scope_error
+  work="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-gate-repair-scope.XXXXXX")"
+  trap 'rm -rf "${work:-}"' RETURN
+
+  git -C "$work" init -q
+  git -C "$work" config user.name "CODEX Gate Test"
+  git -C "$work" config user.email "gate-test@vibetv.invalid"
+  printf 'baseline\n' > "$work/README.md"
+  git -C "$work" add README.md
+  git -C "$work" commit -qm baseline
+  base_sha="$(git -C "$work" rev-parse HEAD)"
+
+  mkdir -p "$work/scripts"
+  printf '# allowed gate test\n' > "$work/scripts/test-vibetv-hosted-gates.sh"
+  git -C "$work" add scripts/test-vibetv-hosted-gates.sh
+  git -C "$work" commit -qm allowed
+  allowed_sha="$(git -C "$work" rev-parse HEAD)"
+  (cd "$work" && "$GATE_REPAIR_SCOPE" "$base_sha" "$allowed_sha" >/dev/null) \
+    || die "safe gate repair scope was rejected"
+
+  mkdir -p "$work/firmware_esp8266/src"
+  printf '// blocked product change\n' > "$work/firmware_esp8266/src/main.cpp"
+  git -C "$work" add firmware_esp8266/src/main.cpp
+  git -C "$work" commit -qm blocked
+  blocked_sha="$(git -C "$work" rev-parse HEAD)"
+  if scope_error="$(cd "$work" && "$GATE_REPAIR_SCOPE" "$base_sha" "$blocked_sha" 2>&1)"; then
+    die "product code was accepted as a gate-only repair"
+  fi
+  [[ "$scope_error" == *"outside the safe scope"* ]] \
+    || die "unsafe gate repair scope failed for the wrong reason: $scope_error"
+}
+
 main() {
   assert_file "$CI_WORKFLOW"
   assert_file "$MERGE_WORKFLOW"
   assert_file "$RC_WORKFLOW"
+  assert_file "$GATE_REPAIR_WORKFLOW"
+  assert_file "$GATE_REPAIR_SCOPE"
   assert_file "$EXTRACTOR"
   assert_file "$GUEST_TEST"
   assert_file "$SPARKLE_BUILDER"
@@ -115,6 +152,20 @@ main() {
     'merge gate must not depend on a self-hosted runner'
   assert_not_contains "$MERGE_WORKFLOW" 'tart' \
     'merge gate must not use Tart'
+
+  assert_contains "$CI_WORKFLOW" './scripts/test-vibetv-hosted-gates.sh' \
+    'normal PR CI must test changes to the hosted VibeTV gate itself'
+
+  assert_contains "$GATE_REPAIR_WORKFLOW" 'name: CODEX Test VibeTV Gate Repair' \
+    'gate repair workflow needs the stable CODEX name'
+  assert_contains "$GATE_REPAIR_WORKFLOW" 'ref: ${{ github.workflow_sha }}' \
+    'gate repair scope validation must use trusted main code'
+  assert_contains "$GATE_REPAIR_WORKFLOW" 'persist-credentials: false' \
+    'untrusted gate repair checkouts must not persist GitHub credentials'
+  assert_contains "$GATE_REPAIR_WORKFLOW" 'CODEX VibeTV Gate Repair' \
+    'gate repair workflow must publish its stable commit status context'
+  assert_not_contains "$GATE_REPAIR_WORKFLOW" 'secrets.' \
+    'gate repair workflow must remain completely secrets-free'
 
   local untrusted_build
   untrusted_build="$(job_block "$MERGE_WORKFLOW" 'build-untrusted')"
@@ -197,6 +248,7 @@ main() {
   assert_contains "$GUEST_TEST" 'daemon --transport wifi' \
     'guest test must exercise the bundled candidate companion render path'
 
+  assert_gate_repair_scope
   assert_safe_app_extractor
   printf 'PASS: hosted VibeTV merge and release-candidate gate contracts\n'
 }


### PR DESCRIPTION
## What this changes

- adds a secrets-free GitHub check for repairs to the virtual VibeTV test road
- accepts only an explicit allowlist of test-infrastructure files
- rejects app, firmware, signing, and unrelated release changes
- runs the gate contract test in normal PR CI
- publishes the exact-SHA status `CODEX VibeTV Gate Repair`

## Why

The full VibeTV merge gate executes trusted scripts from `main`. A PR that repairs those scripts can therefore be blocked by the old broken version. This creates a narrow bootstrap path without Apple signing secrets, releases, or physical device access.

## Verification

- `./scripts/test-vibetv-hosted-gates.sh`
- `go test ./internal/virtualvibetv ./cmd/codexbar-display`
- `actionlint` for both changed workflows

Nothing is merged or released by this PR.