### PR TITLE
CODEX: Correct usage-slot minimum Mac App version

### DIFF
--- a/protocol/compatibility_matrix.json
+++ b/protocol/compatibility_matrix.json
@@ -13,7 +13,7 @@
     },
     "usageSlotsV1": {
       "firmwareMin": "1.0.40",
-      "companionMin": "1.0.52",
+      "companionMin": "1.0.53",
       "updateOrder": "companion-first",
       "notes": "Firmware 1.0.40 advertises usage-slots-v1, renders two provider-neutral lanes, hides absent lanes, and ticks per-slot resets. Slot-based theme packs are blocked on older firmware."
     }


### PR DESCRIPTION
## What changed

- change the `usageSlotsV1` minimum Mac App/Companion version from `1.0.52` to `1.0.53`

## Why

The public `v1.0.52` release predates the dynamic usage-slot implementation merged in PR #260. Firmware `1.0.40` therefore requires the next Mac App release for the complete feature contract.

## Impact

The compatibility matrix now matches the intended companion-first release order: Mac App `1.0.53`, then VibeTV firmware `1.0.40`.

## Validation

- `jq empty protocol/compatibility_matrix.json`
- `./scripts/test-control-center-release-workflow.sh`
- `git diff --check`