### PR TITLE
CODEX: Omit loopback support report page URL

### DIFF
--- a/apps/control-center/src/components/support-report.test.ts
+++ b/apps/control-center/src/components/support-report.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  CompanionInfo,
+  SupportDiagnostics,
+  SupportReportClientState,
+} from "./control-center-types";
+import { collectSupportReport } from "./support-report";
+
+const companion: CompanionInfo = {
+  app: {
+    version: "1.0.98",
+    build: "198",
+  },
+};
+
+function clientState(
+  runtimeSurface: SupportReportClientState["runtimeSurface"],
+): SupportReportClientState {
+  return {
+    runtimeSurface,
+    activeTab: "overview",
+    companionStatus: "online",
+    companion,
+    deviceState: "unknown",
+    deviceSearchState: "idle",
+    deviceCandidates: [],
+    recentEvents: [],
+  };
+}
+
+function stubBrowser(origin: string, pathname: string): void {
+  vi.stubGlobal("window", {
+    innerWidth: 1280,
+    innerHeight: 720,
+    devicePixelRatio: 2,
+    location: { origin, pathname },
+  });
+  vi.stubGlobal("navigator", {
+    userAgent: "VibeTVControlCenter/1.0.98",
+    platform: "MacIntel",
+    language: "en-US",
+    onLine: true,
+  });
+  vi.stubGlobal("document", { visibilityState: "visible" });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("collectSupportReport", () => {
+  it("keeps the native report non-navigable and preserves app metadata", async () => {
+    stubBrowser("http://127.0.0.1:47832", "/control-center");
+
+    const diagnostics: SupportDiagnostics = {
+      ok: true,
+      companion,
+    };
+    const report = await collectSupportReport(
+      async () => diagnostics,
+      clientState("local-control-center"),
+    );
+
+    expect(report.client?.environment).not.toHaveProperty("page");
+    expect(report.client?.state.runtimeSurface).toBe("local-control-center");
+    expect(report.client?.state.companion?.app).toEqual(companion.app);
+    expect(report.companion?.app).toEqual(companion.app);
+  });
+
+  it("includes the public page for hosted setup", async () => {
+    stubBrowser("https://app.vibetv.shop", "/control-center");
+
+    const report = await collectSupportReport(
+      async () => ({ ok: true }),
+      clientState("hosted-setup"),
+    );
+
+    expect(report.client?.environment.page).toBe(
+      "https://app.vibetv.shop/control-center",
+    );
+  });
+
+  it("keeps fallback reports non-navigable when the surface is unknown", async () => {
+    stubBrowser("http://127.0.0.1:47832", "/control-center");
+
+    const report = await collectSupportReport(
+      async () => {
+        throw new Error("Companion unavailable");
+      },
+      clientState("unknown"),
+    );
+
+    expect(report.reportType).toBe("control_center_fallback");
+    expect(report.client?.environment).not.toHaveProperty("page");
+    expect(report.client?.state.companion?.app).toEqual(companion.app);
+    expect(report.collectionErrors?.[0]?.message).toBe("Companion unavailable");
+  });
+});

--- a/apps/control-center/src/components/support-report.ts
+++ b/apps/control-center/src/components/support-report.ts
@@ -9,7 +9,7 @@ export async function collectSupportReport(
 ): Promise<SupportDiagnostics> {
   const generatedAt = new Date().toISOString();
   const client = {
-    environment: readClientEnvironment(),
+    environment: readClientEnvironment(state.runtimeSurface),
     state,
   };
 
@@ -72,11 +72,13 @@ export function supportReportFilename(value?: string): string {
   return `vibetv-support-report-${safeTimestamp}.json`;
 }
 
-function readClientEnvironment() {
+function readClientEnvironment(
+  runtimeSurface: SupportReportClientState["runtimeSurface"],
+) {
   if (typeof window === "undefined" || typeof navigator === "undefined") {
     return {};
   }
-  return {
+  const environment = {
     userAgent: navigator.userAgent,
     platform: navigator.platform,
     language: navigator.language,
@@ -84,8 +86,13 @@ function readClientEnvironment() {
     viewport: `${window.innerWidth}x${window.innerHeight}@${window.devicePixelRatio}`,
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     visibility: document.visibilityState,
-    page: `${window.location.origin}${window.location.pathname}`,
   };
+  return runtimeSurface === "hosted-setup"
+    ? {
+        ...environment,
+        page: `${window.location.origin}${window.location.pathname}`,
+      }
+    : environment;
 }
 
 function safeErrorMessage(error: unknown): string {


### PR DESCRIPTION
## Summary

- Pass the existing `runtimeSurface` into support-report environment collection.
- Include `client.environment.page` only for the hosted setup surface.
- Keep local Control Center and unknown/fallback reports free of the loopback `/control-center` URL.
- Preserve the existing `runtimeSurface` and `companion.app.version/build` fields without a schema bump.
- Add focused native, hosted, and fallback report coverage.

The native Swift report was inspected and left unchanged because it records the loopback runtime origin only for diagnostics and does not expose a customer-readable `/control-center` page URL.

## Validation

- `npm run test:unit -- src/components/support-report.test.ts`
- `npm run lint -- src/components/support-report.ts src/components/support-report.test.ts`
- `npm run test:unit`
- `npm run lint`
- `npx tsc --noEmit`

Refs #341