### PR TITLE
Restore VibeTV merge candidate executable bits

### DIFF
--- a/.github/workflows/vibetv-merge-gate.yml
+++ b/.github/workflows/vibetv-merge-gate.yml
@@ -289,6 +289,7 @@ jobs:
       - name: Run direct hosted macOS guest checks
         run: |
           set -euo pipefail
+          chmod +x candidate/tmp/vibetv-merge/virtual-vibetv candidate/tmp/vibetv-merge/codexbar-display
           version="$(python3 -c 'import json; print(json.load(open("candidate/dist/macos/candidate-manifest.json"))["version"])')"
           baseline_args=()
           if [[ '${{ matrix.state }}' != clean_os ]]; then

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -261,6 +261,8 @@ main() {
   done
   assert_contains "$MERGE_WORKFLOW" '"${baseline_args[@]+"${baseline_args[@]}"}"' \
     'clean OS merge guest test must expand optional baseline arguments safely under set -u'
+  assert_contains "$MERGE_WORKFLOW" 'chmod +x candidate/tmp/vibetv-merge/virtual-vibetv candidate/tmp/vibetv-merge/codexbar-display' \
+    'merge guest matrix must restore executable bits lost during artifact transfer'
   assert_not_contains "$MERGE_WORKFLOW" 'self-hosted' \
     'merge gate must not depend on a self-hosted runner'
   assert_not_contains "$MERGE_WORKFLOW" 'tart' \


### PR DESCRIPTION
## Summary

- restore executable bits for the downloaded Virtual VibeTV and Companion binaries immediately before the hosted guest checks
- add a hosted-gate contract regression check

## Root cause

GitHub Actions artifact upload/download normalizes regular files to mode `0644`. The merge gate downloaded both candidate executables correctly, but all three guest states stopped before testing because the binaries were no longer executable.

## Validation

- `./scripts/test-vibetv-hosted-gates.sh`
- `./scripts/test-agent-git-guardrails.sh`
- `./scripts/test-control-center-release-workflow.sh`
- Bash syntax, YAML parse, and `git diff --check`

## Gate note

The trusted virtual merge workflow is loaded from `main`. Therefore this workflow-file fix cannot exercise itself through the hosted merge gate before a separately approved bootstrap merge. No merge, release, tag, candidate workflow, or hardware action is authorized by this PR.