### PR TITLE
fix: keep VibeTV merge gate CodexBar-compatible

### DIFF
--- a/scripts/verify-bundled-codexbar.sh
+++ b/scripts/verify-bundled-codexbar.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="0.44.0"
-SHA256="958c4b3fc64367d833b6e26df98d262b16384a52dcf6b8181f9b98091505671f"
-LICENSE_SHA256="14293556b79940745123d0160c71d27ed0e9fe9b8a848093f3ed78f4853caafe"
-ARCHIVE_NAME="CodexBar-macos-universal-${VERSION}.zip"
+VERSION=""
+SHA256=""
+LICENSE_SHA256=""
+ARCHIVE_NAME=""
 APP_DIR=""
 
 die() {
@@ -31,9 +31,44 @@ done
 
 [[ -d "$APP_DIR" ]] || die "app bundle not found: ${APP_DIR:-<missing>}"
 resources="${APP_DIR}/Contents/Resources/CodexBar"
-archive="${resources}/${ARCHIVE_NAME}"
-manifest="${resources}/CodexBar-v${VERSION}.manifest.json"
 license="${resources}/CodexBar-LICENSE.txt"
+
+# The trusted gate must validate a candidate built from a newer pinned
+# CodexBar release before that release is present in the current main app
+# builder. Keep the accepted releases explicit and verify their hashes below.
+shopt -s nullglob
+manifests=("${resources}"/CodexBar-v*.manifest.json)
+shopt -u nullglob
+[[ "${#manifests[@]}" -eq 1 ]] \
+  || die "expected exactly one bundled CodexBar manifest"
+manifest="${manifests[0]}"
+VERSION="$(python3 - "$manifest" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    print(json.load(handle).get("version", ""))
+PY
+)" || die "bundled CodexBar manifest could not be read"
+
+case "$VERSION" in
+  0.44.0)
+    SHA256="958c4b3fc64367d833b6e26df98d262b16384a52dcf6b8181f9b98091505671f"
+    LICENSE_SHA256="14293556b79940745123d0160c71d27ed0e9fe9b8a848093f3ed78f4853caafe"
+    ;;
+  0.46.0)
+    SHA256="8fe3e93b84151d682c7b80a10e2878c72cbf2e59ff78dd616c26e8cc197a79a0"
+    LICENSE_SHA256="14293556b79940745123d0160c71d27ed0e9fe9b8a848093f3ed78f4853caafe"
+    ;;
+  *)
+    die "unsupported bundled CodexBar version: ${VERSION:-<missing>}"
+    ;;
+esac
+
+[[ "$manifest" == "${resources}/CodexBar-v${VERSION}.manifest.json" ]] \
+  || die "bundled CodexBar manifest filename does not match its version"
+ARCHIVE_NAME="CodexBar-macos-universal-${VERSION}.zip"
+archive="${resources}/${ARCHIVE_NAME}"
 
 [[ -f "$archive" ]] || die "bundled CodexBar archive is missing"
 [[ -s "$manifest" ]] || die "bundled CodexBar manifest is missing"


### PR DESCRIPTION
## Problem
The trusted VibeTV merge gate on `main` only recognizes bundled CodexBar `0.44.0`. PR #260 builds the app with the pinned `0.46.0` release, so the trusted verifier reports the newer archive as missing before the guest matrix starts.

## Fix
Keep the verifier strict, but select the bundled manifest and accept only the pinned `0.44.0` and `0.46.0` releases with their known archive and license hashes. This keeps the signing job on trusted `main` tooling while allowing a PR to advance the pinned CodexBar release.

## Verification
- Reproduced the existing PR `0.46.0` candidate archive failing before the change.
- Verified the PR `0.46.0` archive after the change.
- Verified the legacy `0.44.0` archive after the change.
- `scripts/test-macos-control-center-app-bundle.sh` passed.
- `go test ./...` in `companion` passed.

Prerequisite for rerunning the merge gate on #260.
