### PR TITLE
Fix macOS VibeTV candidate build dependency

### DIFF
--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -48,7 +48,7 @@ jobs:
           version="${VERSION#v}"
           [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || { echo 'version must be SemVer' >&2; exit 1; }
           test -d companion/cmd/virtual-vibetv || { echo 'error: Issue #177 Core is required: companion/cmd/virtual-vibetv is missing.' >&2; exit 1; }
-          pip install platformio
+          pip install platformio intelhex
           mkdir -p dist/macos tmp/vibetv-rc/publish/companion tmp/vibetv-rc/publish/firmware tmp/vibetv-rc/test
           (
             cd apps/control-center

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -266,6 +266,8 @@ main() {
     'release-candidate workflow must require a candidate version'
   assert_contains "$RC_WORKFLOW" 'ref: ${{ github.sha }}' \
     'release candidate must build the exact main SHA that dispatched it'
+  assert_contains "$RC_WORKFLOW" 'pip install platformio intelhex' \
+    'release candidate must install the ESP32 bootloader dependency on macOS'
   assert_contains "$RC_WORKFLOW" 'candidate-manifest.json' \
     'release candidate must emit an immutable candidate manifest'
   assert_contains "$RC_WORKFLOW" 'name: vibetv-release-candidate' \


### PR DESCRIPTION
## What changed
Install `intelhex` with PlatformIO in the macOS release-candidate build.

## Why
Test run [30542880744](https://github.com/DreamyTalesPAN/CodexBar-Display/actions/runs/30542880744) failed while building the ESP32 bootloader with `ModuleNotFoundError: intelhex`; the actual release workflow already installs this dependency.

## Validation
- Regression assertion failed before the workflow change and passes after it
- `bash -n scripts/test-vibetv-hosted-gates.sh`
- `./scripts/test-vibetv-hosted-gates.sh`
- `./scripts/test-agent-git-guardrails.sh`
- `git diff --check`

This draft PR does not merge, tag, publish, release, or write hardware.