### PR TITLE
Fix VibeTV candidate checksum manifest

### DIFF
--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -158,7 +158,7 @@ jobs:
           mkdir -p tmp/vibetv-rc/publish/macos
           cp dist/macos/VibeTV-Control-Center.dmg tmp/vibetv-rc/publish/macos/VibeTV-Control-Center.dmg
           printf '%s' "$SPARKLE_ED25519_PRIVATE_KEY" | "$sparkle_dir/bin/generate_appcast" --ed-key-file - --maximum-deltas 0 --link https://app.vibetv.shop --download-url-prefix "https://github.com/${REPOSITORY}/releases/download/v${version}/" -o tmp/vibetv-rc/publish/macos/appcast.xml tmp/vibetv-rc/publish/macos
-          (cd tmp/vibetv-rc/publish && find . -type f -print0 | sort -z | xargs -0 shasum -a 256 > "checksums-v${version}.txt")
+          (cd tmp/vibetv-rc/publish && find . -type f ! -name "checksums-*" -print0 | sort -z | xargs -0 shasum -a 256 > "checksums-v${version}.txt")
           (cd tmp/vibetv-rc/publish && shasum -a 256 -c "checksums-v${version}.txt")
           python3 - "$source_sha" "$version" "$REPOSITORY" "$CANDIDATE_RUN_ID" tmp/vibetv-rc/candidate-manifest.json tmp/vibetv-rc <<'PY'
           import datetime, hashlib, json, sys

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -321,6 +321,8 @@ main() {
     'release candidate must enforce the release firmware size budgets'
   assert_contains "$RC_WORKFLOW" 'shasum -a 256 -c "checksums-v${version}.txt"' \
     'release candidate must verify its publish checksum asset before upload'
+  assert_contains "$RC_WORKFLOW" 'find . -type f ! -name "checksums-*"' \
+    'release candidate must exclude its checksum asset from its own checksum list'
   assert_contains "$RC_WORKFLOW" "kind + 'Sha256'" \
     'release candidate must freeze public baseline DMG hashes'
   assert_contains "$RC_WORKFLOW" 'baselines/${{ matrix.state }}.dmg' \


### PR DESCRIPTION
## What changed
Exclude `checksums-*` from the candidate checksum input list.

## Root cause
The failed virtual candidate run [30548056353](https://github.com/DreamyTalesPAN/CodexBar-Display/actions/runs/30548056353) added `checksums-v1.0.53-test.2.txt` to its own checksum list before the file was complete. Its stored hash therefore could not match the finished file.

## Validation
- Reproduced: old pattern exits 1; excluded pattern exits 0
- Regression assertion failed before the workflow change and passes after it
- `bash -n scripts/test-vibetv-hosted-gates.sh`
- `./scripts/test-vibetv-hosted-gates.sh`
- `./scripts/test-agent-git-guardrails.sh`
- `git diff --check`

This draft PR does not merge, tag, publish, release, or write hardware.