### PR TITLE
CODEX: Stamp the release candidate with the run id Sparkle can compare

### DIFF
--- a/.github/workflows/vibetv-release-candidate.yml
+++ b/.github/workflows/vibetv-release-candidate.yml
@@ -75,7 +75,7 @@ jobs:
           cp scripts/install.sh tmp/vibetv-rc/publish/install.sh
           cp scripts/install-control-center-companion-release.sh tmp/vibetv-rc/publish/install-control-center-companion.sh
           chmod +x tmp/vibetv-rc/publish/install*.sh
-          ./scripts/build-macos-control-center-app.sh --version "$version" --build "$GITHUB_RUN_NUMBER" --universal --companion-binary tmp/vibetv-rc/codexbar-display --output 'dist/macos/VibeTV Control Center.app'
+          ./scripts/build-macos-control-center-app.sh --version "$version" --build "$GITHUB_RUN_ID" --universal --companion-binary tmp/vibetv-rc/codexbar-display --output 'dist/macos/VibeTV Control Center.app'
           COPYFILE_DISABLE=1 tar -czf tmp/vibetv-rc/app.tar.gz -C dist/macos 'VibeTV Control Center.app'
           python3 - release/firmware-versions.json > tmp/vibetv-rc/firmware-targets.tsv <<'PY'
           import json, sys


### PR DESCRIPTION
## Summary
- third release-candidate failure mode, caught by the guest matrix as a genuine release blocker: Sparkle exited 4 ("no update") because the candidate's CFBundleVersion was `GITHUB_RUN_NUMBER` (~3) while the installed public 1.0.52 ships build 55 — Sparkle compares build numbers, so customers would never have been offered 1.0.53
- use the globally monotonic `GITHUB_RUN_ID` as the build, identical to the merge gate (`build="${GITHUB_RUN_ID}"`), which is why every merge-gate candidate updated fine

## Tests
- Behavior only observable in the release-candidate guest jobs; next dispatch validates it

No release or tag is part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)