### PR TITLE
Fix hosted VibeTV firmware and Sparkle inputs

### DIFF
--- a/.github/workflows/vibetv-merge-gate.yml
+++ b/.github/workflows/vibetv-merge-gate.yml
@@ -93,6 +93,7 @@ jobs:
           pip install platformio
           source_sha="$(git rev-parse HEAD)"
           version="9999.0.${GITHUB_RUN_NUMBER}"
+          build="${GITHUB_RUN_ID}"
           mkdir -p dist/macos tmp/vibetv-merge
           (
             cd apps/control-center
@@ -115,7 +116,7 @@ jobs:
           lipo -create -output tmp/vibetv-merge/codexbar-display \
             tmp/vibetv-merge/codexbar-display-amd64 tmp/vibetv-merge/codexbar-display-arm64
           ./scripts/build-macos-control-center-app.sh \
-            --version "$version" --build "$GITHUB_RUN_NUMBER" --universal \
+            --version "$version" --build "$build" --universal \
             --companion-binary tmp/vibetv-merge/codexbar-display \
             --output 'dist/macos/VibeTV Control Center.app'
           COPYFILE_DISABLE=1 tar -czf tmp/vibetv-merge/app.tar.gz -C dist/macos 'VibeTV Control Center.app'

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -334,10 +334,14 @@ main() {
     'guest test must start the public baseline before Sparkle'
   assert_contains "$GUEST_TEST" 'replace and relaunch' \
     'guest test must require a replacement Candidate process after Sparkle'
-  assert_not_contains "$GUEST_TEST" 'gzip -cd' \
-    'merge guest test must not decompress the already raw candidate firmware'
-  assert_contains "$GUEST_TEST" 'shasum -a 256 "$FIRMWARE"' \
-    'guest test must hash the raw candidate firmware bytes sent through OTA'
+  assert_contains "$GUEST_TEST" 'gzip -t "$FIRMWARE"' \
+    'guest test must distinguish compressed release firmware from raw merge firmware'
+  assert_contains "$GUEST_TEST" 'gzip -cd "$FIRMWARE"' \
+    'guest test must derive raw OTA bytes from compressed release firmware'
+  assert_contains "$GUEST_TEST" 'cp "$FIRMWARE" "$RAW_FIRMWARE"' \
+    'guest test must preserve already raw merge firmware bytes'
+  assert_contains "$GUEST_TEST" 'shasum -a 256 "$RAW_FIRMWARE"' \
+    'guest test must hash the raw firmware bytes sent through OTA'
   assert_contains "$RC_WORKFLOW" 'artifactHashes": {item["path"]' \
     'candidate result must expose publish validators a path-to-hash map'
   assert_contains "$RC_WORKFLOW" 'check-firmware-size-budget.sh' \

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -242,6 +242,10 @@ main() {
     'merge gate must run its direct macOS checks on GitHub-hosted macOS 15'
   assert_contains "$MERGE_WORKFLOW" '9999.0.${GITHUB_RUN_NUMBER}' \
     'merge candidate must always sort above public releases for Sparkle'
+  assert_contains "$MERGE_WORKFLOW" 'build="${GITHUB_RUN_ID}"' \
+    'merge candidate build must sort above public release build numbers for Sparkle'
+  assert_contains "$MERGE_WORKFLOW" '--build "$build"' \
+    'merge candidate app must use the unique high Sparkle build number'
   assert_contains "$MERGE_WORKFLOW" 'clean_os' \
     'merge gate must cover a clean macOS customer state'
   assert_contains "$MERGE_WORKFLOW" 'current_public' \
@@ -330,8 +334,10 @@ main() {
     'guest test must start the public baseline before Sparkle'
   assert_contains "$GUEST_TEST" 'replace and relaunch' \
     'guest test must require a replacement Candidate process after Sparkle'
-  assert_contains "$GUEST_TEST" 'gzip -cd' \
-    'guest test must hash the raw firmware bytes sent through OTA'
+  assert_not_contains "$GUEST_TEST" 'gzip -cd' \
+    'merge guest test must not decompress the already raw candidate firmware'
+  assert_contains "$GUEST_TEST" 'shasum -a 256 "$FIRMWARE"' \
+    'guest test must hash the raw candidate firmware bytes sent through OTA'
   assert_contains "$RC_WORKFLOW" 'artifactHashes": {item["path"]' \
     'candidate result must expose publish validators a path-to-hash map'
   assert_contains "$RC_WORKFLOW" 'check-firmware-size-budget.sh' \

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -132,8 +132,7 @@ def key(value): return tuple(int(part) for part in value.split('-')[0].split('.'
 print(1 if key(sys.argv[2]) > key(sys.argv[1]) else 0)
 PY
 )"
-RAW_FIRMWARE="$WORK/firmware.bin"; gzip -cd "$FIRMWARE" > "$RAW_FIRMWARE"
-firmware_sha="$(shasum -a 256 "$RAW_FIRMWARE" | awk '{print $1}')"
+firmware_sha="$(shasum -a 256 "$FIRMWARE" | awk '{print $1}')"
 "$VIRTUAL_VIBETV" --addr 127.0.0.1:47834 --raw-addr 127.0.0.1:8081 --firmware "$CURRENT_FIRMWARE" --candidate-firmware "$candidate_firmware" --expected-firmware-sha256 "$firmware_sha" > "$OUTPUT/virtual-vibetv.log" 2>&1 & VIRTUAL_PID=$!
 for _ in $(seq 1 30); do curl --fail --silent "$SERVER_URL/firmware-manifest.json" >/dev/null && curl --fail --silent http://127.0.0.1:47834/health > "$OUTPUT/virtual-health-before.json" && break; sleep 1; done
 [[ -s "$OUTPUT/virtual-health-before.json" ]] || die 'Virtual VibeTV did not become healthy'

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -132,7 +132,14 @@ def key(value): return tuple(int(part) for part in value.split('-')[0].split('.'
 print(1 if key(sys.argv[2]) > key(sys.argv[1]) else 0)
 PY
 )"
-firmware_sha="$(shasum -a 256 "$FIRMWARE" | awk '{print $1}')"
+RAW_FIRMWARE="$WORK/firmware.bin"
+if [[ "$FIRMWARE" == *.gz ]]; then
+  gzip -t "$FIRMWARE"
+  gzip -cd "$FIRMWARE" > "$RAW_FIRMWARE"
+else
+  cp "$FIRMWARE" "$RAW_FIRMWARE"
+fi
+firmware_sha="$(shasum -a 256 "$RAW_FIRMWARE" | awk '{print $1}')"
 "$VIRTUAL_VIBETV" --addr 127.0.0.1:47834 --raw-addr 127.0.0.1:8081 --firmware "$CURRENT_FIRMWARE" --candidate-firmware "$candidate_firmware" --expected-firmware-sha256 "$firmware_sha" > "$OUTPUT/virtual-vibetv.log" 2>&1 & VIRTUAL_PID=$!
 for _ in $(seq 1 30); do curl --fail --silent "$SERVER_URL/firmware-manifest.json" >/dev/null && curl --fail --silent http://127.0.0.1:47834/health > "$OUTPUT/virtual-health-before.json" && break; sleep 1; done
 [[ -s "$OUTPUT/virtual-health-before.json" ]] || die 'Virtual VibeTV did not become healthy'


### PR DESCRIPTION
## Summary
- hash the raw merge-candidate firmware directly instead of attempting gzip decompression
- use the unique Actions run ID as the virtual candidate build so Sparkle sorts it above public builds
- add hosted-gate contract regressions for both failures

## Verification
- `./scripts/test-vibetv-hosted-gates.sh`
- `bash -n scripts/test-vibetv-hosted-guest.sh scripts/test-vibetv-hosted-gates.sh`
- `git diff --check`

This PR only repairs the virtual test pipeline. It does not merge or release anything and does not access hardware.