### PR TITLE
CODEX Fix stateful hosted guest runtime validation

### DIFF
--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -375,8 +375,18 @@ main() {
     'guest test must exercise the bundled candidate companion render path'
   assert_contains "$GUEST_TEST" 'if [[ "$STATE" == clean_os ]]; then' \
     'guest test must run a standalone candidate daemon only on a clean OS'
+  assert_contains "$GUEST_TEST" 'if ! "$CANDIDATE_COMPANION" daemon' \
+    'clean OS guest test must inspect an expected no-provider daemon exit'
+  assert_contains "$GUEST_TEST" 'error code=runtime/no-providers' \
+    'clean OS guest test must only tolerate the known no-provider result'
   assert_contains "$GUEST_TEST" '/v1/device/repair' \
     'public guest states must ask the installed runtime to render to the virtual VibeTV'
+  assert_contains "$GUEST_TEST" 'listenerOwner' \
+    'guest test must bind the live Companion port to the installed runtime service'
+  assert_contains "$GUEST_TEST" 'installationMode' \
+    'guest test must verify the running candidate reports DMG installation mode'
+  assert_not_contains "$GUEST_TEST" 'validate-macos-control-center-runtime.sh' \
+    'stateful guest checks must not invoke the clean-host runtime validator'
   assert_not_contains "$GUEST_TEST" '--once --api-addr' \
     'one-shot candidate daemon must not keep a companion API server alive'
 

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -400,6 +400,8 @@ main() {
     'guest test must verify the running candidate reports DMG installation mode'
   assert_contains "$GUEST_TEST" '--max-time 3 http://127.0.0.1:47832/v1/status' \
     'guest test must bound each installed-runtime status request'
+  assert_contains "$GUEST_TEST" 'if runtime_pid="$(python3 - "$status_output"' \
+    'guest test must keep polling until the candidate runtime status itself validates'
   assert_not_contains "$GUEST_TEST" 'validate-macos-control-center-runtime.sh' \
     'stateful guest checks must not invoke the clean-host runtime validator'
   assert_not_contains "$GUEST_TEST" '--once --api-addr' \

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -385,6 +385,8 @@ main() {
     'guest test must bind the live Companion port to the installed runtime service'
   assert_contains "$GUEST_TEST" 'installationMode' \
     'guest test must verify the running candidate reports DMG installation mode'
+  assert_contains "$GUEST_TEST" '--max-time 3 http://127.0.0.1:47832/v1/status' \
+    'guest test must bound each installed-runtime status request'
   assert_not_contains "$GUEST_TEST" 'validate-macos-control-center-runtime.sh' \
     'stateful guest checks must not invoke the clean-host runtime validator'
   assert_not_contains "$GUEST_TEST" '--once --api-addr' \

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -32,6 +32,17 @@ assert_not_contains() {
   ! grep -Fq -- "$needle" "$file" || die "$message"
 }
 
+assert_before() {
+  local file="$1"
+  local first="$2"
+  local second="$3"
+  local message="$4"
+  local first_line second_line
+  first_line="$(grep -nF -- "$first" "$file" | head -n 1 | cut -d: -f1 || true)"
+  second_line="$(grep -nF -- "$second" "$file" | head -n 1 | cut -d: -f1 || true)"
+  [[ -n "$first_line" && -n "$second_line" && "$first_line" -lt "$second_line" ]] || die "$message"
+}
+
 job_block() {
   local workflow="$1"
   local job="$2"
@@ -381,6 +392,8 @@ main() {
     'clean OS guest test must only tolerate the known no-provider result'
   assert_contains "$GUEST_TEST" '/v1/device/repair' \
     'public guest states must ask the installed runtime to render to the virtual VibeTV'
+  assert_before "$GUEST_TEST" 'validate_installed_runtime "$OUTPUT/candidate-runtime-status.json"' '/v1/device/repair' \
+    'public guest states must verify the installed candidate runtime before requesting a render'
   assert_contains "$GUEST_TEST" 'listenerOwner' \
     'guest test must bind the live Companion port to the installed runtime service'
   assert_contains "$GUEST_TEST" 'installationMode' \

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -184,7 +184,7 @@ if [[ "$STATE" == clean_os ]]; then
   open -na "$INSTALL_APP"
 fi
 for _ in $(seq 1 30); do
-  curl --fail --silent http://127.0.0.1:47832/v1/status > "$OUTPUT/companion-port-47832.txt" && break
+  curl --fail --silent --max-time 3 http://127.0.0.1:47832/v1/status > "$OUTPUT/companion-port-47832.txt" && break
   sleep 1
 done
 [[ -s "$OUTPUT/companion-port-47832.txt" ]] || die 'installed candidate runtime did not become healthy on port 47832'

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -44,6 +44,36 @@ cleanup() {
 }
 trap cleanup EXIT HUP INT TERM
 
+validate_installed_runtime() {
+  local status_output="$1"
+  local runtime_pid listener_pids
+  rm -f "$status_output"
+  for _ in $(seq 1 30); do
+    curl --fail --silent --max-time 3 http://127.0.0.1:47832/v1/status > "$status_output" && break
+    sleep 1
+  done
+  [[ -s "$status_output" ]] || die 'installed candidate runtime did not become healthy on port 47832'
+  runtime_pid="$(python3 - "$status_output" "$VERSION" "$INSTALL_APP" <<'PY'
+import json, sys
+status_path, expected_version, install_app = sys.argv[1:]
+status = json.load(open(status_path, encoding="utf-8"))
+companion = status.get("companion", {})
+runtime = companion.get("runtime", {})
+if (status.get("ok") is not True or companion.get("status") != "ready"
+        or companion.get("version") != expected_version
+        or companion.get("installationMode") != "dmg"
+        or runtime.get("version") != expected_version
+        or runtime.get("executable") != f"{install_app}/Contents/Helpers/codexbar-display"
+        or runtime.get("listenerOwner") != "shop.vibetv.control-center.runtime"
+        or not isinstance(runtime.get("pid"), int) or runtime["pid"] < 1):
+    raise SystemExit("installed candidate runtime status did not match the signed DMG")
+print(runtime["pid"])
+PY
+)"
+  listener_pids="$(lsof -nP -a -iTCP@127.0.0.1:47832 -sTCP:LISTEN -Fp 2>/dev/null | sed -nE 's/^p([0-9]+)$/\1/p' | sort -u)"
+  [[ "$listener_pids" == "$runtime_pid" ]] || die 'installed candidate runtime is not the sole port-47832 listener'
+}
+
 sw_vers > "$OUTPUT/macos-version.txt"
 ps -axo pid=,ppid=,comm= > "$OUTPUT/processes-before.txt"
 "$ROOT/scripts/verify-macos-control-center-dmg.sh" --dmg "$DMG" > "$OUTPUT/candidate-dmg-verification.txt" 2>&1
@@ -155,11 +185,7 @@ if [[ "$STATE" == clean_os ]]; then
 else
   # Sparkle relaunches the candidate runtime, so ask that lock-owning process
   # to render instead of starting a competing daemon.
-  for _ in $(seq 1 30); do
-    curl --fail --silent http://127.0.0.1:47832/v1/status > "$OUTPUT/candidate-runtime-status.json" && break
-    sleep 1
-  done
-  [[ -s "$OUTPUT/candidate-runtime-status.json" ]] || die 'candidate runtime API did not become healthy after Sparkle relaunch'
+  validate_installed_runtime "$OUTPUT/candidate-runtime-status.json"
   curl --fail --silent --show-error --max-time 30 \
     -H 'Content-Type: application/json' \
     --data '{"target":"http://127.0.0.1:47834","forcePair":true}' \
@@ -182,31 +208,8 @@ PY
 
 if [[ "$STATE" == clean_os ]]; then
   open -na "$INSTALL_APP"
+  validate_installed_runtime "$OUTPUT/companion-port-47832.txt"
 fi
-for _ in $(seq 1 30); do
-  curl --fail --silent --max-time 3 http://127.0.0.1:47832/v1/status > "$OUTPUT/companion-port-47832.txt" && break
-  sleep 1
-done
-[[ -s "$OUTPUT/companion-port-47832.txt" ]] || die 'installed candidate runtime did not become healthy on port 47832'
-RUNTIME_PID="$(python3 - "$OUTPUT/companion-port-47832.txt" "$VERSION" "$INSTALL_APP" <<'PY'
-import json, sys
-status_path, expected_version, install_app = sys.argv[1:]
-status = json.load(open(status_path, encoding="utf-8"))
-companion = status.get("companion", {})
-runtime = companion.get("runtime", {})
-if (status.get("ok") is not True or companion.get("status") != "ready"
-        or companion.get("version") != expected_version
-        or companion.get("installationMode") != "dmg"
-        or runtime.get("version") != expected_version
-        or runtime.get("executable") != f"{install_app}/Contents/Helpers/codexbar-display"
-        or runtime.get("listenerOwner") != "shop.vibetv.control-center.runtime"
-        or not isinstance(runtime.get("pid"), int) or runtime["pid"] < 1):
-    raise SystemExit("installed candidate runtime status did not match the signed DMG")
-print(runtime["pid"])
-PY
-)"
-LISTENER_PIDS="$(lsof -nP -a -iTCP@127.0.0.1:47832 -sTCP:LISTEN -Fp 2>/dev/null | sed -nE 's/^p([0-9]+)$/\1/p' | sort -u)"
-[[ "$LISTENER_PIDS" == "$RUNTIME_PID" ]] || die 'installed candidate runtime is not the sole port-47832 listener'
 screencapture -x "$OUTPUT/guest-${STATE}.png"
 python3 - "$OUTPUT/result.json" "$STATE" "$VERSION" <<'PY'
 import json, sys

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -148,7 +148,10 @@ CANDIDATE_COMPANION="$INSTALL_APP/Contents/Helpers/codexbar-display"
 "$CANDIDATE_COMPANION" install-update --target http://127.0.0.1:47834 --manifest-url "$SERVER_URL/firmware-manifest.json" --skip-launchagent-pause > "$OUTPUT/candidate-already-current.txt" 2>&1
 grep -F 'Firmware: already current' "$OUTPUT/candidate-already-current.txt" >/dev/null || die 'candidate companion did not prove already_current'
 if [[ "$STATE" == clean_os ]]; then
-  "$CANDIDATE_COMPANION" daemon --transport wifi --target http://127.0.0.1:47834 --once > "$OUTPUT/candidate-daemon-once.txt" 2>&1
+  if ! "$CANDIDATE_COMPANION" daemon --transport wifi --target http://127.0.0.1:47834 --once > "$OUTPUT/candidate-daemon-once.txt" 2>&1; then
+    grep -F 'error code=runtime/no-providers' "$OUTPUT/candidate-daemon-once.txt" >/dev/null \
+      || die 'candidate daemon failed before rendering to the virtual VibeTV'
+  fi
 else
   # Sparkle relaunches the candidate runtime, so ask that lock-owning process
   # to render instead of starting a competing daemon.
@@ -177,7 +180,33 @@ if not any(event.get("path") == "/update/firmware.raw" for event in state.get("e
     raise SystemExit("candidate companion did not use Raw OTA port 8081")
 PY
 
-CODEX_ALLOW_MACOS_RUNTIME_VALIDATION=1 "$ROOT/scripts/validate-macos-control-center-runtime.sh" --real --installed-app --app "$INSTALL_APP" --expected-version "$VERSION" > "$OUTPUT/companion-port-47832.txt" 2>&1
+if [[ "$STATE" == clean_os ]]; then
+  open -na "$INSTALL_APP"
+fi
+for _ in $(seq 1 30); do
+  curl --fail --silent http://127.0.0.1:47832/v1/status > "$OUTPUT/companion-port-47832.txt" && break
+  sleep 1
+done
+[[ -s "$OUTPUT/companion-port-47832.txt" ]] || die 'installed candidate runtime did not become healthy on port 47832'
+RUNTIME_PID="$(python3 - "$OUTPUT/companion-port-47832.txt" "$VERSION" "$INSTALL_APP" <<'PY'
+import json, sys
+status_path, expected_version, install_app = sys.argv[1:]
+status = json.load(open(status_path, encoding="utf-8"))
+companion = status.get("companion", {})
+runtime = companion.get("runtime", {})
+if (status.get("ok") is not True or companion.get("status") != "ready"
+        or companion.get("version") != expected_version
+        or companion.get("installationMode") != "dmg"
+        or runtime.get("version") != expected_version
+        or runtime.get("executable") != f"{install_app}/Contents/Helpers/codexbar-display"
+        or runtime.get("listenerOwner") != "shop.vibetv.control-center.runtime"
+        or not isinstance(runtime.get("pid"), int) or runtime["pid"] < 1):
+    raise SystemExit("installed candidate runtime status did not match the signed DMG")
+print(runtime["pid"])
+PY
+)"
+LISTENER_PIDS="$(lsof -nP -a -iTCP@127.0.0.1:47832 -sTCP:LISTEN -Fp 2>/dev/null | sed -nE 's/^p([0-9]+)$/\1/p' | sort -u)"
+[[ "$LISTENER_PIDS" == "$RUNTIME_PID" ]] || die 'installed candidate runtime is not the sole port-47832 listener'
 screencapture -x "$OUTPUT/guest-${STATE}.png"
 python3 - "$OUTPUT/result.json" "$STATE" "$VERSION" <<'PY'
 import json, sys

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -46,14 +46,11 @@ trap cleanup EXIT HUP INT TERM
 
 validate_installed_runtime() {
   local status_output="$1"
-  local runtime_pid listener_pids
+  local runtime_pid="" listener_pids
   rm -f "$status_output"
   for _ in $(seq 1 30); do
-    curl --fail --silent --max-time 3 http://127.0.0.1:47832/v1/status > "$status_output" && break
-    sleep 1
-  done
-  [[ -s "$status_output" ]] || die 'installed candidate runtime did not become healthy on port 47832'
-  runtime_pid="$(python3 - "$status_output" "$VERSION" "$INSTALL_APP" <<'PY'
+    if curl --fail --silent --max-time 3 http://127.0.0.1:47832/v1/status > "$status_output"; then
+      if runtime_pid="$(python3 - "$status_output" "$VERSION" "$INSTALL_APP" <<'PY'
 import json, sys
 status_path, expected_version, install_app = sys.argv[1:]
 status = json.load(open(status_path, encoding="utf-8"))
@@ -69,7 +66,14 @@ if (status.get("ok") is not True or companion.get("status") != "ready"
     raise SystemExit("installed candidate runtime status did not match the signed DMG")
 print(runtime["pid"])
 PY
-)"
+)"; then
+        break
+      fi
+    fi
+    runtime_pid=""
+    sleep 1
+  done
+  [[ -n "$runtime_pid" ]] || die 'installed candidate runtime did not become healthy on port 47832'
   listener_pids="$(lsof -nP -a -iTCP@127.0.0.1:47832 -sTCP:LISTEN -Fp 2>/dev/null | sed -nE 's/^p([0-9]+)$/\1/p' | sort -u)"
   [[ "$listener_pids" == "$runtime_pid" ]] || die 'installed candidate runtime is not the sole port-47832 listener'
 }


### PR DESCRIPTION
## Summary
- tolerate the expected no-provider exit only when the hosted clean-OS daemon emitted its known error result
- validate the already-running installed runtime directly instead of invoking the clean-host validator after guest state exists
- bind port 47832 to the expected candidate version, DMG mode, runtime service, executable, and sole listener PID

## Evidence
- failed virtual run: https://github.com/DreamyTalesPAN/CodexBar-Display/actions/runs/30814215157
- all three virtual devices completed OTA and accepted frames before the harness-only failures

## Verification
- `bash -n scripts/test-vibetv-hosted-guest.sh scripts/test-vibetv-hosted-gates.sh`
- `./scripts/test-vibetv-hosted-gates.sh`
- `git diff --check`
- `(cd companion && go vet ./... && go test ./...)`

No release, tag, hardware write, or candidate workflow is part of this PR.