### PR TITLE
CODEX: Make doctor transport-aware

### DIFF
--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -48,6 +48,14 @@ var displayWorkerRestartDelay = 5 * time.Second
 var openControlCenterStartLaunchAgentFn = startLaunchAgent
 var openControlCenterOpenURLFn = openURLWithMacOpen
 var openControlCenterHTTPClient = &http.Client{}
+var doctorListPortsFn = usb.ListPorts
+var doctorResolvePortFn = usb.ResolvePort
+var doctorProbePortFn = usb.ProbePort
+var doctorReadDeviceHelloFn = usb.ReadDeviceHello
+var doctorReadWiFiCapabilitiesFn = func(target string) (protocol.DeviceCapabilities, error) {
+	return transportlayer.NewWiFiTransportWithClient(nil).DeviceCapabilities(target)
+}
+var doctorCheckCompanionHealthFn = checkDoctorCompanionHealth
 
 var displayStreamSensitiveQueryPattern = regexp.MustCompile(`(?i)([?&](?:token|auth|key|secret)=)[^&\s"]+`)
 var displayStreamSensitiveUserInfoPattern = regexp.MustCompile(`(?i)(https?://)[^/@\s]+@`)
@@ -860,21 +868,11 @@ func runDoctor() error {
 		}
 	}
 
-	ports, err := usb.ListPorts()
-	if err != nil {
-		return fmt.Errorf("list serial ports: %w", err)
-	}
-
-	fmt.Println("Serial ports:")
-	if len(ports) == 0 {
-		fmt.Println("  (none)")
-	} else {
-		for _, p := range ports {
-			fmt.Printf("  %s\n", p)
-		}
-	}
-
-	if runtimeErr := runDoctorRuntimeChecks(ports); runtimeErr != nil {
+	runtimeConfig, configErr := readDoctorRuntimeConfig()
+	if configErr != nil {
+		fmt.Printf("Active runtime: unavailable (%v)\n", configErr)
+		doctorErrs = append(doctorErrs, fmt.Errorf("read active runtime configuration failed: %w", configErr))
+	} else if runtimeErr := runDoctorTransportChecks(runtimeConfig); runtimeErr != nil {
 		doctorErrs = append(doctorErrs, runtimeErr)
 	}
 
@@ -898,20 +896,115 @@ func runDoctor() error {
 	return nil
 }
 
-func runDoctorRuntimeChecks(ports []string) error {
+type doctorRuntimeConfig struct {
+	configured bool
+	transport  string
+	target     string
+	port       string
+}
+
+func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return doctorRuntimeConfig{}, err
+	}
+
+	for _, label := range []string{"shop.vibetv.control-center.runtime", "shop.vibetv.control-center.preview-runtime"} {
+		if doctorLaunchAgentLoaded(label) {
+			cfg, err := runtimeconfig.Load(home)
+			if err != nil {
+				return doctorRuntimeConfig{}, err
+			}
+			return doctorRuntimeConfig{configured: true, transport: "wifi", target: cfg.DeviceTarget}, nil
+		}
+	}
+
+	if !doctorLaunchAgentLoaded("com.codexbar-display.daemon") {
+		return doctorRuntimeConfig{}, nil
+	}
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.codexbar-display.daemon.plist")
+	data, err := os.ReadFile(plistPath)
+	if err != nil {
+		return doctorRuntimeConfig{}, err
+	}
+	plist := string(data)
+	transportName := strings.ToLower(parseLaunchAgentArgument(plist, "--transport"))
+	if transportName == "" {
+		if parseLaunchAgentArgument(plist, "--target") != "" {
+			transportName = "wifi"
+		} else {
+			transportName = "usb"
+		}
+	}
+	target := ""
+	if transportName == "wifi" {
+		cfg, err := runtimeconfig.Load(home)
+		if err != nil {
+			return doctorRuntimeConfig{}, err
+		}
+		target = cfg.DeviceTarget
+	}
+	return doctorRuntimeConfig{
+		configured: true,
+		transport:  transportName,
+		target:     target,
+		port:       parseLaunchAgentArgument(plist, "--port"),
+	}, nil
+}
+
+func doctorLaunchAgentLoaded(label string) bool {
+	service := fmt.Sprintf("gui/%d/%s", os.Getuid(), label)
+	return exec.Command("launchctl", "print", service).Run() == nil
+}
+
+func runDoctorTransportChecks(config doctorRuntimeConfig) error {
+	if !config.configured {
+		fmt.Println("Active runtime: not configured (run `codexbar-display setup`)")
+		fmt.Println("  available transports: wifi, usb")
+		return errors.New("runtime setup required: no active runtime configuration")
+	}
+
+	fmt.Printf("Active runtime: transport=%s\n", config.transport)
+	switch config.transport {
+	case "wifi":
+		fmt.Println("Serial ports: not applicable (active transport is WiFi)")
+		return runDoctorWiFiRuntimeChecks(config)
+	case "usb":
+		ports, err := doctorListPortsFn()
+		if err != nil {
+			return fmt.Errorf("list serial ports: %w", err)
+		}
+		fmt.Println("Serial ports:")
+		if len(ports) == 0 {
+			fmt.Println("  (none)")
+		} else {
+			for _, port := range ports {
+				fmt.Printf("  %s\n", port)
+			}
+		}
+		return runDoctorUSBRuntimeChecks(config, ports)
+	default:
+		return fmt.Errorf("runtime setup required: unsupported active transport %q", config.transport)
+	}
+}
+
+func printDoctorRuntimeDefaults() {
 	fmt.Println("Runtime checks:")
 	fmt.Printf("  codexbar timeout: %s\n", codexbar.CommandTimeout())
 	fmt.Printf("  last-good max age: %s\n", daemon.LastGoodMaxAge())
 	fmt.Printf("  sleep/wake threshold (@60s interval): %s\n", daemon.SleepWakeGapThreshold(60*time.Second))
+}
 
-	port, err := usb.ResolvePort("")
+func runDoctorUSBRuntimeChecks(config doctorRuntimeConfig, ports []string) error {
+	printDoctorRuntimeDefaults()
+	port, err := doctorResolvePortFn("")
 	if err != nil {
 		fmt.Printf("  serial resolve: failed (%v)\n", err)
 		return fmt.Errorf("runtime serial resolve failed: %w", err)
 	}
 	fmt.Printf("  serial resolve: ok (%s)\n", port)
 
-	if err := usb.ProbePort(port); err != nil {
+	if err := doctorProbePortFn(port); err != nil {
 		if errcode.Of(err) == errcode.TransportSerialCloseTimeout {
 			fmt.Printf("  serial probe: warning (%v)\n", err)
 		} else {
@@ -922,11 +1015,7 @@ func runDoctorRuntimeChecks(ports []string) error {
 		fmt.Printf("  serial probe: ok (%s)\n", port)
 	}
 
-	pinnedPort, err := doctorPinnedLaunchAgentPort()
-	if err != nil {
-		fmt.Printf("  launchagent port affinity: failed (%v)\n", err)
-		return fmt.Errorf("runtime launchagent affinity check failed: %w", err)
-	}
+	pinnedPort := config.port
 	if pinnedPort == "" {
 		fmt.Println("  launchagent port affinity: auto-detect")
 		if len(ports) > 1 {
@@ -945,24 +1034,50 @@ func runDoctorRuntimeChecks(ports []string) error {
 		}
 	}
 
-	hello, err := usb.ReadDeviceHello(port)
+	hello, err := doctorReadDeviceHelloFn(port)
 	if err != nil {
 		fmt.Printf("  device hello: warning (%v)\n", err)
 		fmt.Println("  warning: capability handshake unavailable; runtime will use optimistic theme send fallback")
 		return nil
 	}
 
-	caps := protocol.CapabilitiesFromHello(hello)
-	fmt.Printf("  device hello: ok board=%s protocol=%d negotiated=%d firmware=%s theme=%t themeSpecV1=%t maxFrameBytes=%d\n",
+	return reportDoctorCapabilities("device hello", protocol.CapabilitiesFromHello(hello))
+}
+
+func runDoctorWiFiRuntimeChecks(config doctorRuntimeConfig) error {
+	printDoctorRuntimeDefaults()
+	target := strings.TrimSpace(config.target)
+	fmt.Println("  launchagent port affinity: not applicable (active transport is WiFi)")
+	if target == "" {
+		fmt.Println("  WiFi device target: unavailable (connect VibeTV in Control Center)")
+		return errors.New("runtime WiFi target unavailable: connect VibeTV in Control Center")
+	}
+	fmt.Printf("  WiFi device target: %s\n", target)
+	if err := doctorCheckCompanionHealthFn(); err != nil {
+		fmt.Printf("  Companion health: failed (%v)\n", err)
+		return fmt.Errorf("runtime Companion health failed: %w", err)
+	}
+	fmt.Println("  Companion health: ok")
+	caps, err := doctorReadWiFiCapabilitiesFn(target)
+	if err != nil {
+		fmt.Printf("  WiFi device reachability: failed (%v)\n", err)
+		return fmt.Errorf("runtime WiFi device reachability failed: %w", err)
+	}
+	return reportDoctorCapabilities("WiFi device reachability", caps)
+}
+
+func reportDoctorCapabilities(label string, caps protocol.DeviceCapabilities) error {
+	fmt.Printf("  %s: ok board=%s protocol=%d negotiated=%d firmware=%s theme=%t themeSpecV1=%t maxFrameBytes=%d\n",
+		label,
 		caps.Board,
 		caps.ProtocolVersion,
 		caps.NegotiatedProtocolVersion,
-		hello.Firmware,
+		caps.Firmware,
 		caps.SupportsTheme,
 		caps.SupportsThemeSpecV1,
 		caps.MaxFrameBytes)
 	if len(caps.SupportedProtocolVersions) > 0 {
-		fmt.Printf("  device hello protocols: %v (preferred=%d)\n", caps.SupportedProtocolVersions, caps.PreferredProtocolVersion)
+		fmt.Printf("  %s protocols: %v (preferred=%d)\n", label, caps.SupportedProtocolVersions, caps.PreferredProtocolVersion)
 	}
 	if !caps.Known {
 		fmt.Println("  warning: device capabilities are unknown; skipping strict hardware/theme contract checks")
@@ -987,6 +1102,40 @@ func runDoctorRuntimeChecks(ports []string) error {
 		)
 	}
 
+	return nil
+}
+
+func checkDoctorCompanionHealth() error {
+	origin := "http://" + companionapi.DefaultAddr
+	if home, err := os.UserHomeDir(); err == nil {
+		if data, err := os.ReadFile(runtimeEndpointPath(home)); err == nil {
+			var endpoint runtimeEndpoint
+			if json.Unmarshal(data, &endpoint) == nil {
+				if published := strings.TrimSpace(endpoint.Origin); published != "" {
+					origin = published
+				}
+			}
+		}
+	}
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	response, err := client.Get(strings.TrimRight(origin, "/") + "/v1/runtime-health")
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", response.StatusCode)
+	}
+	var result struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, 64<<10)).Decode(&result); err != nil {
+		return err
+	}
+	if !result.OK {
+		return errors.New("runtime health reported not ok")
+	}
 	return nil
 }
 
@@ -1873,24 +2022,12 @@ func containsPort(ports []string, target string) bool {
 	return false
 }
 
-func doctorPinnedLaunchAgentPort() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.codexbar-display.daemon.plist")
-	data, err := os.ReadFile(plistPath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", nil
-		}
-		return "", err
-	}
-	return parsePinnedPortFromLaunchAgentPlist(string(data)), nil
+func parsePinnedPortFromLaunchAgentPlist(plist string) string {
+	return parseLaunchAgentArgument(plist, "--port")
 }
 
-func parsePinnedPortFromLaunchAgentPlist(plist string) string {
-	const marker = "<string>--port</string>"
+func parseLaunchAgentArgument(plist, name string) string {
+	marker := "<string>" + name + "</string>"
 	idx := strings.Index(plist, marker)
 	if idx < 0 {
 		return ""

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -927,7 +927,7 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 				label:       label,
 				transport:   "wifi",
 				target:      cfg.DeviceTarget,
-				probeTarget: doctorWiFiProbeTarget(cfg.DeviceTarget, cfg),
+				probeTarget: doctorWiFiProbeTarget(cfg.DeviceTarget, cfg, false),
 			}, nil
 		}
 	}
@@ -957,7 +957,7 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 			return doctorRuntimeConfig{}, err
 		}
 		target = doctorWiFiTarget(cfg.DeviceTarget, parseLaunchAgentArgument(plist, "--target"))
-		probeTarget = doctorWiFiProbeTarget(target, cfg)
+		probeTarget = doctorWiFiProbeTarget(target, cfg, true)
 	}
 	return doctorRuntimeConfig{
 		configured:  true,
@@ -1014,7 +1014,7 @@ func doctorWiFiTarget(configTarget, plistTarget string) string {
 	return strings.TrimSpace(plistTarget)
 }
 
-func doctorWiFiProbeTarget(target string, cfg runtimeconfig.Config) string {
+func doctorWiFiProbeTarget(target string, cfg runtimeconfig.Config, allowInlineToken bool) string {
 	publicTarget := publicDeviceTargetForConfig(target)
 	if publicTarget == "" {
 		return strings.TrimSpace(target)
@@ -1023,7 +1023,10 @@ func doctorWiFiProbeTarget(target string, cfg runtimeconfig.Config) string {
 		(strings.TrimSpace(cfg.DeviceTarget) == "" || sameCommandDeviceTarget(publicTarget, cfg.DeviceTarget)) {
 		return targetWithRequiredQueryToken(publicTarget, cfg.DeviceToken)
 	}
-	return strings.TrimSpace(target)
+	if allowInlineToken {
+		return strings.TrimSpace(target)
+	}
+	return publicTarget
 }
 
 func runDoctorTransportChecks(config doctorRuntimeConfig) error {

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"flag"
 	"fmt"
@@ -1018,7 +1019,8 @@ func doctorWiFiProbeTarget(target string, cfg runtimeconfig.Config) string {
 	if publicTarget == "" {
 		return strings.TrimSpace(target)
 	}
-	if sameCommandDeviceTarget(publicTarget, cfg.DeviceTarget) && strings.TrimSpace(cfg.DeviceToken) != "" {
+	if strings.TrimSpace(cfg.DeviceToken) != "" &&
+		(strings.TrimSpace(cfg.DeviceTarget) == "" || sameCommandDeviceTarget(publicTarget, cfg.DeviceTarget)) {
 		return targetWithQueryToken(publicTarget, cfg.DeviceToken)
 	}
 	for _, known := range cfg.KnownDevices {
@@ -1660,9 +1662,6 @@ func targetWithQueryToken(target, token string) string {
 		return strings.TrimSpace(target)
 	}
 	query := parsed.Query()
-	if strings.TrimSpace(query.Get("token")) != "" {
-		return parsed.String()
-	}
 	query.Set("token", token)
 	parsed.RawQuery = query.Encode()
 	return parsed.String()
@@ -2154,5 +2153,13 @@ func parseLaunchAgentArgument(plist, name string) string {
 	if end < 0 {
 		return ""
 	}
-	return strings.TrimSpace(rest[:end])
+	return strings.TrimSpace(xmlUnescape(rest[:end]))
+}
+
+func xmlUnescape(value string) string {
+	var decoded string
+	if err := xml.Unmarshal([]byte("<string>"+value+"</string>"), &decoded); err != nil {
+		return value
+	}
+	return decoded
 }

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -1101,7 +1101,7 @@ func runDoctorWiFiRuntimeChecks(config doctorRuntimeConfig) error {
 		fmt.Println("  WiFi device target: unavailable (connect VibeTV in Control Center)")
 		return errors.New("runtime WiFi target unavailable: connect VibeTV in Control Center")
 	}
-	fmt.Printf("  WiFi device target: %s\n", target)
+	fmt.Printf("  WiFi device target: %s\n", doctorPublicWiFiTarget(target))
 	if err := doctorCheckCompanionHealthFn(); err != nil {
 		fmt.Printf("  Companion health: failed (%v)\n", err)
 		return fmt.Errorf("runtime Companion health failed: %w", err)
@@ -1117,6 +1117,10 @@ func runDoctorWiFiRuntimeChecks(config doctorRuntimeConfig) error {
 		return fmt.Errorf("runtime WiFi device reachability failed: %w", err)
 	}
 	return reportDoctorCapabilities("WiFi device reachability", caps)
+}
+
+func doctorPublicWiFiTarget(target string) string {
+	return publicDeviceTargetForConfig(target)
 }
 
 func reportDoctorCapabilities(label string, caps protocol.DeviceCapabilities) error {

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -916,7 +916,7 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 	}
 
 	for _, label := range []string{"shop.vibetv.control-center.runtime", "shop.vibetv.control-center.preview-runtime"} {
-		if _, err := doctorLaunchAgentPrintFn(label); err == nil {
+		if output, err := doctorLaunchAgentPrintFn(label); err == nil && doctorLaunchAgentStateHealthy(string(output)) {
 			cfg, err := runtimeconfig.Load(home)
 			if err != nil {
 				return doctorRuntimeConfig{}, err
@@ -932,7 +932,7 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 	}
 
 	launchctlOutput, err := doctorLaunchAgentPrintFn("com.codexbar-display.daemon")
-	if err != nil {
+	if err != nil || !doctorLaunchAgentStateHealthy(string(launchctlOutput)) {
 		return doctorRuntimeConfig{}, nil
 	}
 	data, err := readDoctorLegacyLaunchAgentPlist(home, string(launchctlOutput), os.ReadFile)
@@ -998,6 +998,12 @@ func parseDoctorLaunchAgentPath(output string) string {
 		}
 	}
 	return ""
+}
+
+func doctorLaunchAgentStateHealthy(output string) bool {
+	return strings.Contains(output, "state = running") ||
+		strings.Contains(output, "state = waiting") ||
+		strings.Contains(output, "state = spawn scheduled")
 }
 
 func doctorWiFiTarget(configTarget, plistTarget string) string {
@@ -1141,7 +1147,7 @@ func runDoctorWiFiRuntimeChecks(config doctorRuntimeConfig) error {
 }
 
 func doctorPublicWiFiTarget(target string) string {
-	return publicDeviceTargetForConfig(target)
+	return sanitizeDisplayStreamLogMessage(publicDeviceTargetForConfig(target))
 }
 
 func reportDoctorCapabilities(label string, caps protocol.DeviceCapabilities) error {

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -924,6 +924,7 @@ type doctorRuntimeConfig struct {
 	transport   string
 	target      string
 	probeTarget string
+	authReady   bool
 	port        string
 }
 
@@ -945,6 +946,7 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 				transport:   "wifi",
 				target:      cfg.DeviceTarget,
 				probeTarget: doctorWiFiProbeTarget(cfg.DeviceTarget, cfg, false),
+				authReady:   strings.TrimSpace(cfg.DeviceToken) != "",
 			}, nil
 		}
 	}
@@ -982,6 +984,7 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 		transport:   transportName,
 		target:      target,
 		probeTarget: probeTarget,
+		authReady:   true,
 		port:        parseLaunchAgentArgument(plist, "--port"),
 	}, nil
 }
@@ -1142,6 +1145,10 @@ func runDoctorWiFiRuntimeChecks(config doctorRuntimeConfig) error {
 		return errors.New("runtime WiFi target unavailable: connect VibeTV in Control Center")
 	}
 	fmt.Printf("  WiFi device target: %s\n", doctorPublicWiFiTarget(target))
+	if !config.authReady {
+		fmt.Println("  WiFi device credential: unavailable (reconnect VibeTV in Control Center)")
+		return errors.New("runtime WiFi credential unavailable: reconnect VibeTV in Control Center")
+	}
 	if err := doctorCheckCompanionHealthFn(config.label); err != nil {
 		fmt.Printf("  Companion health: failed (%v)\n", err)
 		return fmt.Errorf("runtime Companion health failed: %w", err)
@@ -1259,6 +1266,10 @@ func checkDoctorCompanionHealthOrigins(origins []string, expectedOwner string) e
 			continue
 		}
 		owner := strings.TrimSpace(result.Companion.Runtime.ListenerOwner)
+		if owner == "" && expectedOwner != "" && expectedOwner != runtimepaths.LegacyDisplayStreamLaunchAgentLabel {
+			lastErr = errors.New("runtime health did not identify its listener owner")
+			continue
+		}
 		if owner != "" && expectedOwner != "" && owner != expectedOwner {
 			lastErr = fmt.Errorf("runtime health belongs to %q, expected %q", owner, expectedOwner)
 			continue

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -1021,11 +1021,11 @@ func doctorWiFiProbeTarget(target string, cfg runtimeconfig.Config) string {
 	}
 	if strings.TrimSpace(cfg.DeviceToken) != "" &&
 		(strings.TrimSpace(cfg.DeviceTarget) == "" || sameCommandDeviceTarget(publicTarget, cfg.DeviceTarget)) {
-		return targetWithQueryToken(publicTarget, cfg.DeviceToken)
+		return targetWithRequiredQueryToken(publicTarget, cfg.DeviceToken)
 	}
 	for _, known := range cfg.KnownDevices {
 		if sameCommandDeviceTarget(publicTarget, known.Target) && strings.TrimSpace(known.DeviceToken) != "" {
-			return targetWithQueryToken(publicTarget, known.DeviceToken)
+			return targetWithRequiredQueryToken(publicTarget, known.DeviceToken)
 		}
 	}
 	return strings.TrimSpace(target)
@@ -1653,6 +1653,24 @@ func sameCommandDeviceTarget(left, right string) bool {
 }
 
 func targetWithQueryToken(target, token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return strings.TrimSpace(target)
+	}
+	parsed, ok := parseCommandDeviceTarget(target)
+	if !ok {
+		return strings.TrimSpace(target)
+	}
+	query := parsed.Query()
+	if strings.TrimSpace(query.Get("token")) != "" {
+		return parsed.String()
+	}
+	query.Set("token", token)
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+func targetWithRequiredQueryToken(target, token string) string {
 	token = strings.TrimSpace(token)
 	if token == "" {
 		return strings.TrimSpace(target)

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -1188,7 +1188,8 @@ func checkDoctorCompanionHealthOrigins(origins []string) error {
 			continue
 		}
 		var result struct {
-			OK bool `json:"ok"`
+			OK            bool  `json:"ok"`
+			DisplayWriter *bool `json:"displayWriter"`
 		}
 		decodeErr := json.NewDecoder(io.LimitReader(response.Body, 64<<10)).Decode(&result)
 		_ = response.Body.Close()
@@ -1202,6 +1203,10 @@ func checkDoctorCompanionHealthOrigins(origins []string) error {
 		}
 		if !result.OK {
 			lastErr = errors.New("runtime health reported not ok")
+			continue
+		}
+		if result.DisplayWriter != nil && !*result.DisplayWriter {
+			lastErr = errors.New("runtime health reported no display writer")
 			continue
 		}
 		return nil

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -998,7 +998,7 @@ func doctorWiFiProbeTarget(target string, cfg runtimeconfig.Config) string {
 			return targetWithQueryToken(publicTarget, known.DeviceToken)
 		}
 	}
-	return publicTarget
+	return strings.TrimSpace(target)
 }
 
 func doctorLaunchAgentLoaded(label string) bool {
@@ -1115,6 +1115,10 @@ func runDoctorWiFiRuntimeChecks(config doctorRuntimeConfig) error {
 	if err != nil {
 		fmt.Printf("  WiFi device reachability: failed (%v)\n", err)
 		return fmt.Errorf("runtime WiFi device reachability failed: %w", err)
+	}
+	if !caps.Known {
+		fmt.Println("  WiFi device reachability: failed (device capabilities unknown)")
+		return errors.New("runtime WiFi device reachability failed: device capabilities unknown")
 	}
 	return reportDoctorCapabilities("WiFi device reachability", caps)
 }

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -1090,7 +1090,7 @@ func printDoctorRuntimeDefaults() {
 
 func runDoctorUSBRuntimeChecks(config doctorRuntimeConfig, ports []string) error {
 	printDoctorRuntimeDefaults()
-	port, err := doctorResolvePortFn("")
+	port, err := doctorResolvePortFn(config.port)
 	if err != nil {
 		fmt.Printf("  serial resolve: failed (%v)\n", err)
 		return fmt.Errorf("runtime serial resolve failed: %w", err)

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -902,6 +902,7 @@ func runDoctor() error {
 
 type doctorRuntimeConfig struct {
 	configured  bool
+	label       string
 	transport   string
 	target      string
 	probeTarget string
@@ -922,6 +923,7 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 			}
 			return doctorRuntimeConfig{
 				configured:  true,
+				label:       label,
 				transport:   "wifi",
 				target:      cfg.DeviceTarget,
 				probeTarget: doctorWiFiProbeTarget(cfg.DeviceTarget, cfg),
@@ -958,6 +960,7 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 	}
 	return doctorRuntimeConfig{
 		configured:  true,
+		label:       "com.codexbar-display.daemon",
 		transport:   transportName,
 		target:      target,
 		probeTarget: probeTarget,
@@ -1116,7 +1119,7 @@ func runDoctorWiFiRuntimeChecks(config doctorRuntimeConfig) error {
 		return errors.New("runtime WiFi target unavailable: connect VibeTV in Control Center")
 	}
 	fmt.Printf("  WiFi device target: %s\n", doctorPublicWiFiTarget(target))
-	if err := doctorCheckCompanionHealthFn(); err != nil {
+	if err := doctorCheckCompanionHealthFn(config.label); err != nil {
 		fmt.Printf("  Companion health: failed (%v)\n", err)
 		return fmt.Errorf("runtime Companion health failed: %w", err)
 	}
@@ -1180,7 +1183,7 @@ func reportDoctorCapabilities(label string, caps protocol.DeviceCapabilities) er
 	return nil
 }
 
-func checkDoctorCompanionHealth() error {
+func checkDoctorCompanionHealth(expectedOwner string) error {
 	defaultOrigin := "http://" + companionapi.DefaultAddr
 	origins := []string{defaultOrigin}
 	if home, err := os.UserHomeDir(); err == nil {
@@ -1193,10 +1196,10 @@ func checkDoctorCompanionHealth() error {
 			}
 		}
 	}
-	return checkDoctorCompanionHealthOrigins(origins)
+	return checkDoctorCompanionHealthOrigins(origins, expectedOwner)
 }
 
-func checkDoctorCompanionHealthOrigins(origins []string) error {
+func checkDoctorCompanionHealthOrigins(origins []string, expectedOwner string) error {
 	client := &http.Client{Timeout: 3 * time.Second}
 	var lastErr error
 	for _, origin := range origins {
@@ -1208,6 +1211,11 @@ func checkDoctorCompanionHealthOrigins(origins []string) error {
 		var result struct {
 			OK            bool  `json:"ok"`
 			DisplayWriter *bool `json:"displayWriter"`
+			Companion     struct {
+				Runtime struct {
+					ListenerOwner string `json:"listenerOwner"`
+				} `json:"runtime"`
+			} `json:"companion"`
 		}
 		decodeErr := json.NewDecoder(io.LimitReader(response.Body, 64<<10)).Decode(&result)
 		_ = response.Body.Close()
@@ -1225,6 +1233,11 @@ func checkDoctorCompanionHealthOrigins(origins []string) error {
 		}
 		if result.DisplayWriter != nil && !*result.DisplayWriter {
 			lastErr = errors.New("runtime health reported no display writer")
+			continue
+		}
+		owner := strings.TrimSpace(result.Companion.Runtime.ListenerOwner)
+		if owner != "" && expectedOwner != "" && owner != expectedOwner {
+			lastErr = fmt.Errorf("runtime health belongs to %q, expected %q", owner, expectedOwner)
 			continue
 		}
 		return nil

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -897,10 +897,11 @@ func runDoctor() error {
 }
 
 type doctorRuntimeConfig struct {
-	configured bool
-	transport  string
-	target     string
-	port       string
+	configured  bool
+	transport   string
+	target      string
+	probeTarget string
+	port        string
 }
 
 func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
@@ -915,15 +916,19 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 			if err != nil {
 				return doctorRuntimeConfig{}, err
 			}
-			return doctorRuntimeConfig{configured: true, transport: "wifi", target: cfg.DeviceTarget}, nil
+			return doctorRuntimeConfig{
+				configured:  true,
+				transport:   "wifi",
+				target:      cfg.DeviceTarget,
+				probeTarget: doctorWiFiProbeTarget(cfg.DeviceTarget, cfg),
+			}, nil
 		}
 	}
 
 	if !doctorLaunchAgentLoaded("com.codexbar-display.daemon") {
 		return doctorRuntimeConfig{}, nil
 	}
-	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.codexbar-display.daemon.plist")
-	data, err := os.ReadFile(plistPath)
+	data, err := readDoctorLegacyLaunchAgentPlist(home, os.ReadFile)
 	if err != nil {
 		return doctorRuntimeConfig{}, err
 	}
@@ -937,19 +942,40 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 		}
 	}
 	target := ""
+	probeTarget := ""
 	if transportName == "wifi" {
 		cfg, err := runtimeconfig.Load(home)
 		if err != nil {
 			return doctorRuntimeConfig{}, err
 		}
 		target = doctorWiFiTarget(cfg.DeviceTarget, parseLaunchAgentArgument(plist, "--target"))
+		probeTarget = doctorWiFiProbeTarget(target, cfg)
 	}
 	return doctorRuntimeConfig{
-		configured: true,
-		transport:  transportName,
-		target:     target,
-		port:       parseLaunchAgentArgument(plist, "--port"),
+		configured:  true,
+		transport:   transportName,
+		target:      target,
+		probeTarget: probeTarget,
+		port:        parseLaunchAgentArgument(plist, "--port"),
 	}, nil
+}
+
+func readDoctorLegacyLaunchAgentPlist(home string, readFile func(string) ([]byte, error)) ([]byte, error) {
+	name := "com.codexbar-display.daemon.plist"
+	paths := []string{
+		filepath.Join(home, "Library", "LaunchAgents", name),
+		filepath.Join("/Library", "LaunchAgents", name),
+	}
+	for _, path := range paths {
+		data, err := readFile(path)
+		if err == nil {
+			return data, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	}
+	return nil, os.ErrNotExist
 }
 
 func doctorWiFiTarget(configTarget, plistTarget string) string {
@@ -957,6 +983,22 @@ func doctorWiFiTarget(configTarget, plistTarget string) string {
 		return target
 	}
 	return strings.TrimSpace(plistTarget)
+}
+
+func doctorWiFiProbeTarget(target string, cfg runtimeconfig.Config) string {
+	publicTarget := publicDeviceTargetForConfig(target)
+	if publicTarget == "" {
+		return strings.TrimSpace(target)
+	}
+	if sameCommandDeviceTarget(publicTarget, cfg.DeviceTarget) && strings.TrimSpace(cfg.DeviceToken) != "" {
+		return targetWithQueryToken(publicTarget, cfg.DeviceToken)
+	}
+	for _, known := range cfg.KnownDevices {
+		if sameCommandDeviceTarget(publicTarget, known.Target) && strings.TrimSpace(known.DeviceToken) != "" {
+			return targetWithQueryToken(publicTarget, known.DeviceToken)
+		}
+	}
+	return publicTarget
 }
 
 func doctorLaunchAgentLoaded(label string) bool {
@@ -1065,7 +1107,11 @@ func runDoctorWiFiRuntimeChecks(config doctorRuntimeConfig) error {
 		return fmt.Errorf("runtime Companion health failed: %w", err)
 	}
 	fmt.Println("  Companion health: ok")
-	caps, err := doctorReadWiFiCapabilitiesFn(target)
+	probeTarget := strings.TrimSpace(config.probeTarget)
+	if probeTarget == "" {
+		probeTarget = target
+	}
+	caps, err := doctorReadWiFiCapabilitiesFn(probeTarget)
 	if err != nil {
 		fmt.Printf("  WiFi device reachability: failed (%v)\n", err)
 		return fmt.Errorf("runtime WiFi device reachability failed: %w", err)

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -56,6 +56,10 @@ var doctorReadWiFiCapabilitiesFn = func(target string) (protocol.DeviceCapabilit
 	return transportlayer.NewWiFiTransportWithClient(nil).DeviceCapabilities(target)
 }
 var doctorCheckCompanionHealthFn = checkDoctorCompanionHealth
+var doctorLaunchAgentPrintFn = func(label string) ([]byte, error) {
+	service := fmt.Sprintf("gui/%d/%s", os.Getuid(), label)
+	return exec.Command("launchctl", "print", service).CombinedOutput()
+}
 
 var displayStreamSensitiveQueryPattern = regexp.MustCompile(`(?i)([?&](?:token|auth|key|secret)=)[^&\s"]+`)
 var displayStreamSensitiveUserInfoPattern = regexp.MustCompile(`(?i)(https?://)[^/@\s]+@`)
@@ -911,7 +915,7 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 	}
 
 	for _, label := range []string{"shop.vibetv.control-center.runtime", "shop.vibetv.control-center.preview-runtime"} {
-		if doctorLaunchAgentLoaded(label) {
+		if _, err := doctorLaunchAgentPrintFn(label); err == nil {
 			cfg, err := runtimeconfig.Load(home)
 			if err != nil {
 				return doctorRuntimeConfig{}, err
@@ -925,10 +929,11 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 		}
 	}
 
-	if !doctorLaunchAgentLoaded("com.codexbar-display.daemon") {
+	launchctlOutput, err := doctorLaunchAgentPrintFn("com.codexbar-display.daemon")
+	if err != nil {
 		return doctorRuntimeConfig{}, nil
 	}
-	data, err := readDoctorLegacyLaunchAgentPlist(home, os.ReadFile)
+	data, err := readDoctorLegacyLaunchAgentPlist(home, string(launchctlOutput), os.ReadFile)
 	if err != nil {
 		return doctorRuntimeConfig{}, err
 	}
@@ -960,13 +965,17 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 	}, nil
 }
 
-func readDoctorLegacyLaunchAgentPlist(home string, readFile func(string) ([]byte, error)) ([]byte, error) {
+func readDoctorLegacyLaunchAgentPlist(home, launchctlOutput string, readFile func(string) ([]byte, error)) ([]byte, error) {
 	name := "com.codexbar-display.daemon.plist"
-	paths := []string{
+	paths := []string{parseDoctorLaunchAgentPath(launchctlOutput)}
+	paths = append(paths,
 		filepath.Join(home, "Library", "LaunchAgents", name),
 		filepath.Join("/Library", "LaunchAgents", name),
-	}
+	)
 	for _, path := range paths {
+		if path == "" {
+			continue
+		}
 		data, err := readFile(path)
 		if err == nil {
 			return data, nil
@@ -976,6 +985,16 @@ func readDoctorLegacyLaunchAgentPlist(home string, readFile func(string) ([]byte
 		}
 	}
 	return nil, os.ErrNotExist
+}
+
+func parseDoctorLaunchAgentPath(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "path = ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "path = "))
+		}
+	}
+	return ""
 }
 
 func doctorWiFiTarget(configTarget, plistTarget string) string {
@@ -999,11 +1018,6 @@ func doctorWiFiProbeTarget(target string, cfg runtimeconfig.Config) string {
 		}
 	}
 	return strings.TrimSpace(target)
-}
-
-func doctorLaunchAgentLoaded(label string) bool {
-	service := fmt.Sprintf("gui/%d/%s", os.Getuid(), label)
-	return exec.Command("launchctl", "print", service).Run() == nil
 }
 
 func runDoctorTransportChecks(config doctorRuntimeConfig) error {

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -1023,11 +1023,6 @@ func doctorWiFiProbeTarget(target string, cfg runtimeconfig.Config) string {
 		(strings.TrimSpace(cfg.DeviceTarget) == "" || sameCommandDeviceTarget(publicTarget, cfg.DeviceTarget)) {
 		return targetWithRequiredQueryToken(publicTarget, cfg.DeviceToken)
 	}
-	for _, known := range cfg.KnownDevices {
-		if sameCommandDeviceTarget(publicTarget, known.Target) && strings.TrimSpace(known.DeviceToken) != "" {
-			return targetWithRequiredQueryToken(publicTarget, known.DeviceToken)
-		}
-	}
 	return strings.TrimSpace(target)
 }
 

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -54,7 +54,11 @@ var doctorResolvePortFn = usb.ResolvePort
 var doctorProbePortFn = usb.ProbePort
 var doctorReadDeviceHelloFn = usb.ReadDeviceHello
 var doctorReadWiFiCapabilitiesFn = func(target string) (protocol.DeviceCapabilities, error) {
-	return transportlayer.NewWiFiTransportWithClient(nil).DeviceCapabilities(target)
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: doctorAuthRoundTripper{token: deviceTokenFromCommandTarget(target)},
+	}
+	return transportlayer.NewWiFiTransportWithClient(client).DeviceCapabilities(target)
 }
 var doctorCheckCompanionHealthFn = checkDoctorCompanionHealth
 var doctorLaunchAgentPrintFn = func(label string) ([]byte, error) {
@@ -64,6 +68,19 @@ var doctorLaunchAgentPrintFn = func(label string) ([]byte, error) {
 
 var displayStreamSensitiveQueryPattern = regexp.MustCompile(`(?i)([?&](?:token|auth|key|secret)=)[^&\s"]+`)
 var displayStreamSensitiveUserInfoPattern = regexp.MustCompile(`(?i)(https?://)[^/@\s]+@`)
+
+type doctorAuthRoundTripper struct {
+	token string
+}
+
+func (t doctorAuthRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	request = request.Clone(request.Context())
+	request.Header.Del("X-VibeTV-Token")
+	if token := strings.TrimSpace(t.token); token != "" {
+		request.Header.Set("X-VibeTV-Token", token)
+	}
+	return http.DefaultTransport.RoundTrip(request)
+}
 
 func main() {
 	args := os.Args[1:]
@@ -1708,6 +1725,14 @@ func parseCommandDeviceTarget(target string) (*url.URL, bool) {
 		return nil, false
 	}
 	return parsed, true
+}
+
+func deviceTokenFromCommandTarget(target string) string {
+	parsed, ok := parseCommandDeviceTarget(target)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(parsed.Query().Get("token"))
 }
 
 var themePackInstallFirmwareUpdateFn = runThemePackInstallFirmwareUpdate

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -942,7 +942,7 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 		if err != nil {
 			return doctorRuntimeConfig{}, err
 		}
-		target = cfg.DeviceTarget
+		target = doctorWiFiTarget(cfg.DeviceTarget, parseLaunchAgentArgument(plist, "--target"))
 	}
 	return doctorRuntimeConfig{
 		configured: true,
@@ -950,6 +950,13 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 		target:     target,
 		port:       parseLaunchAgentArgument(plist, "--port"),
 	}, nil
+}
+
+func doctorWiFiTarget(configTarget, plistTarget string) string {
+	if target := strings.TrimSpace(configTarget); target != "" {
+		return target
+	}
+	return strings.TrimSpace(plistTarget)
 }
 
 func doctorLaunchAgentLoaded(label string) bool {
@@ -1106,37 +1113,50 @@ func reportDoctorCapabilities(label string, caps protocol.DeviceCapabilities) er
 }
 
 func checkDoctorCompanionHealth() error {
-	origin := "http://" + companionapi.DefaultAddr
+	defaultOrigin := "http://" + companionapi.DefaultAddr
+	origins := []string{defaultOrigin}
 	if home, err := os.UserHomeDir(); err == nil {
 		if data, err := os.ReadFile(runtimeEndpointPath(home)); err == nil {
 			var endpoint runtimeEndpoint
 			if json.Unmarshal(data, &endpoint) == nil {
-				if published := strings.TrimSpace(endpoint.Origin); published != "" {
-					origin = published
+				if published := strings.TrimSpace(endpoint.Origin); published != "" && published != defaultOrigin {
+					origins = append([]string{published}, origins...)
 				}
 			}
 		}
 	}
+	return checkDoctorCompanionHealthOrigins(origins)
+}
 
+func checkDoctorCompanionHealthOrigins(origins []string) error {
 	client := &http.Client{Timeout: 3 * time.Second}
-	response, err := client.Get(strings.TrimRight(origin, "/") + "/v1/runtime-health")
-	if err != nil {
-		return err
+	var lastErr error
+	for _, origin := range origins {
+		response, err := client.Get(strings.TrimRight(origin, "/") + "/v1/runtime-health")
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		var result struct {
+			OK bool `json:"ok"`
+		}
+		decodeErr := json.NewDecoder(io.LimitReader(response.Body, 64<<10)).Decode(&result)
+		_ = response.Body.Close()
+		if response.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("HTTP %d", response.StatusCode)
+			continue
+		}
+		if decodeErr != nil {
+			lastErr = decodeErr
+			continue
+		}
+		if !result.OK {
+			lastErr = errors.New("runtime health reported not ok")
+			continue
+		}
+		return nil
 	}
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf("HTTP %d", response.StatusCode)
-	}
-	var result struct {
-		OK bool `json:"ok"`
-	}
-	if err := json.NewDecoder(io.LimitReader(response.Body, 64<<10)).Decode(&result); err != nil {
-		return err
-	}
-	if !result.OK {
-		return errors.New("runtime health reported not ok")
-	}
-	return nil
+	return lastErr
 }
 
 func runSetup(args []string) error {

--- a/companion/cmd/codexbar-display/main.go
+++ b/companion/cmd/codexbar-display/main.go
@@ -940,13 +940,14 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 			if err != nil {
 				return doctorRuntimeConfig{}, err
 			}
+			probeTarget := doctorWiFiProbeTarget(cfg.DeviceTarget, cfg, false)
 			return doctorRuntimeConfig{
 				configured:  true,
 				label:       label,
 				transport:   "wifi",
 				target:      cfg.DeviceTarget,
-				probeTarget: doctorWiFiProbeTarget(cfg.DeviceTarget, cfg, false),
-				authReady:   strings.TrimSpace(cfg.DeviceToken) != "",
+				probeTarget: probeTarget,
+				authReady:   deviceTokenFromCommandTarget(probeTarget) != "",
 			}, nil
 		}
 	}
@@ -984,7 +985,7 @@ func readDoctorRuntimeConfig() (doctorRuntimeConfig, error) {
 		transport:   transportName,
 		target:      target,
 		probeTarget: probeTarget,
-		authReady:   true,
+		authReady:   transportName != "wifi" || deviceTokenFromCommandTarget(probeTarget) != "",
 		port:        parseLaunchAgentArgument(plist, "--port"),
 	}, nil
 }

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -61,25 +61,28 @@ func TestDoctorWiFiProbeTargetUsesTokenOnlyForMatchingDevice(t *testing.T) {
 		DeviceTarget: "http://192.0.2.10",
 		DeviceToken:  "saved-token",
 	}
-	if got := doctorWiFiProbeTarget("http://192.0.2.10", cfg); !strings.Contains(got, "token=saved-token") {
+	if got := doctorWiFiProbeTarget("http://192.0.2.10", cfg, false); !strings.Contains(got, "token=saved-token") {
 		t.Fatalf("expected matching target token, got %q", got)
 	}
-	if got := doctorWiFiProbeTarget("http://192.0.2.11", cfg); strings.Contains(got, "token=") {
+	if got := doctorWiFiProbeTarget("http://192.0.2.11", cfg, false); strings.Contains(got, "token=") {
 		t.Fatalf("must not send token to another target, got %q", got)
 	}
 	legacyTarget := "http://192.0.2.12?token=legacy-token"
-	if got := doctorWiFiProbeTarget(legacyTarget, runtimeconfig.Config{}); got != legacyTarget {
+	if got := doctorWiFiProbeTarget(legacyTarget, runtimeconfig.Config{}, true); got != legacyTarget {
 		t.Fatalf("expected legacy inline token to remain private probe credential, got %q", got)
 	}
+	if got := doctorWiFiProbeTarget(legacyTarget, runtimeconfig.Config{}, false); strings.Contains(got, "token=") {
+		t.Fatalf("app-managed probe must not use inline-only token, got %q", got)
+	}
 	cfg = runtimeconfig.Config{DeviceToken: "saved-token"}
-	if got := doctorWiFiProbeTarget(legacyTarget, cfg); !strings.Contains(got, "token=saved-token") || strings.Contains(got, "legacy-token") {
+	if got := doctorWiFiProbeTarget(legacyTarget, cfg, true); !strings.Contains(got, "token=saved-token") || strings.Contains(got, "legacy-token") {
 		t.Fatalf("expected saved token to authenticate legacy fallback target, got %q", got)
 	}
 	if got := targetWithQueryToken(legacyTarget, "other-token"); got != legacyTarget {
 		t.Fatalf("shared target helper must preserve explicit token, got %q", got)
 	}
 	cfg = runtimeconfig.Config{KnownDevices: []runtimeconfig.KnownDevice{{Target: "http://192.0.2.13", DeviceToken: "historical-token"}}}
-	if got := doctorWiFiProbeTarget("http://192.0.2.13", cfg); strings.Contains(got, "token=") {
+	if got := doctorWiFiProbeTarget("http://192.0.2.13", cfg, false); strings.Contains(got, "token=") {
 		t.Fatalf("doctor must not use historical known-device token, got %q", got)
 	}
 }

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -369,6 +369,34 @@ func TestDoctorUSBStillRejectsAmbiguousUnpinnedPorts(t *testing.T) {
 	}
 }
 
+func TestDoctorUSBResolvesConfiguredPort(t *testing.T) {
+	restoreDoctorTestDeps(t)
+	const configuredPort = "/dev/cu.usbserial-pinned"
+	doctorResolvePortFn = func(requested string) (string, error) {
+		if requested != configuredPort {
+			t.Fatalf("expected configured port %q, got %q", configuredPort, requested)
+		}
+		return requested, nil
+	}
+	doctorProbePortFn = func(port string) error {
+		if port != configuredPort {
+			t.Fatalf("expected probe on %q, got %q", configuredPort, port)
+		}
+		return nil
+	}
+	doctorReadDeviceHelloFn = func(port string) (protocol.DeviceHello, error) {
+		if port != configuredPort {
+			t.Fatalf("expected hello on %q, got %q", configuredPort, port)
+		}
+		return protocol.DeviceHello{}, errors.New("handshake unavailable")
+	}
+
+	err := runDoctorUSBRuntimeChecks(doctorRuntimeConfig{port: configuredPort}, []string{configuredPort})
+	if err != nil {
+		t.Fatalf("expected configured USB port check to pass, got %v", err)
+	}
+}
+
 func TestDoctorWithoutRuntimeRequestsSetupWithoutListingPorts(t *testing.T) {
 	restoreDoctorTestDeps(t)
 	doctorListPortsFn = func() ([]string, error) {

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -38,6 +41,37 @@ func TestParseLaunchAgentArgument(t *testing.T) {
 	}
 	if got := parseLaunchAgentArgument(plist, "--target"); got != "http://192.0.2.10" {
 		t.Fatalf("expected WiFi target, got %q", got)
+	}
+}
+
+func TestDoctorWiFiTargetFallsBackToLegacyPlist(t *testing.T) {
+	if got := doctorWiFiTarget("", "http://192.0.2.10"); got != "http://192.0.2.10" {
+		t.Fatalf("expected legacy plist target, got %q", got)
+	}
+	if got := doctorWiFiTarget("http://192.0.2.20", "http://192.0.2.10"); got != "http://192.0.2.20" {
+		t.Fatalf("expected runtime config target to win, got %q", got)
+	}
+}
+
+func TestDoctorCompanionHealthFallsBackFromStalePublishedEndpoint(t *testing.T) {
+	deadListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadOrigin := "http://" + deadListener.Addr().String()
+	_ = deadListener.Close()
+
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/runtime-health" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer healthy.Close()
+
+	if err := checkDoctorCompanionHealthOrigins([]string{deadOrigin, healthy.URL}); err != nil {
+		t.Fatalf("expected default endpoint fallback to pass: %v", err)
 	}
 }
 

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -137,6 +137,31 @@ func TestDoctorCompanionHealthFallsBackFromStalePublishedEndpoint(t *testing.T) 
 	}
 }
 
+func TestDoctorCompanionHealthRejectsNonWriter(t *testing.T) {
+	nonWriter := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"displayWriter":false}`))
+	}))
+	defer nonWriter.Close()
+
+	err := checkDoctorCompanionHealthOrigins([]string{nonWriter.URL})
+	if err == nil || !strings.Contains(err.Error(), "no display writer") {
+		t.Fatalf("expected non-writer runtime to fail, got %v", err)
+	}
+}
+
+func TestDoctorCompanionHealthAcceptsLegacyWriterResponse(t *testing.T) {
+	legacy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer legacy.Close()
+
+	if err := checkDoctorCompanionHealthOrigins([]string{legacy.URL}); err != nil {
+		t.Fatalf("expected legacy runtime response to pass: %v", err)
+	}
+}
+
 func TestContainsPort(t *testing.T) {
 	ports := []string{"/dev/cu.usbmodem101", "/dev/cu.usbserial-10"}
 	if !containsPort(ports, "/dev/cu.usbserial-10") {

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -67,6 +67,10 @@ func TestDoctorWiFiProbeTargetUsesTokenOnlyForMatchingDevice(t *testing.T) {
 	if got := doctorWiFiProbeTarget("http://192.0.2.11", cfg); strings.Contains(got, "token=") {
 		t.Fatalf("must not send token to another target, got %q", got)
 	}
+	legacyTarget := "http://192.0.2.12?token=legacy-token"
+	if got := doctorWiFiProbeTarget(legacyTarget, runtimeconfig.Config{}); got != legacyTarget {
+		t.Fatalf("expected legacy inline token to remain private probe credential, got %q", got)
+	}
 }
 
 func TestDoctorPublicWiFiTargetRedactsSavedToken(t *testing.T) {
@@ -187,7 +191,12 @@ func TestDoctorWiFiSkipsSerialChecks(t *testing.T) {
 			}
 			doctorCheckCompanionHealthFn = func() error { return nil }
 			doctorReadWiFiCapabilitiesFn = func(string) (protocol.DeviceCapabilities, error) {
-				return protocol.UnknownDeviceCapabilities(), nil
+				return protocol.DeviceCapabilities{
+					Known:                     true,
+					Board:                     "esp8266-smalltv-st7789",
+					NegotiatedProtocolVersion: protocol.ProtocolVersionV1,
+					SupportsTheme:             true,
+				}, nil
 			}
 
 			err := runDoctorTransportChecks(doctorRuntimeConfig{
@@ -202,6 +211,23 @@ func TestDoctorWiFiSkipsSerialChecks(t *testing.T) {
 				t.Fatal("WiFi doctor must not list serial ports")
 			}
 		})
+	}
+}
+
+func TestDoctorWiFiRejectsUnknownCapabilities(t *testing.T) {
+	restoreDoctorTestDeps(t)
+	doctorCheckCompanionHealthFn = func() error { return nil }
+	doctorReadWiFiCapabilitiesFn = func(string) (protocol.DeviceCapabilities, error) {
+		return protocol.UnknownDeviceCapabilities(), nil
+	}
+
+	err := runDoctorWiFiRuntimeChecks(doctorRuntimeConfig{
+		configured: true,
+		transport:  "wifi",
+		target:     "http://192.0.2.10",
+	})
+	if err == nil || !strings.Contains(err.Error(), "capabilities unknown") {
+		t.Fatalf("expected unknown WiFi capabilities to fail, got %v", err)
 	}
 }
 

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -78,6 +78,10 @@ func TestDoctorWiFiProbeTargetUsesTokenOnlyForMatchingDevice(t *testing.T) {
 	if got := targetWithQueryToken(legacyTarget, "other-token"); got != legacyTarget {
 		t.Fatalf("shared target helper must preserve explicit token, got %q", got)
 	}
+	cfg = runtimeconfig.Config{KnownDevices: []runtimeconfig.KnownDevice{{Target: "http://192.0.2.13", DeviceToken: "historical-token"}}}
+	if got := doctorWiFiProbeTarget("http://192.0.2.13", cfg); strings.Contains(got, "token=") {
+		t.Fatalf("doctor must not use historical known-device token, got %q", got)
+	}
 }
 
 func TestDoctorPublicWiFiTargetRedactsSavedToken(t *testing.T) {

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -69,6 +69,13 @@ func TestDoctorWiFiProbeTargetUsesTokenOnlyForMatchingDevice(t *testing.T) {
 	}
 }
 
+func TestDoctorPublicWiFiTargetRedactsSavedToken(t *testing.T) {
+	got := doctorPublicWiFiTarget("http://192.0.2.10?token=secret-token")
+	if got != "http://192.0.2.10" {
+		t.Fatalf("expected redacted target, got %q", got)
+	}
+}
+
 func TestReadDoctorLegacyLaunchAgentPlistFallsBackToSystemPath(t *testing.T) {
 	home := "/Users/test"
 	systemPath := filepath.Join("/Library", "LaunchAgents", "com.codexbar-display.daemon.plist")

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -322,6 +322,18 @@ func TestDoctorAppWiFiRejectsMissingActiveCredential(t *testing.T) {
 	}
 }
 
+func TestDoctorLegacyWiFiAuthReadinessUsesProbeCredential(t *testing.T) {
+	withoutToken := doctorWiFiProbeTarget("http://192.0.2.10", runtimeconfig.Config{}, true)
+	if deviceTokenFromCommandTarget(withoutToken) != "" {
+		t.Fatalf("expected tokenless legacy probe, got %q", withoutToken)
+	}
+
+	withToken := doctorWiFiProbeTarget("http://192.0.2.10?token=legacy-token", runtimeconfig.Config{}, true)
+	if deviceTokenFromCommandTarget(withToken) != "legacy-token" {
+		t.Fatalf("expected legacy inline credential, got %q", withToken)
+	}
+}
+
 func TestDoctorWiFiRejectsUnknownCapabilities(t *testing.T) {
 	restoreDoctorTestDeps(t)
 	doctorCheckCompanionHealthFn = func(string) error { return nil }

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -5,10 +5,13 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/runtimeconfig"
 )
 
 func TestParsePinnedPortFromLaunchAgentPlist(t *testing.T) {
@@ -50,6 +53,58 @@ func TestDoctorWiFiTargetFallsBackToLegacyPlist(t *testing.T) {
 	}
 	if got := doctorWiFiTarget("http://192.0.2.20", "http://192.0.2.10"); got != "http://192.0.2.20" {
 		t.Fatalf("expected runtime config target to win, got %q", got)
+	}
+}
+
+func TestDoctorWiFiProbeTargetUsesTokenOnlyForMatchingDevice(t *testing.T) {
+	cfg := runtimeconfig.Config{
+		DeviceTarget: "http://192.0.2.10",
+		DeviceToken:  "saved-token",
+	}
+	if got := doctorWiFiProbeTarget("http://192.0.2.10", cfg); !strings.Contains(got, "token=saved-token") {
+		t.Fatalf("expected matching target token, got %q", got)
+	}
+	if got := doctorWiFiProbeTarget("http://192.0.2.11", cfg); strings.Contains(got, "token=") {
+		t.Fatalf("must not send token to another target, got %q", got)
+	}
+}
+
+func TestReadDoctorLegacyLaunchAgentPlistFallsBackToSystemPath(t *testing.T) {
+	home := "/Users/test"
+	systemPath := filepath.Join("/Library", "LaunchAgents", "com.codexbar-display.daemon.plist")
+	data, err := readDoctorLegacyLaunchAgentPlist(home, func(path string) ([]byte, error) {
+		if path == systemPath {
+			return []byte("system plist"), nil
+		}
+		return nil, os.ErrNotExist
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "system plist" {
+		t.Fatalf("unexpected plist %q", data)
+	}
+}
+
+func TestDoctorWiFiRejectsStaleSavedToken(t *testing.T) {
+	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-VibeTV-Token") != "stale-token" {
+			t.Fatalf("expected saved token in auth header")
+		}
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer device.Close()
+
+	restoreDoctorTestDeps(t)
+	doctorCheckCompanionHealthFn = func() error { return nil }
+	err := runDoctorWiFiRuntimeChecks(doctorRuntimeConfig{
+		configured:  true,
+		transport:   "wifi",
+		target:      device.URL,
+		probeTarget: targetWithQueryToken(device.URL, "stale-token"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "status=401") {
+		t.Fatalf("expected rejected saved token, got %v", err)
 	}
 }
 

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -160,6 +160,7 @@ func TestDoctorWiFiRejectsStaleSavedToken(t *testing.T) {
 		transport:   "wifi",
 		target:      device.URL,
 		probeTarget: targetWithQueryToken(device.URL, "stale-token"),
+		authReady:   true,
 	})
 	if err == nil || !strings.Contains(err.Error(), "status=401") {
 		t.Fatalf("expected rejected saved token, got %v", err)
@@ -241,6 +242,19 @@ func TestDoctorCompanionHealthRejectsDifferentRuntimeOwner(t *testing.T) {
 	}
 }
 
+func TestDoctorCompanionHealthRequiresAppRuntimeOwner(t *testing.T) {
+	legacyResponse := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"displayWriter":true}`))
+	}))
+	defer legacyResponse.Close()
+
+	err := checkDoctorCompanionHealthOrigins([]string{legacyResponse.URL}, "shop.vibetv.control-center.runtime")
+	if err == nil || !strings.Contains(err.Error(), "listener owner") {
+		t.Fatalf("expected missing app runtime owner to fail, got %v", err)
+	}
+}
+
 func TestContainsPort(t *testing.T) {
 	ports := []string{"/dev/cu.usbmodem101", "/dev/cu.usbserial-10"}
 	if !containsPort(ports, "/dev/cu.usbserial-10") {
@@ -278,6 +292,7 @@ func TestDoctorWiFiSkipsSerialChecks(t *testing.T) {
 				configured: true,
 				transport:  "wifi",
 				target:     "http://192.0.2.10",
+				authReady:  true,
 			})
 			if err != nil {
 				t.Fatalf("WiFi doctor failed: %v", err)
@@ -286,6 +301,24 @@ func TestDoctorWiFiSkipsSerialChecks(t *testing.T) {
 				t.Fatal("WiFi doctor must not list serial ports")
 			}
 		})
+	}
+}
+
+func TestDoctorAppWiFiRejectsMissingActiveCredential(t *testing.T) {
+	restoreDoctorTestDeps(t)
+	doctorCheckCompanionHealthFn = func(string) error {
+		t.Fatal("missing credential must fail before health probe")
+		return nil
+	}
+
+	err := runDoctorWiFiRuntimeChecks(doctorRuntimeConfig{
+		configured: true,
+		label:      "shop.vibetv.control-center.runtime",
+		transport:  "wifi",
+		target:     "http://192.0.2.10",
+	})
+	if err == nil || !strings.Contains(err.Error(), "credential unavailable") {
+		t.Fatalf("expected missing active credential to fail, got %v", err)
 	}
 }
 
@@ -300,6 +333,7 @@ func TestDoctorWiFiRejectsUnknownCapabilities(t *testing.T) {
 		configured: true,
 		transport:  "wifi",
 		target:     "http://192.0.2.10",
+		authReady:  true,
 	})
 	if err == nil || !strings.Contains(err.Error(), "capabilities unknown") {
 		t.Fatalf("expected unknown WiFi capabilities to fail, got %v", err)

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
+)
 
 func TestParsePinnedPortFromLaunchAgentPlist(t *testing.T) {
 	t.Run("unpinned", func(t *testing.T) {
@@ -25,6 +31,16 @@ func TestParsePinnedPortFromLaunchAgentPlist(t *testing.T) {
 	})
 }
 
+func TestParseLaunchAgentArgument(t *testing.T) {
+	plist := `<plist><dict><array><string>daemon</string><string>--transport</string><string>wifi</string><string>--target</string><string>http://192.0.2.10</string></array></dict></plist>`
+	if got := parseLaunchAgentArgument(plist, "--transport"); got != "wifi" {
+		t.Fatalf("expected WiFi transport, got %q", got)
+	}
+	if got := parseLaunchAgentArgument(plist, "--target"); got != "http://192.0.2.10" {
+		t.Fatalf("expected WiFi target, got %q", got)
+	}
+}
+
 func TestContainsPort(t *testing.T) {
 	ports := []string{"/dev/cu.usbmodem101", "/dev/cu.usbserial-10"}
 	if !containsPort(ports, "/dev/cu.usbserial-10") {
@@ -33,6 +49,87 @@ func TestContainsPort(t *testing.T) {
 	if containsPort(ports, "/dev/cu.usbserial-11") {
 		t.Fatalf("did not expect unknown port to match")
 	}
+}
+
+func TestDoctorWiFiSkipsSerialChecks(t *testing.T) {
+	for _, ports := range [][]string{
+		{},
+		{"/dev/cu.usbserial-1"},
+		{"/dev/cu.Bluetooth-Incoming-Port", "/dev/cu.usbserial-1", "/dev/cu.usbserial-2"},
+	} {
+		t.Run(strings.Join(ports, ","), func(t *testing.T) {
+			restoreDoctorTestDeps(t)
+			serialCalled := false
+			doctorListPortsFn = func() ([]string, error) {
+				serialCalled = true
+				return ports, nil
+			}
+			doctorCheckCompanionHealthFn = func() error { return nil }
+			doctorReadWiFiCapabilitiesFn = func(string) (protocol.DeviceCapabilities, error) {
+				return protocol.UnknownDeviceCapabilities(), nil
+			}
+
+			err := runDoctorTransportChecks(doctorRuntimeConfig{
+				configured: true,
+				transport:  "wifi",
+				target:     "http://192.0.2.10",
+			})
+			if err != nil {
+				t.Fatalf("WiFi doctor failed: %v", err)
+			}
+			if serialCalled {
+				t.Fatal("WiFi doctor must not list serial ports")
+			}
+		})
+	}
+}
+
+func TestDoctorUSBStillRejectsAmbiguousUnpinnedPorts(t *testing.T) {
+	restoreDoctorTestDeps(t)
+	doctorListPortsFn = func() ([]string, error) {
+		return []string{"/dev/cu.usbserial-1", "/dev/cu.usbserial-2"}, nil
+	}
+	doctorResolvePortFn = func(string) (string, error) { return "/dev/cu.usbserial-1", nil }
+	doctorProbePortFn = func(string) error { return nil }
+	doctorReadDeviceHelloFn = func(string) (protocol.DeviceHello, error) {
+		return protocol.DeviceHello{}, errors.New("must not reach device hello")
+	}
+
+	err := runDoctorTransportChecks(doctorRuntimeConfig{configured: true, transport: "usb"})
+	if err == nil || !strings.Contains(err.Error(), "2 serial ports detected") {
+		t.Fatalf("expected USB ambiguity error, got %v", err)
+	}
+}
+
+func TestDoctorWithoutRuntimeRequestsSetupWithoutListingPorts(t *testing.T) {
+	restoreDoctorTestDeps(t)
+	doctorListPortsFn = func() ([]string, error) {
+		t.Fatal("unconfigured doctor must not list serial ports")
+		return nil, nil
+	}
+
+	err := runDoctorTransportChecks(doctorRuntimeConfig{})
+	if err == nil || !strings.Contains(err.Error(), "setup required") {
+		t.Fatalf("expected setup-required error, got %v", err)
+	}
+}
+
+func restoreDoctorTestDeps(t *testing.T) {
+	t.Helper()
+	listPorts := doctorListPortsFn
+	resolvePort := doctorResolvePortFn
+	probePort := doctorProbePortFn
+	readHello := doctorReadDeviceHelloFn
+	readWiFiCapabilities := doctorReadWiFiCapabilitiesFn
+	checkCompanionHealth := doctorCheckCompanionHealthFn
+	t.Cleanup(func() {
+		doctorListPortsFn = listPorts
+		doctorResolvePortFn = resolvePort
+		doctorProbePortFn = probePort
+		doctorReadDeviceHelloFn = readHello
+		doctorReadWiFiCapabilitiesFn = readWiFiCapabilities
+		doctorCheckCompanionHealthFn = checkCompanionHealth
+	})
 }
 
 func TestFallbackThemeSpecCapabilities(t *testing.T) {

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -38,11 +38,11 @@ func TestParsePinnedPortFromLaunchAgentPlist(t *testing.T) {
 }
 
 func TestParseLaunchAgentArgument(t *testing.T) {
-	plist := `<plist><dict><array><string>daemon</string><string>--transport</string><string>wifi</string><string>--target</string><string>http://192.0.2.10</string></array></dict></plist>`
+	plist := `<plist><dict><array><string>daemon</string><string>--transport</string><string>wifi</string><string>--target</string><string>http://192.0.2.10?mode=x&amp;token=secret</string></array></dict></plist>`
 	if got := parseLaunchAgentArgument(plist, "--transport"); got != "wifi" {
 		t.Fatalf("expected WiFi transport, got %q", got)
 	}
-	if got := parseLaunchAgentArgument(plist, "--target"); got != "http://192.0.2.10" {
+	if got := parseLaunchAgentArgument(plist, "--target"); got != "http://192.0.2.10?mode=x&token=secret" {
 		t.Fatalf("expected WiFi target, got %q", got)
 	}
 }
@@ -70,6 +70,10 @@ func TestDoctorWiFiProbeTargetUsesTokenOnlyForMatchingDevice(t *testing.T) {
 	legacyTarget := "http://192.0.2.12?token=legacy-token"
 	if got := doctorWiFiProbeTarget(legacyTarget, runtimeconfig.Config{}); got != legacyTarget {
 		t.Fatalf("expected legacy inline token to remain private probe credential, got %q", got)
+	}
+	cfg = runtimeconfig.Config{DeviceToken: "saved-token"}
+	if got := doctorWiFiProbeTarget(legacyTarget, cfg); !strings.Contains(got, "token=saved-token") || strings.Contains(got, "legacy-token") {
+		t.Fatalf("expected saved token to authenticate legacy fallback target, got %q", got)
 	}
 }
 

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -74,9 +74,20 @@ func TestDoctorWiFiProbeTargetUsesTokenOnlyForMatchingDevice(t *testing.T) {
 }
 
 func TestDoctorPublicWiFiTargetRedactsSavedToken(t *testing.T) {
-	got := doctorPublicWiFiTarget("http://192.0.2.10?token=secret-token")
-	if got != "http://192.0.2.10" {
+	got := doctorPublicWiFiTarget("http://user:password@192.0.2.10?token=token-value&auth=auth-value&key=key-value&secret=secret-value")
+	if got != "http://<redacted>@192.0.2.10?auth=<redacted>&key=<redacted>&secret=<redacted>" {
 		t.Fatalf("expected redacted target, got %q", got)
+	}
+}
+
+func TestDoctorLaunchAgentStateMustBeActive(t *testing.T) {
+	for _, state := range []string{"running", "waiting", "spawn scheduled"} {
+		if !doctorLaunchAgentStateHealthy("state = " + state) {
+			t.Fatalf("expected %q to be healthy", state)
+		}
+	}
+	if doctorLaunchAgentStateHealthy("state = exited") {
+		t.Fatal("exited LaunchAgent must not be treated as active")
 	}
 }
 

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -83,7 +83,7 @@ func TestDoctorPublicWiFiTargetRedactsSavedToken(t *testing.T) {
 func TestReadDoctorLegacyLaunchAgentPlistFallsBackToSystemPath(t *testing.T) {
 	home := "/Users/test"
 	systemPath := filepath.Join("/Library", "LaunchAgents", "com.codexbar-display.daemon.plist")
-	data, err := readDoctorLegacyLaunchAgentPlist(home, func(path string) ([]byte, error) {
+	data, err := readDoctorLegacyLaunchAgentPlist(home, "", func(path string) ([]byte, error) {
 		if path == systemPath {
 			return []byte("system plist"), nil
 		}
@@ -94,6 +94,28 @@ func TestReadDoctorLegacyLaunchAgentPlistFallsBackToSystemPath(t *testing.T) {
 	}
 	if string(data) != "system plist" {
 		t.Fatalf("unexpected plist %q", data)
+	}
+}
+
+func TestReadDoctorLegacyLaunchAgentPlistUsesLoadedServicePath(t *testing.T) {
+	home := "/Users/test"
+	loadedPath := filepath.Join("/Library", "LaunchAgents", "com.codexbar-display.daemon.plist")
+	userPath := filepath.Join(home, "Library", "LaunchAgents", "com.codexbar-display.daemon.plist")
+	data, err := readDoctorLegacyLaunchAgentPlist(home, "path = "+loadedPath, func(path string) ([]byte, error) {
+		switch path {
+		case loadedPath:
+			return []byte("loaded system plist"), nil
+		case userPath:
+			return []byte("stale user plist"), nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "loaded system plist" {
+		t.Fatalf("expected loaded service plist, got %q", data)
 	}
 }
 

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -75,6 +75,9 @@ func TestDoctorWiFiProbeTargetUsesTokenOnlyForMatchingDevice(t *testing.T) {
 	if got := doctorWiFiProbeTarget(legacyTarget, cfg); !strings.Contains(got, "token=saved-token") || strings.Contains(got, "legacy-token") {
 		t.Fatalf("expected saved token to authenticate legacy fallback target, got %q", got)
 	}
+	if got := targetWithQueryToken(legacyTarget, "other-token"); got != legacyTarget {
+		t.Fatalf("shared target helper must preserve explicit token, got %q", got)
+	}
 }
 
 func TestDoctorPublicWiFiTargetRedactsSavedToken(t *testing.T) {

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -129,7 +129,7 @@ func TestDoctorWiFiRejectsStaleSavedToken(t *testing.T) {
 	defer device.Close()
 
 	restoreDoctorTestDeps(t)
-	doctorCheckCompanionHealthFn = func() error { return nil }
+	doctorCheckCompanionHealthFn = func(string) error { return nil }
 	err := runDoctorWiFiRuntimeChecks(doctorRuntimeConfig{
 		configured:  true,
 		transport:   "wifi",
@@ -158,7 +158,7 @@ func TestDoctorCompanionHealthFallsBackFromStalePublishedEndpoint(t *testing.T) 
 	}))
 	defer healthy.Close()
 
-	if err := checkDoctorCompanionHealthOrigins([]string{deadOrigin, healthy.URL}); err != nil {
+	if err := checkDoctorCompanionHealthOrigins([]string{deadOrigin, healthy.URL}, ""); err != nil {
 		t.Fatalf("expected default endpoint fallback to pass: %v", err)
 	}
 }
@@ -170,7 +170,7 @@ func TestDoctorCompanionHealthRejectsNonWriter(t *testing.T) {
 	}))
 	defer nonWriter.Close()
 
-	err := checkDoctorCompanionHealthOrigins([]string{nonWriter.URL})
+	err := checkDoctorCompanionHealthOrigins([]string{nonWriter.URL}, "")
 	if err == nil || !strings.Contains(err.Error(), "no display writer") {
 		t.Fatalf("expected non-writer runtime to fail, got %v", err)
 	}
@@ -183,8 +183,21 @@ func TestDoctorCompanionHealthAcceptsLegacyWriterResponse(t *testing.T) {
 	}))
 	defer legacy.Close()
 
-	if err := checkDoctorCompanionHealthOrigins([]string{legacy.URL}); err != nil {
+	if err := checkDoctorCompanionHealthOrigins([]string{legacy.URL}, "com.codexbar-display.daemon"); err != nil {
 		t.Fatalf("expected legacy runtime response to pass: %v", err)
+	}
+}
+
+func TestDoctorCompanionHealthRejectsDifferentRuntimeOwner(t *testing.T) {
+	legacy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"displayWriter":true,"companion":{"runtime":{"listenerOwner":"com.codexbar-display.daemon"}}}`))
+	}))
+	defer legacy.Close()
+
+	err := checkDoctorCompanionHealthOrigins([]string{legacy.URL}, "shop.vibetv.control-center.runtime")
+	if err == nil || !strings.Contains(err.Error(), "belongs to") {
+		t.Fatalf("expected mismatched runtime owner to fail, got %v", err)
 	}
 }
 
@@ -211,7 +224,7 @@ func TestDoctorWiFiSkipsSerialChecks(t *testing.T) {
 				serialCalled = true
 				return ports, nil
 			}
-			doctorCheckCompanionHealthFn = func() error { return nil }
+			doctorCheckCompanionHealthFn = func(string) error { return nil }
 			doctorReadWiFiCapabilitiesFn = func(string) (protocol.DeviceCapabilities, error) {
 				return protocol.DeviceCapabilities{
 					Known:                     true,
@@ -238,7 +251,7 @@ func TestDoctorWiFiSkipsSerialChecks(t *testing.T) {
 
 func TestDoctorWiFiRejectsUnknownCapabilities(t *testing.T) {
 	restoreDoctorTestDeps(t)
-	doctorCheckCompanionHealthFn = func() error { return nil }
+	doctorCheckCompanionHealthFn = func(string) error { return nil }
 	doctorReadWiFiCapabilitiesFn = func(string) (protocol.DeviceCapabilities, error) {
 		return protocol.UnknownDeviceCapabilities(), nil
 	}

--- a/companion/cmd/codexbar-display/main_doctor_test.go
+++ b/companion/cmd/codexbar-display/main_doctor_test.go
@@ -166,6 +166,21 @@ func TestDoctorWiFiRejectsStaleSavedToken(t *testing.T) {
 	}
 }
 
+func TestDoctorWiFiProbeIgnoresAmbientToken(t *testing.T) {
+	t.Setenv("CODEXBAR_DISPLAY_DEVICE_TOKEN", "ambient-token")
+	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-VibeTV-Token"); got != "" {
+			t.Fatalf("expected no ambient token, got %q", got)
+		}
+		_, _ = w.Write([]byte(`{"kind":"hello","protocolVersion":1,"board":"esp8266-smalltv-st7789","firmware":"1.0.40"}`))
+	}))
+	defer device.Close()
+
+	if _, err := doctorReadWiFiCapabilitiesFn(device.URL); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDoctorCompanionHealthFallsBackFromStalePublishedEndpoint(t *testing.T) {
 	deadListener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/docs/macos-dmg-distribution.md
+++ b/docs/macos-dmg-distribution.md
@@ -83,11 +83,13 @@ The embedded LaunchAgent runs the integrated display daemon and local API:
 ```bash
 codexbar-display daemon \
   --transport wifi \
-  --target http://<device-ip> \
   --interval 30s \
   --api-addr 127.0.0.1:47832 \
   --api-dev-origin http://127.0.0.1:47832
 ```
+
+The app-managed native plist intentionally does not contain `--target`; the
+Mac App loads the active VibeTV target from its local runtime configuration.
 
 This keeps normal VibeTV usage frames updating in the background. App install
 and migration do not trigger firmware updates, theme installs, asset uploads,

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -357,9 +357,11 @@ cd companion
 - last successful `sent frame` timestamp + port
 - last runtime error (if any)
 
-`doctor` runtime checks additionally validate:
-- board/protocol/theme capability contract from device hello
-- LaunchAgent port affinity safety (fails when multiple serial ports are present and daemon is unpinned)
+`doctor` runtime checks are transport-aware:
+- active runtime service and configured transport
+- WiFi: configured target, local Mac App health, and read-only device reachability; USB/serial affinity is not applicable
+- USB: board/protocol/theme capability contract, serial probe, and LaunchAgent port affinity safety (fails when multiple serial ports are present and daemon is unpinned)
+- no active runtime: clear setup-required result without treating unrelated serial inventory as fatal
 
 Runtime error logs use:
 - stable `code=<category/item>` (`transport/*`, `protocol/*`, `runtime/*`, `setup/*`)


### PR DESCRIPTION
## Summary

- detect the active native, preview, or legacy runtime before transport diagnostics
- skip serial inventory, probing, and affinity checks for WiFi runtimes
- report the configured WiFi target, local Mac App health, and read-only device capabilities
- preserve USB ambiguity, probe, and capability checks
- report a clear setup-required result when no supported runtime is active
- update the operator and native DMG documentation

## Tests

- `cd companion && go test ./...`
- `cd companion && go vet ./...`
- `cd companion && staticcheck ./...`
- `./scripts/check-companion-bench-budget.sh`
- focused WiFi zero/one/many serial-port, USB ambiguity, no-runtime, and LaunchAgent parser tests
- read-only local `doctor` smoke test: unsupported manual runtime is reported as setup required without serial checks

No hardware writes, runtime changes, UI changes, merge, tag, or release were performed.

Supersedes the stale stacked draft #344.

Closes #340