### PR TITLE
CODEX: Make doctor transport-aware

### DIFF
--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -48,6 +48,14 @@ var displayWorkerRestartDelay = 5 * time.Second
 var openControlCenterStartLaunchAgentFn = startLaunchAgent
 var openControlCenterOpenURLFn = openURLWithMacOpen
 var openControlCenterHTTPClient = &http.Client{}
+var doctorListPortsFn = usb.ListPorts
+var doctorResolvePortFn = usb.ResolvePort
+var doctorProbePortFn = usb.ProbePort
+var doctorReadDeviceHelloFn = usb.ReadDeviceHello
+var doctorReadWiFiCapabilitiesFn = func(target string) (protocol.DeviceCapabilities, error) {
+	return transportlayer.NewWiFiTransportWithClient(nil).DeviceCapabilities(target)
+}
+var doctorCheckCompanionHealthFn = checkDoctorCompanionHealth
 
 var displayStreamSensitiveQueryPattern = regexp.MustCompile(`(?i)([?&](?:token|auth|key|secret)=)[^&\s"]+`)
 var displayStreamSensitiveUserInfoPattern = regexp.MustCompile(`(?i)(https?://)[^/@\s]+@`)
@@ -857,21 +865,11 @@ func runDoctor() error {
 		}
 	}
 
-	ports, err := usb.ListPorts()
-	if err != nil {
-		return fmt.Errorf("list serial ports: %w", err)
-	}
-
-	fmt.Println("Serial ports:")
-	if len(ports) == 0 {
-		fmt.Println("  (none)")
-	} else {
-		for _, p := range ports {
-			fmt.Printf("  %s\n", p)
-		}
-	}
-
-	if runtimeErr := runDoctorRuntimeChecks(ports); runtimeErr != nil {
+	runtimeConfig, configErr := readDoctorRuntimeConfig()
+	if configErr != nil {
+		fmt.Printf("Active runtime: unavailable (%v)\n", configErr)
+		doctorErrs = append(doctorErrs, fmt.Errorf("read active runtime configuration failed: %w", configErr))
+	} else if runtimeErr := runDoctorTransportChecks(runtimeConfig); runtimeErr != nil {
 		doctorErrs = append(doctorErrs, runtimeErr)
 	}
 
@@ -895,20 +893,118 @@ func runDoctor() error {
 	return nil
 }
 
-func runDoctorRuntimeChecks(ports []string) error {
+type doctorRuntimeConfig struct {
+	configured bool
+	transport  string
+	target     string
+	port       string
+}
+
+func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return doctorRuntimeConfig{}, err
+	}
+	for _, label := range []string{"shop.vibetv.control-center.runtime", "shop.vibetv.control-center.preview-runtime"} {
+		if !doctorLaunchAgentLoaded(label) {
+			continue
+		}
+		data, err := os.ReadFile(runtimeconfig.ConfigPath(home))
+		if errors.Is(err, os.ErrNotExist) {
+			return doctorRuntimeConfig{configured: true, transport: "wifi"}, nil
+		}
+		if err != nil {
+			return doctorRuntimeConfig{}, err
+		}
+		var config runtimeconfig.Config
+		if err := json.Unmarshal(data, &config); err != nil {
+			return doctorRuntimeConfig{}, fmt.Errorf("parse runtime config: %w", err)
+		}
+		return doctorRuntimeConfig{configured: true, transport: "wifi", target: strings.TrimSpace(config.DeviceTarget)}, nil
+	}
+
+	if !doctorLaunchAgentLoaded("com.codexbar-display.daemon") {
+		return doctorRuntimeConfig{}, nil
+	}
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.codexbar-display.daemon.plist")
+	data, err := os.ReadFile(plistPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return doctorRuntimeConfig{}, nil
+	}
+	if err != nil {
+		return doctorRuntimeConfig{}, err
+	}
+	plist := string(data)
+	transportName := strings.ToLower(parseLaunchAgentArgument(plist, "--transport"))
+	target := parseLaunchAgentArgument(plist, "--target")
+	if transportName == "" {
+		if target != "" {
+			transportName = "wifi"
+		} else {
+			transportName = "usb"
+		}
+	}
+	return doctorRuntimeConfig{
+		configured: true,
+		transport:  transportName,
+		target:     target,
+		port:       parsePinnedPortFromLaunchAgentPlist(plist),
+	}, nil
+}
+
+func doctorLaunchAgentLoaded(label string) bool {
+	service := fmt.Sprintf("gui/%d/%s", os.Getuid(), label)
+	return exec.Command("launchctl", "print", service).Run() == nil
+}
+
+func runDoctorTransportChecks(config doctorRuntimeConfig) error {
+	if !config.configured {
+		fmt.Println("Active runtime: not configured (run `codexbar-display setup`)")
+		fmt.Println("  available transports: wifi, usb")
+		return errors.New("runtime setup required: no active runtime configuration")
+	}
+
+	fmt.Printf("Active runtime: transport=%s\n", config.transport)
+	if config.transport == "wifi" {
+		fmt.Println("Serial ports: not applicable (active transport is WiFi)")
+		return runDoctorWiFiRuntimeChecks(config)
+	}
+	if config.transport != "usb" {
+		return fmt.Errorf("runtime setup required: unsupported active transport %q", config.transport)
+	}
+
+	ports, err := doctorListPortsFn()
+	if err != nil {
+		return fmt.Errorf("list serial ports: %w", err)
+	}
+	fmt.Println("Serial ports:")
+	if len(ports) == 0 {
+		fmt.Println("  (none)")
+	} else {
+		for _, port := range ports {
+			fmt.Printf("  %s\n", port)
+		}
+	}
+	return runDoctorUSBRuntimeChecks(config, ports)
+}
+
+func printDoctorRuntimeDefaults() {
 	fmt.Println("Runtime checks:")
 	fmt.Printf("  codexbar timeout: %s\n", codexbar.CommandTimeout())
 	fmt.Printf("  last-good max age: %s\n", daemon.LastGoodMaxAge())
 	fmt.Printf("  sleep/wake threshold (@60s interval): %s\n", daemon.SleepWakeGapThreshold(60*time.Second))
+}
 
-	port, err := usb.ResolvePort("")
+func runDoctorUSBRuntimeChecks(config doctorRuntimeConfig, ports []string) error {
+	printDoctorRuntimeDefaults()
+	port, err := doctorResolvePortFn("")
 	if err != nil {
 		fmt.Printf("  serial resolve: failed (%v)\n", err)
 		return fmt.Errorf("runtime serial resolve failed: %w", err)
 	}
 	fmt.Printf("  serial resolve: ok (%s)\n", port)
 
-	if err := usb.ProbePort(port); err != nil {
+	if err := doctorProbePortFn(port); err != nil {
 		if errcode.Of(err) == errcode.TransportSerialCloseTimeout {
 			fmt.Printf("  serial probe: warning (%v)\n", err)
 		} else {
@@ -919,11 +1015,7 @@ func runDoctorRuntimeChecks(ports []string) error {
 		fmt.Printf("  serial probe: ok (%s)\n", port)
 	}
 
-	pinnedPort, err := doctorPinnedLaunchAgentPort()
-	if err != nil {
-		fmt.Printf("  launchagent port affinity: failed (%v)\n", err)
-		return fmt.Errorf("runtime launchagent affinity check failed: %w", err)
-	}
+	pinnedPort := config.port
 	if pinnedPort == "" {
 		fmt.Println("  launchagent port affinity: auto-detect")
 		if len(ports) > 1 {
@@ -942,24 +1034,50 @@ func runDoctorRuntimeChecks(ports []string) error {
 		}
 	}
 
-	hello, err := usb.ReadDeviceHello(port)
+	hello, err := doctorReadDeviceHelloFn(port)
 	if err != nil {
 		fmt.Printf("  device hello: warning (%v)\n", err)
 		fmt.Println("  warning: capability handshake unavailable; runtime will use optimistic theme send fallback")
 		return nil
 	}
 
-	caps := protocol.CapabilitiesFromHello(hello)
-	fmt.Printf("  device hello: ok board=%s protocol=%d negotiated=%d firmware=%s theme=%t themeSpecV1=%t maxFrameBytes=%d\n",
+	return reportDoctorCapabilities("device hello", protocol.CapabilitiesFromHello(hello))
+}
+
+func runDoctorWiFiRuntimeChecks(config doctorRuntimeConfig) error {
+	printDoctorRuntimeDefaults()
+	target := strings.TrimSpace(config.target)
+	fmt.Println("  launchagent port affinity: not applicable (active transport is WiFi)")
+	if target == "" {
+		fmt.Println("  WiFi device target: unavailable (rerun setup)")
+		return errors.New("runtime WiFi target unavailable: rerun setup")
+	}
+	fmt.Printf("  WiFi device target: %s\n", target)
+	if err := doctorCheckCompanionHealthFn(); err != nil {
+		fmt.Printf("  Companion health: failed (%v)\n", err)
+		return fmt.Errorf("runtime Companion health failed: %w", err)
+	}
+	fmt.Println("  Companion health: ok")
+	caps, err := doctorReadWiFiCapabilitiesFn(target)
+	if err != nil {
+		fmt.Printf("  WiFi device reachability: failed (%v)\n", err)
+		return fmt.Errorf("runtime WiFi device reachability failed: %w", err)
+	}
+	return reportDoctorCapabilities("WiFi device reachability", caps)
+}
+
+func reportDoctorCapabilities(label string, caps protocol.DeviceCapabilities) error {
+	fmt.Printf("  %s: ok board=%s protocol=%d negotiated=%d firmware=%s theme=%t themeSpecV1=%t maxFrameBytes=%d\n",
+		label,
 		caps.Board,
 		caps.ProtocolVersion,
 		caps.NegotiatedProtocolVersion,
-		hello.Firmware,
+		caps.Firmware,
 		caps.SupportsTheme,
 		caps.SupportsThemeSpecV1,
 		caps.MaxFrameBytes)
 	if len(caps.SupportedProtocolVersions) > 0 {
-		fmt.Printf("  device hello protocols: %v (preferred=%d)\n", caps.SupportedProtocolVersions, caps.PreferredProtocolVersion)
+		fmt.Printf("  %s protocols: %v (preferred=%d)\n", label, caps.SupportedProtocolVersions, caps.PreferredProtocolVersion)
 	}
 	if !caps.Known {
 		fmt.Println("  warning: device capabilities are unknown; skipping strict hardware/theme contract checks")
@@ -984,6 +1102,28 @@ func runDoctorRuntimeChecks(ports []string) error {
 		)
 	}
 
+	return nil
+}
+
+func checkDoctorCompanionHealth() error {
+	client := &http.Client{Timeout: 3 * time.Second}
+	response, err := client.Get("http://" + companionapi.DefaultAddr + "/v1/runtime-health")
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", response.StatusCode)
+	}
+	var result struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, 64<<10)).Decode(&result); err != nil {
+		return err
+	}
+	if !result.OK {
+		return errors.New("runtime health reported not ok")
+	}
 	return nil
 }
 
@@ -1870,24 +2010,12 @@ func containsPort(ports []string, target string) bool {
 	return false
 }
 
-func doctorPinnedLaunchAgentPort() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.codexbar-display.daemon.plist")
-	data, err := os.ReadFile(plistPath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", nil
-		}
-		return "", err
-	}
-	return parsePinnedPortFromLaunchAgentPlist(string(data)), nil
+func parsePinnedPortFromLaunchAgentPlist(plist string) string {
+	return parseLaunchAgentArgument(plist, "--port")
 }
 
-func parsePinnedPortFromLaunchAgentPlist(plist string) string {
-	const marker = "<string>--port</string>"
+func parseLaunchAgentArgument(plist, name string) string {
+	marker := "<string>" + name + "</string>"
 	idx := strings.Index(plist, marker)
 	if idx < 0 {
 		return ""

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
+)
 
 func TestParsePinnedPortFromLaunchAgentPlist(t *testing.T) {
 	t.Run("unpinned", func(t *testing.T) {
@@ -33,6 +39,91 @@ func TestContainsPort(t *testing.T) {
 	if containsPort(ports, "/dev/cu.usbserial-11") {
 		t.Fatalf("did not expect unknown port to match")
 	}
+}
+
+func TestDoctorWiFiSkipsSerialChecks(t *testing.T) {
+	for _, ports := range [][]string{
+		{},
+		{"/dev/cu.usbserial-1"},
+		{"/dev/cu.Bluetooth-Incoming-Port", "/dev/cu.usbserial-1", "/dev/cu.usbserial-2"},
+	} {
+		t.Run(strings.Join(ports, ","), func(t *testing.T) {
+			serialCalled := false
+			restoreDoctorTestDeps(t)
+			doctorListPortsFn = func() ([]string, error) {
+				serialCalled = true
+				return ports, nil
+			}
+			doctorCheckCompanionHealthFn = func() error { return nil }
+			doctorReadWiFiCapabilitiesFn = func(string) (protocol.DeviceCapabilities, error) {
+				return protocol.UnknownDeviceCapabilities(), nil
+			}
+
+			err := runDoctorTransportChecks(doctorRuntimeConfig{
+				configured: true,
+				transport:  "wifi",
+				target:     "http://192.0.2.10",
+			})
+			if err != nil {
+				t.Fatalf("WiFi doctor failed: %v", err)
+			}
+			if serialCalled {
+				t.Fatal("WiFi doctor must not list serial ports")
+			}
+		})
+	}
+}
+
+func TestDoctorUSBStillRejectsAmbiguousUnpinnedPorts(t *testing.T) {
+	restoreDoctorTestDeps(t)
+	doctorListPortsFn = func() ([]string, error) {
+		return []string{"/dev/cu.usbserial-1", "/dev/cu.usbserial-2"}, nil
+	}
+	doctorResolvePortFn = func(string) (string, error) { return "/dev/cu.usbserial-1", nil }
+	doctorProbePortFn = func(string) error { return nil }
+	doctorReadDeviceHelloFn = func(string) (protocol.DeviceHello, error) {
+		return protocol.DeviceHello{}, errors.New("must not reach device hello")
+	}
+
+	err := runDoctorTransportChecks(doctorRuntimeConfig{configured: true, transport: "usb"})
+	if err == nil || !strings.Contains(err.Error(), "2 serial ports detected") {
+		t.Fatalf("expected USB ambiguity error, got %v", err)
+	}
+}
+
+func TestDoctorWithoutRuntimeRequestsSetupWithoutListingPorts(t *testing.T) {
+	restoreDoctorTestDeps(t)
+	serialCalled := false
+	doctorListPortsFn = func() ([]string, error) {
+		serialCalled = true
+		return nil, nil
+	}
+
+	err := runDoctorTransportChecks(doctorRuntimeConfig{})
+	if err == nil || !strings.Contains(err.Error(), "setup required") {
+		t.Fatalf("expected setup-required error, got %v", err)
+	}
+	if serialCalled {
+		t.Fatal("unconfigured doctor must not treat serial inventory as fatal")
+	}
+}
+
+func restoreDoctorTestDeps(t *testing.T) {
+	t.Helper()
+	listPorts := doctorListPortsFn
+	resolvePort := doctorResolvePortFn
+	probePort := doctorProbePortFn
+	readHello := doctorReadDeviceHelloFn
+	readWiFiCapabilities := doctorReadWiFiCapabilitiesFn
+	checkCompanionHealth := doctorCheckCompanionHealthFn
+	t.Cleanup(func() {
+		doctorListPortsFn = listPorts
+		doctorResolvePortFn = resolvePort
+		doctorProbePortFn = probePort
+		doctorReadDeviceHelloFn = readHello
+		doctorReadWiFiCapabilitiesFn = readWiFiCapabilities
+		doctorCheckCompanionHealthFn = checkCompanionHealth
+	})
 }
 
 func TestFallbackThemeSpecCapabilities(t *testing.T) {

--- a/docs/macos-dmg-distribution.md
+++ b/docs/macos-dmg-distribution.md
@@ -83,11 +83,13 @@ The embedded LaunchAgent runs the integrated display daemon and local API:
 ```bash
 codexbar-display daemon \
   --transport wifi \
-  --target http://<device-ip> \
   --interval 30s \
   --api-addr 127.0.0.1:47832 \
   --api-dev-origin http://127.0.0.1:47832
 ```
+
+The app-managed native plist intentionally does not contain `--target`; the
+Mac App loads the active VibeTV target from its local runtime configuration.
 
 This keeps normal VibeTV usage frames updating in the background. App install
 and migration do not trigger firmware updates, theme installs, asset uploads,

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -357,9 +357,11 @@ cd companion
 - last successful `sent frame` timestamp + port
 - last runtime error (if any)
 
-`doctor` runtime checks additionally validate:
-- board/protocol/theme capability contract from device hello
-- LaunchAgent port affinity safety (fails when multiple serial ports are present and daemon is unpinned)
+`doctor` runtime checks are transport-aware:
+- active runtime service and configured transport
+- WiFi: configured target, local Companion health, and read-only device reachability; USB/serial affinity is not applicable
+- USB: board/protocol/theme capability contract, serial probe, and LaunchAgent port affinity safety (fails when multiple serial ports are present and daemon is unpinned)
+- no active runtime: clear setup-required result without treating unrelated serial inventory as fatal
 
 Runtime error logs use:
 - stable `code=<category/item>` (`transport/*`, `protocol/*`, `runtime/*`, `setup/*`)


### PR DESCRIPTION
## Summary

- detect the active bundled, preview, or legacy runtime before transport diagnostics
- skip all USB inventory, probing, and affinity checks for WiFi runtimes
- report the configured WiFi target, local Companion health, and read-only device reachability
- preserve the existing USB ambiguity and capability checks
- report a clear setup-required result when no runtime is active

## Tests

- `cd companion && go test ./...`
- `cd companion && go vet ./...`

## Stacking

This Draft PR is intentionally based on PR #260 (`codex/bearbeite-issue-237`) and should be reviewed after or alongside it. It does not modify PR #260.

Closes #340