### PR TITLE
Allow safe framework symlinks in VibeTV candidate extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Test macOS Control Center DMG prep
         run: ./scripts/test-macos-control-center-app-bundle.sh
 
+      - name: Test hosted VibeTV gate contracts on macOS
+        run: ./scripts/test-vibetv-hosted-gates.sh
+
   theme-studio-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Test agent git guardrails
         run: ./scripts/test-agent-git-guardrails.sh
 
+      - name: Test hosted VibeTV gate contracts
+        run: ./scripts/test-vibetv-hosted-gates.sh
+
       - name: Check ESP8266 soak gate
         run: ./scripts/check-esp8266-soak-gate.sh
 

--- a/scripts/extract-vibetv-candidate-app.sh
+++ b/scripts/extract-vibetv-candidate-app.sh
@@ -36,6 +36,7 @@ with tarfile.open(archive, "r:gz") as candidate:
     members = candidate.getmembers()
     if not members:
         raise SystemExit("candidate app archive is empty")
+    symlink_paths = set()
     for member in members:
         path = pathlib.PurePosixPath(member.name)
         if path.is_absolute() or ".." in path.parts:
@@ -47,8 +48,13 @@ with tarfile.open(archive, "r:gz") as candidate:
             resolved = pathlib.PurePosixPath(posixpath.normpath(str(path.parent / link)))
             if not member.linkname or link.is_absolute() or not resolved.parts or resolved.parts[0] != expected_root:
                 raise SystemExit(f"unsafe candidate archive symlink: {member.name} -> {member.linkname}")
+            symlink_paths.add(path)
         elif not (member.isdir() or member.isfile()):
             raise SystemExit(f"candidate archive contains a non-regular entry: {member.name}")
+    for member in members:
+        path = pathlib.PurePosixPath(member.name)
+        if any(parent in symlink_paths for parent in path.parents):
+            raise SystemExit(f"candidate archive member descends through symlink: {member.name}")
     output.mkdir(parents=True)
     candidate.extractall(output)
 

--- a/scripts/extract-vibetv-candidate-app.sh
+++ b/scripts/extract-vibetv-candidate-app.sh
@@ -22,6 +22,7 @@ done
 [[ ! -e "$OUTPUT" ]] || die "output path must not exist: $OUTPUT"
 
 python3 - "$ARCHIVE" "$OUTPUT" <<'PY'
+import os
 import pathlib
 import posixpath
 import shutil
@@ -32,35 +33,82 @@ archive = pathlib.Path(sys.argv[1])
 output = pathlib.Path(sys.argv[2])
 expected_root = "VibeTV Control Center.app"
 
+def path_key(path):
+    return tuple(part.casefold() for part in path.parts)
+
 with tarfile.open(archive, "r:gz") as candidate:
     members = candidate.getmembers()
     if not members:
         raise SystemExit("candidate app archive is empty")
-    member_paths = set()
-    symlink_paths = set()
+    member_keys = set()
+    symlink_keys = set()
     for member in members:
         path = pathlib.PurePosixPath(member.name)
         if path.is_absolute() or ".." in path.parts:
             raise SystemExit(f"unsafe candidate archive path: {member.name}")
         if not path.parts or path.parts[0] != expected_root:
             raise SystemExit(f"unexpected candidate archive root: {member.name}")
-        if path in member_paths:
+        key = path_key(path)
+        if key in member_keys:
             raise SystemExit(f"duplicate candidate archive path: {member.name}")
-        member_paths.add(path)
+        member_keys.add(key)
         if member.issym():
             link = pathlib.PurePosixPath(member.linkname)
             resolved = pathlib.PurePosixPath(posixpath.normpath(str(path.parent / link)))
             if not member.linkname or link.is_absolute() or not resolved.parts or resolved.parts[0] != expected_root:
                 raise SystemExit(f"unsafe candidate archive symlink: {member.name} -> {member.linkname}")
-            symlink_paths.add(path)
+            symlink_keys.add(key)
         elif not (member.isdir() or member.isfile()):
             raise SystemExit(f"candidate archive contains a non-regular entry: {member.name}")
     for member in members:
         path = pathlib.PurePosixPath(member.name)
-        if any(parent in symlink_paths for parent in path.parents):
+        if any(path_key(parent) in symlink_keys for parent in path.parents):
             raise SystemExit(f"candidate archive member descends through symlink: {member.name}")
+
     output.mkdir(parents=True)
-    candidate.extractall(output)
+    try:
+        for member in members:
+            path = pathlib.PurePosixPath(member.name)
+            destination = output.joinpath(*path.parts)
+            if member.isdir():
+                destination.mkdir(parents=True, exist_ok=True)
+            elif member.isfile():
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                source = candidate.extractfile(member)
+                if source is None:
+                    raise SystemExit(f"candidate archive file cannot be read: {member.name}")
+                with source, destination.open("xb") as target:
+                    shutil.copyfileobj(source, target)
+                os.chmod(destination, member.mode & 0o777)
+
+        for member in members:
+            if not member.issym():
+                continue
+            path = pathlib.PurePosixPath(member.name)
+            destination = output.joinpath(*path.parts)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            os.symlink(member.linkname, destination)
+
+        app_root = (output / expected_root).resolve()
+        for member in members:
+            if not member.issym():
+                continue
+            path = pathlib.PurePosixPath(member.name)
+            destination = output.joinpath(*path.parts)
+            try:
+                resolved = destination.resolve(strict=True)
+            except (OSError, RuntimeError):
+                raise SystemExit(f"unsafe candidate archive symlink cannot resolve: {member.name}")
+            if pathlib.Path(os.path.commonpath((app_root, resolved))) != app_root:
+                raise SystemExit(f"candidate archive symlink resolves outside app: {member.name}")
+
+        for member in reversed(members):
+            if member.isdir():
+                path = pathlib.PurePosixPath(member.name)
+                os.chmod(output.joinpath(*path.parts), member.mode & 0o777)
+    except BaseException:
+        shutil.rmtree(output, ignore_errors=True)
+        raise
 
 app = output / expected_root
 if not (app / "Contents" / "Info.plist").is_file():

--- a/scripts/extract-vibetv-candidate-app.sh
+++ b/scripts/extract-vibetv-candidate-app.sh
@@ -23,6 +23,7 @@ done
 
 python3 - "$ARCHIVE" "$OUTPUT" <<'PY'
 import pathlib
+import posixpath
 import shutil
 import sys
 import tarfile
@@ -41,7 +42,12 @@ with tarfile.open(archive, "r:gz") as candidate:
             raise SystemExit(f"unsafe candidate archive path: {member.name}")
         if not path.parts or path.parts[0] != expected_root:
             raise SystemExit(f"unexpected candidate archive root: {member.name}")
-        if not (member.isdir() or member.isfile()):
+        if member.issym():
+            link = pathlib.PurePosixPath(member.linkname)
+            resolved = pathlib.PurePosixPath(posixpath.normpath(str(path.parent / link)))
+            if not member.linkname or link.is_absolute() or not resolved.parts or resolved.parts[0] != expected_root:
+                raise SystemExit(f"unsafe candidate archive symlink: {member.name} -> {member.linkname}")
+        elif not (member.isdir() or member.isfile()):
             raise SystemExit(f"candidate archive contains a non-regular entry: {member.name}")
     output.mkdir(parents=True)
     candidate.extractall(output)

--- a/scripts/extract-vibetv-candidate-app.sh
+++ b/scripts/extract-vibetv-candidate-app.sh
@@ -36,6 +36,7 @@ with tarfile.open(archive, "r:gz") as candidate:
     members = candidate.getmembers()
     if not members:
         raise SystemExit("candidate app archive is empty")
+    member_paths = set()
     symlink_paths = set()
     for member in members:
         path = pathlib.PurePosixPath(member.name)
@@ -43,6 +44,9 @@ with tarfile.open(archive, "r:gz") as candidate:
             raise SystemExit(f"unsafe candidate archive path: {member.name}")
         if not path.parts or path.parts[0] != expected_root:
             raise SystemExit(f"unexpected candidate archive root: {member.name}")
+        if path in member_paths:
+            raise SystemExit(f"duplicate candidate archive path: {member.name}")
+        member_paths.add(path)
         if member.issym():
             link = pathlib.PurePosixPath(member.linkname)
             resolved = pathlib.PurePosixPath(posixpath.normpath(str(path.parent / link)))

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -150,6 +150,59 @@ PY
   fi
   [[ "$duplicate_path_error" == *"duplicate candidate archive path"* ]] \
     || die "duplicate path test failed for the wrong reason: $duplicate_path_error"
+
+  python3 - "$work/casefold-parent.tar.gz" <<'PY'
+import io
+import sys
+import tarfile
+
+root = "VibeTV Control Center.app"
+with tarfile.open(sys.argv[1], "w:gz") as archive:
+    plist = tarfile.TarInfo(f"{root}/Contents/Info.plist")
+    plist_payload = b'<plist version="1.0"><dict/></plist>\n'
+    plist.size = len(plist_payload)
+    archive.addfile(plist, io.BytesIO(plist_payload))
+    link = tarfile.TarInfo(f"{root}/A")
+    link.type = tarfile.SYMTYPE
+    link.linkname = "."
+    archive.addfile(link)
+    nested = tarfile.TarInfo(f"{root}/a/payload")
+    payload = b"case-insensitive parent"
+    nested.size = len(payload)
+    archive.addfile(nested, io.BytesIO(payload))
+PY
+  local casefold_parent_error
+  if casefold_parent_error="$("$EXTRACTOR" --archive "$work/casefold-parent.tar.gz" --output "$work/casefold-output" 2>&1)"; then
+    die "archive with a case-variant symlink parent was accepted"
+  fi
+  [[ "$casefold_parent_error" == *"candidate archive member descends through symlink"* ]] \
+    || die "casefold symlink ancestor test failed for the wrong reason: $casefold_parent_error"
+
+  python3 - "$work/symlink-cycle.tar.gz" <<'PY'
+import io
+import sys
+import tarfile
+
+root = "VibeTV Control Center.app"
+with tarfile.open(sys.argv[1], "w:gz") as archive:
+    plist = tarfile.TarInfo(f"{root}/Contents/Info.plist")
+    plist_payload = b'<plist version="1.0"><dict/></plist>\n'
+    plist.size = len(plist_payload)
+    archive.addfile(plist, io.BytesIO(plist_payload))
+    for name, target in [(f"{root}/a", "b"), (f"{root}/b", "a")]:
+        link = tarfile.TarInfo(name)
+        link.type = tarfile.SYMTYPE
+        link.linkname = target
+        archive.addfile(link)
+PY
+  local symlink_cycle_error
+  if symlink_cycle_error="$("$EXTRACTOR" --archive "$work/symlink-cycle.tar.gz" --output "$work/symlink-cycle-output" 2>&1)"; then
+    die "archive with a symlink cycle was accepted"
+  fi
+  [[ "$symlink_cycle_error" == *"unsafe candidate archive symlink cannot resolve"* ]] \
+    || die "symlink cycle test failed for the wrong reason: $symlink_cycle_error"
+  [[ ! -e "$work/symlink-cycle-output" ]] \
+    || die "symlink cycle left a partially extracted candidate app behind"
 }
 
 main() {

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -89,6 +89,40 @@ PY
   fi
   [[ "$unsafe_link_error" == *"unsafe candidate archive symlink"* ]] \
     || die "escaping symlink test failed for the wrong reason: $unsafe_link_error"
+
+  python3 - "$work/chained-link.tar.gz" <<'PY'
+import io
+import sys
+import tarfile
+
+root = "VibeTV Control Center.app"
+with tarfile.open(sys.argv[1], "w:gz") as archive:
+    plist = tarfile.TarInfo(f"{root}/Contents/Info.plist")
+    plist_payload = b'<plist version="1.0"><dict/></plist>\n'
+    plist.size = len(plist_payload)
+    archive.addfile(plist, io.BytesIO(plist_payload))
+    for name, target in [
+        (f"{root}/a", "."),
+        (f"{root}/a/b", ".."),
+        (f"{root}/a/b/c", ".."),
+    ]:
+        link = tarfile.TarInfo(name)
+        link.type = tarfile.SYMTYPE
+        link.linkname = target
+        archive.addfile(link)
+    escaped = tarfile.TarInfo(f"{root}/a/b/c/escaped")
+    payload = b"outside output"
+    escaped.size = len(payload)
+    archive.addfile(escaped, io.BytesIO(payload))
+PY
+  local chained_link_error
+  if chained_link_error="$("$EXTRACTOR" --archive "$work/chained-link.tar.gz" --output "$work/chained-output" 2>&1)"; then
+    die "archive with a symlinked parent was accepted"
+  fi
+  [[ "$chained_link_error" == *"candidate archive member descends through symlink"* ]] \
+    || die "symlink ancestor test failed for the wrong reason: $chained_link_error"
+  [[ ! -e "$work/escaped" ]] \
+    || die "archive symlink chain wrote outside the output directory"
 }
 
 main() {

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -123,6 +123,33 @@ PY
     || die "symlink ancestor test failed for the wrong reason: $chained_link_error"
   [[ ! -e "$work/escaped" ]] \
     || die "archive symlink chain wrote outside the output directory"
+
+  python3 - "$work/duplicate-path.tar.gz" <<'PY'
+import io
+import sys
+import tarfile
+
+root = "VibeTV Control Center.app"
+with tarfile.open(sys.argv[1], "w:gz") as archive:
+    plist = tarfile.TarInfo(f"{root}/Contents/Info.plist")
+    plist_payload = b'<plist version="1.0"><dict/></plist>\n'
+    plist.size = len(plist_payload)
+    archive.addfile(plist, io.BytesIO(plist_payload))
+    link = tarfile.TarInfo(f"{root}/duplicate")
+    link.type = tarfile.SYMTYPE
+    link.linkname = "Contents/Info.plist"
+    archive.addfile(link)
+    duplicate = tarfile.TarInfo(f"{root}/duplicate")
+    payload = b"duplicate path"
+    duplicate.size = len(payload)
+    archive.addfile(duplicate, io.BytesIO(payload))
+PY
+  local duplicate_path_error
+  if duplicate_path_error="$("$EXTRACTOR" --archive "$work/duplicate-path.tar.gz" --output "$work/duplicate-output" 2>&1)"; then
+    die "archive with a duplicate symlink path was accepted"
+  fi
+  [[ "$duplicate_path_error" == *"duplicate candidate archive path"* ]] \
+    || die "duplicate path test failed for the wrong reason: $duplicate_path_error"
 }
 
 main() {

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -105,6 +105,8 @@ main() {
     'stable aggregation status must be named CODEX CI'
   assert_contains "$CI_WORKFLOW" 'if: always()' \
     'CODEX CI must report failure even when an upstream job fails'
+  assert_contains "$CI_WORKFLOW" './scripts/test-vibetv-hosted-gates.sh' \
+    'normal PR CI must run the hosted VibeTV gate contracts'
 
   assert_contains "$MERGE_WORKFLOW" 'name: CODEX Test VibeTV Merge' \
     'merge gate workflow needs the stable CODEX name'

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -47,12 +47,16 @@ assert_safe_app_extractor() {
   work="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-hosted-gate.XXXXXX")"
   trap 'rm -rf "${work:-}"' RETURN
 
-  mkdir -p "$work/safe/VibeTV Control Center.app/Contents"
+  mkdir -p "$work/safe/VibeTV Control Center.app/Contents/Frameworks/Test.framework/Versions/B/Resources"
   printf '<plist version="1.0"><dict/></plist>\n' > "$work/safe/VibeTV Control Center.app/Contents/Info.plist"
+  ln -s B "$work/safe/VibeTV Control Center.app/Contents/Frameworks/Test.framework/Versions/Current"
+  ln -s Versions/Current/Resources "$work/safe/VibeTV Control Center.app/Contents/Frameworks/Test.framework/Resources"
   COPYFILE_DISABLE=1 tar -czf "$work/safe.tar.gz" -C "$work/safe" "VibeTV Control Center.app"
   "$EXTRACTOR" --archive "$work/safe.tar.gz" --output "$work/extracted" >/dev/null
   [[ -f "$work/extracted/VibeTV Control Center.app/Contents/Info.plist" ]] \
     || die "safe candidate archive was not extracted"
+  [[ -d "$work/extracted/VibeTV Control Center.app/Contents/Frameworks/Test.framework/Resources" ]] \
+    || die "safe framework symlinks were not preserved"
 
   python3 - "$work/unsafe.tar.gz" <<'PY'
 import io
@@ -68,6 +72,23 @@ PY
   if "$EXTRACTOR" --archive "$work/unsafe.tar.gz" --output "$work/unsafe" >/dev/null 2>&1; then
     die "unsafe candidate archive path was accepted"
   fi
+
+  python3 - "$work/unsafe-link.tar.gz" <<'PY'
+import sys
+import tarfile
+
+with tarfile.open(sys.argv[1], "w:gz") as archive:
+    member = tarfile.TarInfo("VibeTV Control Center.app/Contents/Frameworks/escape")
+    member.type = tarfile.SYMTYPE
+    member.linkname = "../../../../escape"
+    archive.addfile(member)
+PY
+  local unsafe_link_error
+  if unsafe_link_error="$("$EXTRACTOR" --archive "$work/unsafe-link.tar.gz" --output "$work/unsafe-link" 2>&1)"; then
+    die "escaping candidate archive symlink was accepted"
+  fi
+  [[ "$unsafe_link_error" == *"unsafe candidate archive symlink"* ]] \
+    || die "escaping symlink test failed for the wrong reason: $unsafe_link_error"
 }
 
 main() {


### PR DESCRIPTION
## What this changes

- permits normal macOS framework symlinks inside the extracted app bundle
- still rejects absolute or escaping symlink targets
- adds a regression test for both the valid and unsafe cases

This is the minimal bootstrap repair split out of PR #315. It changes no app code, firmware, signing workflow, or release workflow.

## Verification

- `./scripts/test-vibetv-hosted-gates.sh`
- shell syntax checks

This PR must not be merged without explicit approval for its exact SHA.