### PR TITLE
CODEX Fix hosted VibeTV guest daemon lifecycle

### DIFF
--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -373,6 +373,10 @@ main() {
     'guest test must use the bundled candidate companion for OTA'
   assert_contains "$GUEST_TEST" 'daemon --transport wifi' \
     'guest test must exercise the bundled candidate companion render path'
+  assert_contains "$GUEST_TEST" 'if [[ "$STATE" == clean_os ]]; then' \
+    'guest test must run a standalone candidate daemon only on a clean OS'
+  assert_not_contains "$GUEST_TEST" '--once --api-addr' \
+    'one-shot candidate daemon must not keep a companion API server alive'
 
   assert_safe_app_extractor
   printf 'PASS: hosted VibeTV merge and release-candidate gate contracts\n'

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -375,6 +375,8 @@ main() {
     'guest test must exercise the bundled candidate companion render path'
   assert_contains "$GUEST_TEST" 'if [[ "$STATE" == clean_os ]]; then' \
     'guest test must run a standalone candidate daemon only on a clean OS'
+  assert_contains "$GUEST_TEST" '/v1/device/repair' \
+    'public guest states must ask the installed runtime to render to the virtual VibeTV'
   assert_not_contains "$GUEST_TEST" '--once --api-addr' \
     'one-shot candidate daemon must not keep a companion API server alive'
 

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -147,7 +147,11 @@ CANDIDATE_COMPANION="$INSTALL_APP/Contents/Helpers/codexbar-display"
 "$CANDIDATE_COMPANION" install-update --target http://127.0.0.1:47834 --manifest-url "$SERVER_URL/firmware-manifest.json" --skip-launchagent-pause > "$OUTPUT/candidate-install-update.txt" 2>&1
 "$CANDIDATE_COMPANION" install-update --target http://127.0.0.1:47834 --manifest-url "$SERVER_URL/firmware-manifest.json" --skip-launchagent-pause > "$OUTPUT/candidate-already-current.txt" 2>&1
 grep -F 'Firmware: already current' "$OUTPUT/candidate-already-current.txt" >/dev/null || die 'candidate companion did not prove already_current'
-"$CANDIDATE_COMPANION" daemon --transport wifi --target http://127.0.0.1:47834 --once --api-addr 127.0.0.1:47832 > "$OUTPUT/candidate-daemon-once.txt" 2>&1
+# Sparkle relaunches the candidate runtime in public states, so it already owns
+# the display writer lock and proves rendering through the virtual state below.
+if [[ "$STATE" == clean_os ]]; then
+  "$CANDIDATE_COMPANION" daemon --transport wifi --target http://127.0.0.1:47834 --once > "$OUTPUT/candidate-daemon-once.txt" 2>&1
+fi
 curl --fail --silent http://127.0.0.1:47834/__virtual/state > "$OUTPUT/virtual-state.json"
 python3 - "$OUTPUT/virtual-state.json" "$expected_uploads" <<'PY'
 import json, sys

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -147,11 +147,26 @@ CANDIDATE_COMPANION="$INSTALL_APP/Contents/Helpers/codexbar-display"
 "$CANDIDATE_COMPANION" install-update --target http://127.0.0.1:47834 --manifest-url "$SERVER_URL/firmware-manifest.json" --skip-launchagent-pause > "$OUTPUT/candidate-install-update.txt" 2>&1
 "$CANDIDATE_COMPANION" install-update --target http://127.0.0.1:47834 --manifest-url "$SERVER_URL/firmware-manifest.json" --skip-launchagent-pause > "$OUTPUT/candidate-already-current.txt" 2>&1
 grep -F 'Firmware: already current' "$OUTPUT/candidate-already-current.txt" >/dev/null || die 'candidate companion did not prove already_current'
-# Sparkle relaunches the candidate runtime in public states, so it already owns
-# the display writer lock and proves rendering through the virtual state below.
 if [[ "$STATE" == clean_os ]]; then
   "$CANDIDATE_COMPANION" daemon --transport wifi --target http://127.0.0.1:47834 --once > "$OUTPUT/candidate-daemon-once.txt" 2>&1
+else
+  # Sparkle relaunches the candidate runtime, so ask that lock-owning process
+  # to render instead of starting a competing daemon.
+  for _ in $(seq 1 30); do
+    curl --fail --silent http://127.0.0.1:47832/v1/status > "$OUTPUT/candidate-runtime-status.json" && break
+    sleep 1
+  done
+  [[ -s "$OUTPUT/candidate-runtime-status.json" ]] || die 'candidate runtime API did not become healthy after Sparkle relaunch'
+  curl --fail --silent --show-error --max-time 30 \
+    -H 'Content-Type: application/json' \
+    --data '{"target":"http://127.0.0.1:47834","forcePair":true}' \
+    http://127.0.0.1:47832/v1/device/repair > "$OUTPUT/candidate-runtime-repair.json"
 fi
+for _ in $(seq 1 30); do
+  curl --fail --silent http://127.0.0.1:47834/__virtual/state > "$OUTPUT/virtual-state.json"
+  python3 -c 'import json,sys; raise SystemExit(json.load(open(sys.argv[1])).get("framesAccepted", 0) < 1)' "$OUTPUT/virtual-state.json" && break
+  sleep 1
+done
 curl --fail --silent http://127.0.0.1:47834/__virtual/state > "$OUTPUT/virtual-state.json"
 python3 - "$OUTPUT/virtual-state.json" "$expected_uploads" <<'PY'
 import json, sys


### PR DESCRIPTION
## Summary
- run the standalone one-shot candidate daemon only for `clean_os`
- omit `--api-addr` so the one-shot process can exit
- let Sparkle-relaunched public-state runtimes remain the sole display writer
- add hosted-gate regression contracts for both lifecycle rules

## Root cause
Run 30803032807 proved firmware OTA and rendering, but public states launched a second writer and hit `runtime/display-writer-locked`; `clean_os` combined `--once` with the long-lived companion API and timed out.

## Verification
- `bash -n scripts/test-vibetv-hosted-guest.sh scripts/test-vibetv-hosted-gates.sh`
- `./scripts/test-vibetv-hosted-gates.sh`
- `(cd companion && go vet ./... && go test ./...)`
- `git diff --check`