### PR TITLE
CODEX: Collect guest-matrix diagnostics and serve a deterministic release feed

### DIFF
--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -34,10 +34,32 @@ WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-hosted-guest.XXXXXX")"
 CANDIDATE_MOUNT="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-candidate-mount.XXXXXX")"
 BASELINE_MOUNT="$(mktemp -d "${TMPDIR:-/tmp}/vibetv-baseline-mount.XXXXXX")"
 VIRTUAL_PID="" HTTP_PID=""
+# Everything the runtime knows about why a display stream is or is not healthy
+# lives outside this script, so a failure here used to be undebuggable from the
+# uploaded artifacts alone. Collect it unconditionally, before cleanup deletes
+# the installed app.
+collect_diagnostics() {
+  local dir="$OUTPUT/diagnostics"
+  mkdir -p "$dir" || return 0
+  curl --fail --silent --max-time 10 http://127.0.0.1:47832/v1/status > "$dir/runtime-status.json" 2>/dev/null || true
+  curl --fail --silent --max-time 10 http://127.0.0.1:47832/v1/device > "$dir/device.json" 2>/dev/null || true
+  curl --fail --silent --max-time 10 http://127.0.0.1:47832/v1/diagnostics > "$dir/diagnostics.json" 2>/dev/null || true
+  curl --fail --silent --max-time 10 http://127.0.0.1:47834/__virtual/state > "$dir/virtual-state-final.json" 2>/dev/null || true
+  local support="$HOME/Library/Application Support/codexbar-display"
+  # daemon.out.log is the file the runtime parses to decide stream health, so
+  # it is the only place that explains a stream_attention outcome.
+  for log in daemon.out.log daemon.out.log.1 firmware-update.log; do
+    [[ -f "$support/logs/$log" ]] && tail -c 200000 "$support/logs/$log" > "$dir/$log" 2>/dev/null || true
+  done
+  launchctl print "gui/$(id -u)/shop.vibetv.control-center.runtime" > "$dir/launchctl-runtime.txt" 2>&1 || true
+  launchctl list > "$dir/launchctl-list.txt" 2>&1 || true
+}
 cleanup() {
+  collect_diagnostics || true
   [[ -z "$VIRTUAL_PID" ]] || kill "$VIRTUAL_PID" >/dev/null 2>&1 || true
   [[ -z "$HTTP_PID" ]] || kill "$HTTP_PID" >/dev/null 2>&1 || true
   launchctl unsetenv CODEXBAR_DISPLAY_FIRMWARE_MANIFEST_URL >/dev/null 2>&1 || true
+  launchctl unsetenv CODEXBAR_DISPLAY_MAC_APP_RELEASE_API_URL >/dev/null 2>&1 || true
   hdiutil detach "$CANDIDATE_MOUNT" -quiet >/dev/null 2>&1 || true
   hdiutil detach "$BASELINE_MOUNT" -quiet >/dev/null 2>&1 || true
   [[ ! -e "$INSTALL_APP" ]] || rm -rf "$INSTALL_APP" || true
@@ -176,6 +198,12 @@ else
   # environment at spawn, so it must be set before launchd starts any app or
   # runtime process on this guest.
   launchctl setenv CODEXBAR_DISPLAY_FIRMWARE_MANIFEST_URL "$SERVER_URL/firmware-manifest.json"
+  # The firmware-install gate fails closed when the Mac App release check does
+  # not answer, so the guest must provide a deterministic release feed: the
+  # public GitHub API would rate-limit shared CI runners. The feed announces
+  # exactly the candidate version, proving "app is current" honestly.
+  printf '{"tag_name": "v%s"}\n' "$VERSION" > "$WORK/serve/mac-app-release.json"
+  launchctl setenv CODEXBAR_DISPLAY_MAC_APP_RELEASE_API_URL "$SERVER_URL/mac-app-release.json"
   open -na "$INSTALL_APP"
   sleep 2
   BASELINE_PID="$(pgrep -f "$INSTALL_APP/Contents/MacOS/VibeTVControlCenter" | head -n1)"


### PR DESCRIPTION
## Summary
- add `collect_diagnostics` to `scripts/test-vibetv-hosted-guest.sh`: before cleanup deletes the installed app, capture `/v1/status`, `/v1/device`, `/v1/diagnostics`, the virtual VibeTV state, the runtime launchctl state, and the daemon logs (`daemon.out.log` is the file the runtime parses for stream health — the only place that explains a `stream_attention` outcome)
- serve a loopback `mac-app-release.json` announcing exactly the candidate version and point `CODEXBAR_DISPLAY_MAC_APP_RELEASE_API_URL` at it (cleanup unsets it), so the candidate's fail-closed Mac-App-first firmware gate gets a deterministic answer instead of risking GitHub API rate limits on shared runners

Both changes are extracted verbatim from PR #348's harness. The merge gate deliberately runs **main's** scripts against the candidate artifacts, so these improvements only help once they land on main: the baseline guest legs (`current_public`/`previous_public`) currently fail intermittently with `firmware_current_stream_attention` and the uploaded artifacts contain nothing that explains the stream state. Merging PR #348 later is conflict-free — its file content is identical.

## Tests
- `bash -n scripts/test-vibetv-hosted-guest.sh`
- Behavior only observable in the hosted guest jobs of `CODEX Test VibeTV Merge`

No release or tag is part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)