### PR TITLE
Drive guest-matrix firmware updates through the runtime API

### DIFF
--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -398,6 +398,14 @@ main() {
     'public guest states must ask the installed runtime to render to the virtual VibeTV'
   assert_before "$GUEST_TEST" 'validate_installed_runtime "$OUTPUT/candidate-runtime-status.json"' '/v1/device/repair' \
     'public guest states must verify the installed candidate runtime before requesting a render'
+  assert_contains "$GUEST_TEST" 'http://127.0.0.1:47832/v1/updates/install' \
+    'public guest states must drive the firmware update through the installed runtime API, not a direct CLI flash'
+  assert_contains "$GUEST_TEST" '/v1/updates/install/status?jobId=' \
+    'guest test must wait for the runtime firmware update job to finish'
+  assert_before "$GUEST_TEST" '/v1/device/repair' 'api_firmware_update "$OUTPUT/candidate-install-update.json"' \
+    'the runtime must own the paired device before the API firmware update starts'
+  assert_contains "$GUEST_TEST" 'api_firmware_update "$OUTPUT/candidate-already-current.json" already_current' \
+    'public guest states must prove already_current through the runtime API as well'
   assert_contains "$GUEST_TEST" 'listenerOwner' \
     'guest test must bind the live Companion port to the installed runtime service'
   assert_contains "$GUEST_TEST" 'installationMode' \

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -37,6 +37,7 @@ VIRTUAL_PID="" HTTP_PID=""
 cleanup() {
   [[ -z "$VIRTUAL_PID" ]] || kill "$VIRTUAL_PID" >/dev/null 2>&1 || true
   [[ -z "$HTTP_PID" ]] || kill "$HTTP_PID" >/dev/null 2>&1 || true
+  launchctl unsetenv CODEXBAR_DISPLAY_FIRMWARE_MANIFEST_URL >/dev/null 2>&1 || true
   hdiutil detach "$CANDIDATE_MOUNT" -quiet >/dev/null 2>&1 || true
   hdiutil detach "$BASELINE_MOUNT" -quiet >/dev/null 2>&1 || true
   [[ ! -e "$INSTALL_APP" ]] || rm -rf "$INSTALL_APP" || true
@@ -76,6 +77,40 @@ PY
   [[ -n "$runtime_pid" ]] || die 'installed candidate runtime did not become healthy on port 47832'
   listener_pids="$(lsof -nP -a -iTCP@127.0.0.1:47832 -sTCP:LISTEN -Fp 2>/dev/null | sed -nE 's/^p([0-9]+)$/\1/p' | sort -u)"
   [[ "$listener_pids" == "$runtime_pid" ]] || die 'installed candidate runtime is not the sole port-47832 listener'
+}
+
+# Drives one firmware update through the installed runtime's Companion API and
+# waits for the job to finish. This is the exact path the Updates tab uses: the
+# runtime pauses its own display stream and marks the child updater as
+# parent-paused, so the writer-quiesce gate stays satisfied without stopping
+# the app.
+api_firmware_update() {
+  local status_output="$1" expected_outcome="$2"
+  local start_output="${status_output%.json}.start.json"
+  curl --fail --silent --show-error --max-time 30 \
+    -H 'Content-Type: application/json' --data '{}' \
+    http://127.0.0.1:47832/v1/updates/install > "$start_output"
+  local job_id
+  job_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["job"]["id"])' "$start_output")"
+  [[ -n "$job_id" ]] || die 'installed runtime did not start a firmware update job'
+  local deadline=$((SECONDS + 300))
+  while (( SECONDS < deadline )); do
+    curl --fail --silent --max-time 10 \
+      "http://127.0.0.1:47832/v1/updates/install/status?jobId=${job_id}" > "$status_output" \
+      || { sleep 2; continue; }
+    if python3 -c 'import json,sys; job=json.load(open(sys.argv[1]))["job"]; raise SystemExit(0 if job.get("phase") in ("complete","error","attention") else 1)' "$status_output"; then
+      break
+    fi
+    sleep 2
+  done
+  python3 - "$status_output" "$expected_outcome" <<'PY'
+import json, sys
+job = json.load(open(sys.argv[1], encoding="utf-8"))["job"]
+if job.get("phase") != "complete" or job.get("outcome") != sys.argv[2]:
+    raise SystemExit(
+        "firmware update job ended phase=%r outcome=%r message=%r; expected complete/%s"
+        % (job.get("phase"), job.get("outcome"), job.get("message"), sys.argv[2]))
+PY
 }
 
 sw_vers > "$OUTPUT/macos-version.txt"
@@ -118,6 +153,16 @@ _, _, tail = rest.partition('/VibeTV-Control-Center.dmg')
 open(path, 'w', encoding='utf-8').write(before + url + tail)
 PY
 
+# The served firmware manifest must exist before any app process starts: the
+# installed runtime resolves it from the launchd environment as soon as it runs.
+python3 - "$WORK/serve/firmware-manifest.template.json" "$WORK/serve/firmware-manifest.json" "$SERVER_URL/firmware.bin" <<'PY'
+import json, sys
+source, output, url = sys.argv[1:]
+manifest = json.load(open(source, encoding="utf-8"))
+for artifact in manifest.get("artifacts", []): artifact["firmwareUrl"] = url
+json.dump(manifest, open(output, "w", encoding="utf-8"), indent=2)
+PY
+
 if [[ "$STATE" == clean_os ]]; then
   ditto "$CANDIDATE_APP" "$INSTALL_APP"
 else
@@ -127,6 +172,10 @@ else
   [[ -d "$BASELINE_APP" ]] || die 'baseline DMG has no app'
   ditto "$BASELINE_APP" "$INSTALL_APP"
   plutil -extract CFBundleShortVersionString raw -o - "$INSTALL_APP/Contents/Info.plist" > "$OUTPUT/baseline-version.txt"
+  # The runtime reads the firmware manifest override from the launchd
+  # environment at spawn, so it must be set before launchd starts any app or
+  # runtime process on this guest.
+  launchctl setenv CODEXBAR_DISPLAY_FIRMWARE_MANIFEST_URL "$SERVER_URL/firmware-manifest.json"
   open -na "$INSTALL_APP"
   sleep 2
   BASELINE_PID="$(pgrep -f "$INSTALL_APP/Contents/MacOS/VibeTVControlCenter" | head -n1)"
@@ -152,13 +201,6 @@ plutil -extract CFBundleShortVersionString raw -o - "$INSTALL_APP/Contents/Info.
 [[ "$(cat "$OUTPUT/installed-candidate-version.txt")" == "$VERSION" ]] || die 'installed app is not the candidate version after Sparkle/direct install'
 cmp "$COMPANION" "$INSTALL_APP/Contents/Helpers/codexbar-display" || die 'installed app does not contain the candidate companion artifact'
 
-python3 - "$WORK/serve/firmware-manifest.template.json" "$WORK/serve/firmware-manifest.json" "$SERVER_URL/firmware.bin" <<'PY'
-import json, sys
-source, output, url = sys.argv[1:]
-manifest = json.load(open(source, encoding="utf-8"))
-for artifact in manifest.get("artifacts", []): artifact["firmwareUrl"] = url
-json.dump(manifest, open(output, "w", encoding="utf-8"), indent=2)
-PY
 candidate_firmware="$(python3 -c 'import json; print(next(a["firmwareVersion"] for a in json.load(open("'"$FIRMWARE_MANIFEST"'"))["artifacts"] if a["firmwareEnv"] == "esp8266_smalltv_st7789"))')"
 expected_uploads="$(python3 - "$CURRENT_FIRMWARE" "$candidate_firmware" <<'PY'
 import sys
@@ -178,22 +220,30 @@ firmware_sha="$(shasum -a 256 "$RAW_FIRMWARE" | awk '{print $1}')"
 for _ in $(seq 1 30); do curl --fail --silent "$SERVER_URL/firmware-manifest.json" >/dev/null && curl --fail --silent http://127.0.0.1:47834/health > "$OUTPUT/virtual-health-before.json" && break; sleep 1; done
 [[ -s "$OUTPUT/virtual-health-before.json" ]] || die 'Virtual VibeTV did not become healthy'
 CANDIDATE_COMPANION="$INSTALL_APP/Contents/Helpers/codexbar-display"
-"$CANDIDATE_COMPANION" install-update --target http://127.0.0.1:47834 --manifest-url "$SERVER_URL/firmware-manifest.json" --skip-launchagent-pause > "$OUTPUT/candidate-install-update.txt" 2>&1
-"$CANDIDATE_COMPANION" install-update --target http://127.0.0.1:47834 --manifest-url "$SERVER_URL/firmware-manifest.json" --skip-launchagent-pause > "$OUTPUT/candidate-already-current.txt" 2>&1
-grep -F 'Firmware: already current' "$OUTPUT/candidate-already-current.txt" >/dev/null || die 'candidate companion did not prove already_current'
 if [[ "$STATE" == clean_os ]]; then
+  # No runtime is alive on a clean OS, so the direct CLI updater is the honest
+  # path and its writer-quiesce probe finds the runtime-health endpoint dead.
+  "$CANDIDATE_COMPANION" install-update --target http://127.0.0.1:47834 --manifest-url "$SERVER_URL/firmware-manifest.json" --skip-launchagent-pause > "$OUTPUT/candidate-install-update.txt" 2>&1
+  "$CANDIDATE_COMPANION" install-update --target http://127.0.0.1:47834 --manifest-url "$SERVER_URL/firmware-manifest.json" --skip-launchagent-pause > "$OUTPUT/candidate-already-current.txt" 2>&1
+  grep -F 'Firmware: already current' "$OUTPUT/candidate-already-current.txt" >/dev/null || die 'candidate companion did not prove already_current'
   if ! "$CANDIDATE_COMPANION" daemon --transport wifi --target http://127.0.0.1:47834 --once > "$OUTPUT/candidate-daemon-once.txt" 2>&1; then
     grep -F 'error code=runtime/no-providers' "$OUTPUT/candidate-daemon-once.txt" >/dev/null \
       || die 'candidate daemon failed before rendering to the virtual VibeTV'
   fi
 else
-  # Sparkle relaunches the candidate runtime, so ask that lock-owning process
-  # to render instead of starting a competing daemon.
+  # Sparkle relaunched the candidate app, so its runtime owns the device and a
+  # direct CLI flash is refused by the writer-quiesce gate — deliberately.
+  # Drive the update the way a customer does: through the runtime's Companion
+  # API, which pauses its own display stream around the child updater.
   validate_installed_runtime "$OUTPUT/candidate-runtime-status.json"
   curl --fail --silent --show-error --max-time 30 \
     -H 'Content-Type: application/json' \
     --data '{"target":"http://127.0.0.1:47834","forcePair":true}' \
     http://127.0.0.1:47832/v1/device/repair > "$OUTPUT/candidate-runtime-repair.json"
+  first_outcome=updated
+  [[ "$expected_uploads" == 0 ]] && first_outcome=already_current
+  api_firmware_update "$OUTPUT/candidate-install-update.json" "$first_outcome"
+  api_firmware_update "$OUTPUT/candidate-already-current.json" already_current
 fi
 for _ in $(seq 1 30); do
   curl --fail --silent http://127.0.0.1:47834/__virtual/state > "$OUTPUT/virtual-state.json"


### PR DESCRIPTION
The hosted guest test flashes the virtual VibeTV with a direct `install-update` CLI call while the Sparkle-relaunched candidate runtime is alive and polling the device. The writer-quiesce gate introduced on PR #348 (hardware BUG-7 measurement) rightly refuses exactly that, so `guest-test (previous_public)` and `guest-test (current_public)` fail with `quiesce-device-writers` for every candidate that carries the guard — see run 31160064711 and run 31161390646.

The refusal is correct; the test was on the wrong path. A customer never runs the CLI next to the app — the Updates tab posts to `/v1/updates/install` and the runtime pauses its own display stream around the child updater. The baseline states now drive both the update and the already-current proof through that API and wait on `/v1/updates/install/status`. `clean_os` keeps the CLI path: no runtime is alive there, which is the one situation the direct flash is for.

The served firmware manifest is published and exported via `launchctl setenv` before any app process starts, because the runtime resolves `CODEXBAR_DISPLAY_FIRMWARE_MANIFEST_URL` from the launchd environment at spawn.

The hosted-gates contract pins the new path so the guest test cannot quietly fall back to a direct CLI flash in the baseline states (`scripts/test-vibetv-hosted-gates.sh` passes locally).

This must land on `main` because the merge gate deliberately checks out the guest test from the trusted workflow SHA, not from the PR under test — PR #348 can only gate green once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)