### PR TITLE
Fix VibeTV guest matrix setup

### DIFF
--- a/.github/workflows/vibetv-merge-gate.yml
+++ b/.github/workflows/vibetv-merge-gate.yml
@@ -289,16 +289,16 @@ jobs:
       - name: Run direct hosted macOS guest checks
         run: |
           set -euo pipefail
-          version="$(python3 -c 'import json; print(json.load(open("candidate/candidate-manifest.json"))["version"])')"
+          version="$(python3 -c 'import json; print(json.load(open("candidate/dist/macos/candidate-manifest.json"))["version"])')"
           baseline_args=()
           if [[ '${{ matrix.state }}' != clean_os ]]; then
             baseline_args=(--baseline-dmg baseline.dmg --baseline-appcast baseline-appcast.xml)
           fi
           ./scripts/test-vibetv-hosted-guest.sh \
-            --dmg candidate/VibeTV-Control-Center.dmg --appcast candidate/appcast.xml \
-            --virtual-vibetv candidate/virtual-vibetv --companion candidate/codexbar-display \
-            --firmware candidate/firmware.bin --firmware-manifest candidate/firmware-manifest.json \
-            --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
+            --dmg candidate/dist/macos/VibeTV-Control-Center.dmg --appcast candidate/dist/macos/appcast.xml \
+            --virtual-vibetv candidate/tmp/vibetv-merge/virtual-vibetv --companion candidate/tmp/vibetv-merge/codexbar-display \
+            --firmware candidate/tmp/vibetv-merge/firmware.bin --firmware-manifest candidate/tmp/vibetv-merge/firmware-manifest.json \
+            --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]+"${baseline_args[@]}"}"
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -257,9 +257,9 @@ jobs:
           print("DMG_URL=" + shlex.quote(baseline["dmgUrl"]))
           print("APPCAST_URL=" + shlex.quote(baseline["appcastUrl"]))
           PY
-          cp "baselines/${{ matrix.state }}.dmg" baseline.dmg
-          cp "baselines/${{ matrix.state }}.appcast.xml" baseline-appcast.xml
-          cp "baselines/${{ matrix.state }}.firmware-manifest.json" baseline-firmware-manifest.json
+          cp "baselines/baselines/${{ matrix.state }}.dmg" baseline.dmg
+          cp "baselines/baselines/${{ matrix.state }}.appcast.xml" baseline-appcast.xml
+          cp "baselines/baselines/${{ matrix.state }}.firmware-manifest.json" baseline-firmware-manifest.json
           shasum -a 256 baseline.dmg baseline-appcast.xml
       - name: Run full direct hosted macOS guest matrix
         run: |
@@ -271,7 +271,7 @@ jobs:
             baseline_args=(--baseline-dmg baseline.dmg --baseline-appcast baseline-appcast.xml)
             current_firmware="$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("baseline-firmware-manifest.json"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789"))')"
           fi
-          ./scripts/test-vibetv-hosted-guest.sh --dmg candidate/publish/macos/VibeTV-Control-Center.dmg --appcast candidate/publish/macos/appcast.xml --virtual-vibetv candidate/test/virtual-vibetv --companion candidate/test/codexbar-display --firmware candidate/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("release/firmware-versions.json"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789")').bin.gz --firmware-manifest candidate/publish/firmware/firmware-manifest.json --current-firmware "$current_firmware" --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]}"
+          ./scripts/test-vibetv-hosted-guest.sh --dmg candidate/publish/macos/VibeTV-Control-Center.dmg --appcast candidate/publish/macos/appcast.xml --virtual-vibetv candidate/test/virtual-vibetv --companion candidate/test/codexbar-display --firmware candidate/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("release/firmware-versions.json"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789"))').bin.gz --firmware-manifest candidate/publish/firmware/firmware-manifest.json --current-firmware "$current_firmware" --version "$version" --state '${{ matrix.state }}' --output 'results/${{ matrix.state }}' "${baseline_args[@]+"${baseline_args[@]}"}"
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -325,8 +325,15 @@ main() {
     'release candidate must exclude its checksum asset from its own checksum list'
   assert_contains "$RC_WORKFLOW" "kind + 'Sha256'" \
     'release candidate must freeze public baseline DMG hashes'
-  assert_contains "$RC_WORKFLOW" 'baselines/${{ matrix.state }}.dmg' \
-    'guest matrix must consume the frozen baseline bytes'
+  local frozen_baseline
+  for frozen_baseline in dmg appcast.xml firmware-manifest.json; do
+    assert_contains "$RC_WORKFLOW" 'baselines/baselines/${{ matrix.state }}.'"${frozen_baseline}" \
+      "guest matrix must consume the downloaded frozen ${frozen_baseline} bytes"
+  done
+  assert_contains "$RC_WORKFLOW" "esp8266_smalltv_st7789\"))').bin.gz" \
+    'release candidate must close the firmware-version Python expression'
+  assert_contains "$RC_WORKFLOW" '"${baseline_args[@]+"${baseline_args[@]}"}"' \
+    'clean OS guest test must expand optional baseline arguments safely under set -u'
   assert_contains "$RC_WORKFLOW" '"protocolVersion":config.get' \
     'release candidate must preserve release firmware protocol metadata'
   assert_contains "$SPARKLE_BUILDER" '6276ba2b404829d139c45ff98427cf90e2efc59b' \

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -248,6 +248,19 @@ main() {
     'merge gate must cover the current public customer state'
   assert_contains "$MERGE_WORKFLOW" 'previous_public' \
     'merge gate must cover the previous public customer state'
+  for merge_candidate_path in \
+    dist/macos/candidate-manifest.json \
+    dist/macos/VibeTV-Control-Center.dmg \
+    dist/macos/appcast.xml \
+    tmp/vibetv-merge/virtual-vibetv \
+    tmp/vibetv-merge/codexbar-display \
+    tmp/vibetv-merge/firmware.bin \
+    tmp/vibetv-merge/firmware-manifest.json; do
+    assert_contains "$MERGE_WORKFLOW" "candidate/${merge_candidate_path}" \
+      "merge guest matrix must consume the uploaded ${merge_candidate_path} path"
+  done
+  assert_contains "$MERGE_WORKFLOW" '"${baseline_args[@]+"${baseline_args[@]}"}"' \
+    'clean OS merge guest test must expand optional baseline arguments safely under set -u'
   assert_not_contains "$MERGE_WORKFLOW" 'self-hosted' \
     'merge gate must not depend on a self-hosted runner'
   assert_not_contains "$MERGE_WORKFLOW" 'tart' \


### PR DESCRIPTION
## Summary
- consume frozen release-candidate baselines from their downloaded artifact paths
- close the release-candidate firmware-version expression
- expand optional baseline arguments safely on macOS Bash
- consume merge-candidate files from the directory structure retained by the artifact
- add focused hosted-gate regression assertions

## Root cause
The release-candidate workflow used incorrect frozen-baseline paths and had two clean-OS shell defects. After those were fixed, the virtual merge gate exposed the same class of artifact-layout mismatch in its separate trusted workflow: the uploaded merge candidate retains `dist/macos/` and `tmp/vibetv-merge/`, while the guest jobs expected flat `candidate/` paths.

## Validation
- `./scripts/test-vibetv-hosted-gates.sh`
- `./scripts/test-agent-git-guardrails.sh`
- `./scripts/test-control-center-release-workflow.sh`
- YAML parse, Bash 3.2 argument checks, and `git diff --check`

Failed gate that established the second root cause: https://github.com/DreamyTalesPAN/CodexBar-Display/actions/runs/30625133490