### PR TITLE
CODEX: Restore the executable bit for release-candidate guest binaries

### DIFF
--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -264,6 +264,9 @@ jobs:
       - name: Run full direct hosted macOS guest matrix
         run: |
           set -euo pipefail
+          # actions/download-artifact strips the executable bit; the harness
+          # refuses non-executable helper binaries (same chmod as the merge gate).
+          chmod +x candidate/test/virtual-vibetv candidate/test/codexbar-display
           version="$(python3 -c 'import json; print(json.load(open("candidate/candidate-manifest.json"))["version"])')"
           baseline_args=()
           current_firmware=0.0.0


### PR DESCRIPTION
## Summary
- the first `CODEX Test VibeTV Release Candidate` run with guest legs (31466400851) failed in all three states at `--virtual-vibetv must be executable`
- `actions/download-artifact` strips the executable bit; the merge gate restores it with a `chmod +x` before invoking the harness, this workflow never did
- add the identical `chmod` for `candidate/test/virtual-vibetv` and `candidate/test/codexbar-display`

## Tests
- Behavior only observable in the release-candidate guest jobs; next dispatch validates it

No release or tag is part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)