### PR TITLE
Fix VibeTV hosted guest provenance checks

### DIFF
--- a/.github/workflows/vibetv-merge-gate.yml
+++ b/.github/workflows/vibetv-merge-gate.yml
@@ -178,6 +178,7 @@ jobs:
           ./scripts/build-macos-control-center-dmg.sh --app 'dist/macos/VibeTV Control Center.app' --output dist/macos/VibeTV-Control-Center.dmg --staging-dir tmp/vibetv-merge/dmg-stage
           ./scripts/sign-notarize-macos-control-center.sh --app 'dist/macos/VibeTV Control Center.app' --dmg dist/macos/VibeTV-Control-Center.dmg --skip-app-sign
           ./scripts/verify-macos-control-center-dmg.sh --dmg dist/macos/VibeTV-Control-Center.dmg
+          cp 'dist/macos/VibeTV Control Center.app/Contents/Helpers/codexbar-display' tmp/vibetv-merge/codexbar-display
 
       - name: Build signed candidate appcast and immutable manifest
         env:

--- a/scripts/build-sparkle-cli.sh
+++ b/scripts/build-sparkle-cli.sh
@@ -13,6 +13,7 @@ work="$(mktemp -d "${TMPDIR:-/tmp}/sparkle-cli.XXXXXX")"; trap 'rm -rf "$work"' 
 git init -q "$work/source"
 git -C "$work/source" remote add origin "$REPOSITORY"
 git -C "$work/source" fetch -q --depth=1 origin "$COMMIT"
+git -C "$work/source" checkout -q --detach FETCH_HEAD
 [[ "$(git -C "$work/source" rev-parse HEAD)" == "$COMMIT" ]] || { echo 'error: Sparkle source commit mismatch' >&2; exit 1; }
 xcodebuild -project "$work/source/Sparkle.xcodeproj" -scheme sparkle-cli -configuration Release -derivedDataPath "$work/derived" CODE_SIGNING_ALLOWED=NO build >/dev/null
 cli="$(find "$work/derived" -type f -path '*/sparkle.app/Contents/MacOS/sparkle' -print -quit)"

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -263,6 +263,8 @@ main() {
     'clean OS merge guest test must expand optional baseline arguments safely under set -u'
   assert_contains "$MERGE_WORKFLOW" 'chmod +x candidate/tmp/vibetv-merge/virtual-vibetv candidate/tmp/vibetv-merge/codexbar-display' \
     'merge guest matrix must restore executable bits lost during artifact transfer'
+  assert_contains "$MERGE_WORKFLOW" "cp 'dist/macos/VibeTV Control Center.app/Contents/Helpers/codexbar-display' tmp/vibetv-merge/codexbar-display" \
+    'merge candidate must compare the installed helper with the same signed companion artifact'
   assert_not_contains "$MERGE_WORKFLOW" 'self-hosted' \
     'merge gate must not depend on a self-hosted runner'
   assert_not_contains "$MERGE_WORKFLOW" 'tart' \
@@ -353,6 +355,8 @@ main() {
     'release candidate must preserve release firmware protocol metadata'
   assert_contains "$SPARKLE_BUILDER" '6276ba2b404829d139c45ff98427cf90e2efc59b' \
     'Sparkle CLI source must be pinned to the reviewed upstream commit'
+  assert_contains "$SPARKLE_BUILDER" 'git -C "$work/source" checkout -q --detach FETCH_HEAD' \
+    'Sparkle CLI build must check out the fetched pinned source commit'
   assert_contains "$GUEST_TEST" 'CANDIDATE_COMPANION' \
     'guest test must select the installed candidate companion for OTA'
   assert_contains "$GUEST_TEST" 'install-update --target' \


### PR DESCRIPTION
## Summary

- compare the installed Companion with the same signed helper artifact copied from the notarized candidate app
- check out the pinned Sparkle source commit after fetching it
- add hosted-gate regression contracts for both failures

## Root causes

Run 30631635395 reached the hosted guest matrix and exposed two deterministic test defects:

1. `clean_os` compared the unsigned build artifact byte-for-byte with the signed helper inside the candidate app. Code signing necessarily changes the binary bytes.
2. `current_public` and `previous_public` fetched the pinned Sparkle commit into a new repository but never checked out `FETCH_HEAD`, so `HEAD` did not exist.

## Validation

- `./scripts/test-vibetv-hosted-gates.sh`
- `./scripts/test-agent-git-guardrails.sh`
- `./scripts/test-control-center-release-workflow.sh`
- Bash syntax, YAML parse, and `git diff --check`

## Gate note

The trusted virtual merge workflow is loaded from `main`, so this workflow-file fix cannot exercise itself end-to-end before a separately approved bootstrap merge. No merge, release, tag, candidate workflow, or hardware action is authorized by this PR.