### PR TITLE
Test VibeTV merge pipeline - do not merge

### DIFF
--- a/docs/vibetv-hosted-gates.md
+++ b/docs/vibetv-hosted-gates.md
@@ -5,6 +5,8 @@ It resolves the submitted PR to its immutable head SHA, builds that SHA without
 Apple or Sparkle secrets, then checks out the trusted main workflow revision for
 archive extraction, signing, notarization, and status publication. The final
 commit status is `CODEX VibeTV Merge Gate`.
+For test PRs, a successful virtual gate is integration evidence only and does
+not authorize merging or releasing.
 
 `CODEX Test VibeTV Release Candidate` is also owner-restricted and builds only
 the exact `main` SHA that dispatched it. It creates one signed candidate bundle


### PR DESCRIPTION
## Pure test PR — do not merge

This PR is a harmless end-to-end test of the repaired VibeTV merge pipeline. It must never be merged.

- Docs-only change: `docs/vibetv-hosted-gates.md`.
- No release, tag, candidate workflow, `main` push, or hardware access is in scope.
- The follow-up gate must use the exact head SHA `aaeffb7c7b7e757b2640c74528cae8f7f6c2c31d`.
- After CI and a fresh Codex review, the trusted `main` definition of `CODEX Test VibeTV Merge` will be manually dispatched for this PR.
- Keep this PR open until the final test result is reported and closure is explicitly approved.