### PR TITLE
CODEX: Recover first-run setup when CodexBar stays unavailable

### DIFF
--- a/apps/control-center/scripts/check-customer-ui-copy.mjs
+++ b/apps/control-center/scripts/check-customer-ui-copy.mjs
@@ -94,7 +94,11 @@ for (const file of files) {
 
   for (const item of extractCustomerCopy(sourceFile)) {
     const text = normalizeCopy(item.text);
-    if (!text || shouldIgnoreText(text)) {
+    if (
+      !text ||
+      shouldIgnoreText(text) ||
+      isApprovedCodexBarRecoveryCopy(file, text)
+    ) {
       continue;
     }
     for (const forbidden of forbiddenPatterns) {
@@ -112,6 +116,17 @@ for (const file of files) {
       }
     }
   }
+}
+
+function isApprovedCodexBarRecoveryCopy(file, text) {
+  return (
+    file.endsWith("src/components/device-startup-screen.tsx") &&
+    [
+      "CodexBar needs attention",
+      "VibeTV could not load valid usage data from CodexBar.",
+      "Repair CodexBar",
+    ].includes(text)
+  );
 }
 
 if (findings.length > 0) {

--- a/apps/control-center/scripts/test-customer-flows.mjs
+++ b/apps/control-center/scripts/test-customer-flows.mjs
@@ -477,7 +477,7 @@ async function main() {
         browser,
         appContext.appUrl,
       );
-      await testLocalReachableWithoutFrameWaitsUntilPreview(
+      await testFirstUsageCodexBarFailureOffersRecovery(
         browser,
         appContext.appUrl,
       );
@@ -635,7 +635,7 @@ async function main() {
       browser,
       appContext.appUrl,
     );
-    await testLocalReachableWithoutFrameWaitsUntilPreview(
+    await testFirstUsageCodexBarFailureOffersRecovery(
       browser,
       appContext.appUrl,
     );
@@ -3102,7 +3102,7 @@ async function testLocalReachableWithoutFrameWaitsForUsage(browser, appUrl) {
   await page.close();
 }
 
-async function testLocalReachableWithoutFrameWaitsUntilPreview(browser, appUrl) {
+async function testFirstUsageCodexBarFailureOffersRecovery(browser, appUrl) {
   const page = await newCustomerPage(browser, appUrl, {
     viewport: desktopViewport,
   });
@@ -3113,6 +3113,7 @@ async function testLocalReachableWithoutFrameWaitsUntilPreview(browser, appUrl) 
   };
   let recovered = false;
   let recoveredFrameRequests = 0;
+  let providerRetries = 0;
   await page.clock.install({ time: new Date("2026-07-29T08:00:00Z") });
   await routeCompanionOnline(page, [], () => {}, {
     device: companionDevice,
@@ -3134,9 +3135,21 @@ async function testLocalReachableWithoutFrameWaitsUntilPreview(browser, appUrl) 
     },
     preferencesResponse: { ok: true, items: [] },
     providerSetup: {
-      status: "not_configured",
-      engine: { status: "not_configured" },
-      providers: [],
+      status: "setup_required",
+      engine: { status: "ready" },
+      providers: [{ id: "codexbar", status: "timeout" }],
+    },
+    onProviderRetry: () => {
+      providerRetries += 1;
+      if (providerRetries === 2) {
+        recovered = true;
+        return readyProviderSetup();
+      }
+      return {
+        status: "setup_required",
+        engine: { status: "ready" },
+        providers: [{ id: "codexbar", status: "timeout" }],
+      };
     },
     usageResponse: noProviderUsage,
   });
@@ -3144,17 +3157,53 @@ async function testLocalReachableWithoutFrameWaitsUntilPreview(browser, appUrl) 
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page.clock.runFor(0);
   await page
-    .getByText("Waiting for live preview…", { exact: true })
+    .getByRole("heading", { name: "CodexBar needs attention" })
     .waitFor({ timeout: 10_000 });
-  await page.clock.runFor(60_000);
   assert(
     (await page.getByRole("navigation", { name: "Control Center" }).count()) ===
       0,
-    "Startup must remain visible until a live preview exists",
+    "A failed first usage check must keep setup visible",
   );
+  await page.getByRole("button", { name: "Repair CodexBar" }).waitFor();
+  await page.getByRole("button", { name: "Create support report" }).waitFor();
+  await page.getByRole("button", { name: "Try again" }).click();
+  await page
+    .getByRole("heading", { name: "CodexBar needs attention" })
+    .waitFor({ timeout: 10_000 });
+  assert(providerRetries === 1, "Try again must start exactly one provider retry");
 
-  recovered = true;
+  await page.getByRole("button", { name: "Repair CodexBar" }).click();
+  await page.evaluate(() => {
+    window.dispatchEvent(
+      new CustomEvent("vibetv:codexbar-repair-result", {
+        detail: { success: false },
+      }),
+    );
+  });
+  await page
+    .getByRole("button", { name: "Repair CodexBar" })
+    .waitFor({ timeout: 10_000 });
+  assert(
+    providerRetries === 1,
+    "A failed native repair must not start another provider retry",
+  );
+  await page.getByRole("button", { name: "Try again" }).waitFor();
+  await page.getByRole("button", { name: "Create support report" }).waitFor();
+
+  await page.getByRole("button", { name: "Repair CodexBar" }).click();
+  await page.evaluate(() => {
+    window.dispatchEvent(
+      new CustomEvent("vibetv:codexbar-repair-result", {
+        detail: { success: true },
+      }),
+    );
+  });
+
   await page.clock.runFor(1_000);
+  assert(
+    providerRetries === 2,
+    "A successful native repair must start exactly one fresh provider retry",
+  );
   await waitForCondition(
     () => recoveredFrameRequests > 0,
     "Display-frame recovery must keep polling after startup entry",

--- a/apps/control-center/src/components/control-center-app.tsx
+++ b/apps/control-center/src/components/control-center-app.tsx
@@ -20,6 +20,7 @@ import {
   isNativeControlCenterApp,
   localizeCompanionAssetUrl,
   localControlCenterUrl,
+  launchCodexBarRepair,
   needsLoopbackTargetAddressSpace,
   repairLocalControlCenterRuntime,
   restartLocalControlCenterApp,
@@ -90,6 +91,7 @@ const RECENT_COMPANION_REQUEST_MS = 5_000;
 const LAUNCHD_RECOVERY_GRACE_MS = 12_000;
 const NATIVE_RUNTIME_REPAIR_TIMEOUT_MS = 55_000;
 const NATIVE_RUNTIME_REPAIR_RESULT_EVENT = "vibetv:runtime-repair-result";
+const NATIVE_CODEXBAR_REPAIR_RESULT_EVENT = "vibetv:codexbar-repair-result";
 
 type LocalNetworkRequestInit = RequestInit & {
   targetAddressSpace?: "loopback";
@@ -347,6 +349,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
   const statusPollInFlight = useRef(false);
   const runtimeRepairAttempted = useRef(false);
   const runtimeRepairTimeout = useRef<number | null>(null);
+  const codexBarRepairTimeout = useRef<number | null>(null);
   const themeInstallPollJobRef = useRef("");
   const activeThemeUpgradeAttemptRef = useRef("");
   const [events, setEvents] = useState<ControlCenterEvent[]>(() => [
@@ -2848,6 +2851,100 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
     usage,
   ]);
 
+  const retryFirstUsage = useCallback(async () => {
+    const setupGeneration = setupGenerationRef.current;
+    setBusyAction("providers-retry");
+    setLastError(null);
+    try {
+      const payload = await runCompanion<{
+        providerSetup?: ProviderSetupInfo;
+      }>("/v1/providers/retry", { method: "POST" });
+      if (setupGeneration === setupGenerationRef.current) {
+        setProviderSetup(payload.providerSetup || null);
+      }
+    } catch (error) {
+      if (setupGeneration === setupGenerationRef.current) {
+        setLastError(
+          normalizeCaughtError(error, "Usage check could not finish."),
+        );
+      }
+    } finally {
+      if (setupGeneration === setupGenerationRef.current) {
+        setBusyAction(null);
+      }
+    }
+  }, [runCompanion]);
+
+  const repairCodexBar = useCallback(() => {
+    if (codexBarRepairTimeout.current !== null) {
+      window.clearTimeout(codexBarRepairTimeout.current);
+    }
+    setBusyAction("codexbar-repair");
+    setLastError(null);
+    addEvent({
+      label: "Usage service repair started",
+      detail: "Restarting the managed usage service.",
+      tone: "unknown",
+    });
+    launchCodexBarRepair();
+    codexBarRepairTimeout.current = window.setTimeout(() => {
+      codexBarRepairTimeout.current = null;
+      setBusyAction(null);
+      setLastError({
+        code: "CODEXBAR_REPAIR_TIMEOUT",
+        message: "Repair could not finish.",
+        nextAction: "Try the repair again or create a support report.",
+      });
+      addEvent({
+        label: "Usage service restart timed out",
+        detail: "The managed usage service did not return in time.",
+        tone: "attention",
+      });
+    }, NATIVE_RUNTIME_REPAIR_TIMEOUT_MS);
+  }, [addEvent]);
+
+  useEffect(() => {
+    const handleResult = (event: Event) => {
+      if (codexBarRepairTimeout.current === null) {
+        return;
+      }
+      window.clearTimeout(codexBarRepairTimeout.current);
+      codexBarRepairTimeout.current = null;
+      const detail = (event as CustomEvent<{ success?: boolean }>).detail;
+      if (detail?.success) {
+        addEvent({
+          label: "Usage service restarted",
+          detail: "Checking whether valid usage data is available now.",
+          tone: "unknown",
+        });
+        void retryFirstUsage();
+        return;
+      }
+      setBusyAction(null);
+      setLastError({
+        code: "CODEXBAR_REPAIR_FAILED",
+        message: "Repair could not finish.",
+        nextAction: "Try the repair again or create a support report.",
+      });
+      addEvent({
+        label: "Usage service restart failed",
+        detail: "The managed usage service could not restart.",
+        tone: "attention",
+      });
+    };
+    window.addEventListener(NATIVE_CODEXBAR_REPAIR_RESULT_EVENT, handleResult);
+    return () => {
+      window.removeEventListener(
+        NATIVE_CODEXBAR_REPAIR_RESULT_EVENT,
+        handleResult,
+      );
+      if (codexBarRepairTimeout.current !== null) {
+        window.clearTimeout(codexBarRepairTimeout.current);
+        codexBarRepairTimeout.current = null;
+      }
+    };
+  }, [addEvent, retryFirstUsage]);
+
   useEffect(() => {
     if (!deviceBoard || !deviceFirmware) {
       return;
@@ -3310,6 +3407,8 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
           void connectManualTarget(target);
         }}
         onCreateSupportReport={loadSupportDiagnostics}
+        onRepairCodexBar={repairCodexBar}
+        onRetryCodexBar={() => void retryFirstUsage()}
         onPair={() => {
           const candidate = pendingPairingCandidate.current;
           setLastError(null);
@@ -3326,6 +3425,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
         selectingDeviceTarget={
           busyAction === "select" ? selectingDeviceTarget : undefined
         }
+        providerSetup={providerSetup}
         supportReportBusy={supportReportBusy}
       />
     );

--- a/apps/control-center/src/components/control-center-runtime.test.ts
+++ b/apps/control-center/src/components/control-center-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   isNativeControlCenterUserAgent,
   localThemeRenderPackUrl,
+  REPAIR_CODEXBAR_URL,
   REPAIR_CONTROL_CENTER_RUNTIME_URL,
   RESTART_CONTROL_CENTER_URL,
 } from "./control-center-runtime";
@@ -20,6 +21,7 @@ describe("native Control Center recovery", () => {
   });
 
   it("keeps automatic repair separate from the full app restart", () => {
+    expect(REPAIR_CODEXBAR_URL).toBe("vibetv://repair-codexbar");
     expect(REPAIR_CONTROL_CENTER_RUNTIME_URL).toBe("vibetv://repair-runtime");
     expect(RESTART_CONTROL_CENTER_URL).toBe(
       "vibetv://restart-control-center",

--- a/apps/control-center/src/components/device-startup-screen.test.tsx
+++ b/apps/control-center/src/components/device-startup-screen.test.tsx
@@ -82,6 +82,64 @@ describe("DeviceStartupScreen", () => {
     );
   });
 
+  it("stops first-run waiting when CodexBar needs recovery", () => {
+    const html = renderToStaticMarkup(
+      <DeviceStartupScreen
+        deviceCandidates={[]}
+        deviceSearchState="waiting"
+        onCreateSupportReport={vi.fn()}
+        onPair={vi.fn()}
+        onRepairCodexBar={vi.fn()}
+        onRetryCodexBar={vi.fn()}
+        onSearch={vi.fn()}
+        onSelect={vi.fn()}
+        providerSetup={{
+          status: "setup_required",
+          engine: { status: "engine_error" },
+        }}
+      />,
+    );
+
+    expect(html).toContain("CodexBar needs attention</h1>");
+    expect(html).not.toContain("Waiting for live preview…");
+    expect(html).toContain("Repair CodexBar</button>");
+    expect(html).toContain("Try again</span></button>");
+    expect(html).toContain("Create support report</span></button>");
+  });
+
+  it("only treats a CodexBar timeout as first-run recovery", () => {
+    const timeoutMarkup = renderToStaticMarkup(
+      <DeviceStartupScreen
+        deviceCandidates={[]}
+        deviceSearchState="waiting"
+        onPair={vi.fn()}
+        onSearch={vi.fn()}
+        onSelect={vi.fn()}
+        providerSetup={{
+          status: "setup_required",
+          providers: [{ id: "codexbar", status: "timeout" }],
+        }}
+      />,
+    );
+    const providerTimeoutMarkup = renderToStaticMarkup(
+      <DeviceStartupScreen
+        deviceCandidates={[]}
+        deviceSearchState="waiting"
+        onPair={vi.fn()}
+        onSearch={vi.fn()}
+        onSelect={vi.fn()}
+        providerSetup={{
+          status: "setup_required",
+          providers: [{ id: "claude", status: "timeout" }],
+        }}
+      />,
+    );
+
+    expect(timeoutMarkup).toContain("Repair CodexBar");
+    expect(providerTimeoutMarkup).toContain("Waiting for live preview…");
+    expect(providerTimeoutMarkup).not.toContain("Repair CodexBar");
+  });
+
   it("uses shadcn recovery UI and names the action that is actually shown", () => {
     const html = renderToStaticMarkup(
       <DeviceStartupScreen

--- a/apps/control-center/src/components/device-startup-screen.tsx
+++ b/apps/control-center/src/components/device-startup-screen.tsx
@@ -13,6 +13,7 @@ import type {
   ApiError,
   DeviceCandidate,
   DeviceSearchState,
+  ProviderSetupInfo,
   SupportDiagnostics,
 } from "./control-center-types";
 import { DeviceTargetForm } from "./device-target-form";
@@ -31,11 +32,14 @@ type Props = {
   lastError?: ApiError | null;
   diagnostics?: SupportDiagnostics | null;
   onCreateSupportReport?: () => void;
+  onRepairCodexBar?: () => void;
+  onRetryCodexBar?: () => void;
   onDeviceTargetChange?: (target: string) => void;
   onManualTarget?: (target: string) => void;
   onPair: () => void;
   onSearch: () => void;
   onSelect: (candidate: DeviceCandidate) => void;
+  providerSetup?: ProviderSetupInfo | null;
   selectingDeviceTarget?: string;
   supportReportBusy?: boolean;
 };
@@ -48,6 +52,8 @@ export function DeviceStartupScreen({
   lastError,
   diagnostics,
   onCreateSupportReport,
+  onRepairCodexBar,
+  onRetryCodexBar,
   onDeviceTargetChange,
   onManualTarget,
   onPair,
@@ -55,6 +61,7 @@ export function DeviceStartupScreen({
   onSelect,
   selectingDeviceTarget,
   supportReportBusy = false,
+  providerSetup,
 }: Props) {
   const selecting = busyAction === "select";
   const manualConnecting = busyAction === "manual-target";
@@ -62,6 +69,8 @@ export function DeviceStartupScreen({
   const searching =
     deviceSearchState === "searching" || busyAction === "search";
   const waiting = deviceSearchState === "waiting";
+  const codexBarRecoveryNeeded =
+    waiting && firstUsageNeedsCodexBarRecovery(providerSetup);
   const choosing =
     deviceSearchState === "multiple" && deviceCandidates.length > 0;
   const legacyRecovery =
@@ -94,6 +103,9 @@ export function DeviceStartupScreen({
   } else if (reconnecting) {
     title = "Reconnecting to your VibeTV";
     detail = "Connecting to your saved VibeTV.";
+  } else if (codexBarRecoveryNeeded) {
+    title = "CodexBar needs attention";
+    detail = "VibeTV could not load valid usage data from CodexBar.";
   } else if (waiting) {
     title = "Connecting to VibeTV";
     detail = "VibeTV was found. Waiting for the first live preview.";
@@ -120,13 +132,15 @@ export function DeviceStartupScreen({
 
   const statusLabel = reconnecting
     ? "Reconnecting…"
-      : waiting
+      : waiting && !codexBarRecoveryNeeded
         ? "Waiting for live preview…"
         : searching
           ? "Searching…"
           : undefined;
 
-  const visual = choosing ? (
+  const visual = codexBarRecoveryNeeded ? (
+    <CircleAlert aria-hidden />
+  ) : choosing ? (
     <Monitor aria-hidden />
   ) : wifiSetupNeeded ? (
     <Wifi aria-hidden />
@@ -136,7 +150,13 @@ export function DeviceStartupScreen({
     <CircleAlert aria-hidden />
   ) : undefined;
 
-  const actions = legacyRecovery ? null : choosing ? (
+  const actions = codexBarRecoveryNeeded ? (
+    <CodexBarRecoveryActions
+      busy={Boolean(busyAction)}
+      onRepair={onRepairCodexBar}
+      onRetry={onRetryCodexBar}
+    />
+  ) : legacyRecovery ? null : choosing ? (
     <StartupActions
       busy={Boolean(busyAction)}
       onSearch={onSearch}
@@ -181,7 +201,13 @@ export function DeviceStartupScreen({
   return (
     <SetupStatusScreen
       actions={actions}
-      busy={searching || selecting || manualConnecting || reconnecting || waiting}
+      busy={
+        searching ||
+        selecting ||
+        manualConnecting ||
+        reconnecting ||
+        (waiting && !codexBarRecoveryNeeded)
+      }
       description={detail}
       footer={
         <SupportReportActions
@@ -190,6 +216,11 @@ export function DeviceStartupScreen({
           diagnostics={diagnostics}
           emphasis="secondary"
           onCreate={onCreateSupportReport}
+          createLabel={
+            codexBarRecoveryNeeded
+              ? "Create support report"
+              : "Create report"
+          }
         />
       }
       statusLabel={statusLabel}
@@ -251,6 +282,50 @@ export function DeviceStartupScreen({
         {manualTargetForm}
       </div>
     </SetupStatusScreen>
+  );
+}
+
+function CodexBarRecoveryActions({
+  busy,
+  onRepair,
+  onRetry,
+}: {
+  busy: boolean;
+  onRepair?: () => void;
+  onRetry?: () => void;
+}) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      <Button className="w-full" disabled={busy} onClick={onRepair} size="lg">
+        Repair CodexBar
+      </Button>
+      <Button
+        className="w-full"
+        disabled={busy}
+        onClick={onRetry}
+        size="lg"
+        variant="outline"
+      >
+        <RefreshCw data-icon="inline-start" aria-hidden />
+        <span>Try again</span>
+      </Button>
+    </div>
+  );
+}
+
+export function firstUsageNeedsCodexBarRecovery(
+  providerSetup: ProviderSetupInfo | null | undefined,
+): boolean {
+  const engineStatus = providerSetup?.engine?.status?.toLowerCase();
+  if (engineStatus === "not_configured" || engineStatus === "engine_error") {
+    return true;
+  }
+  return Boolean(
+    providerSetup?.providers?.some(
+      (provider) =>
+        provider.id.toLowerCase() === "codexbar" &&
+        provider.status.toLowerCase() === "timeout",
+    ),
   );
 }
 

--- a/apps/control-center/src/components/support-report-actions.test.tsx
+++ b/apps/control-center/src/components/support-report-actions.test.tsx
@@ -26,6 +26,17 @@ describe("SupportReportActions", () => {
     expect(html).toContain("sm:justify-center");
   });
 
+  it("allows setup recovery to name the support action explicitly", () => {
+    const html = renderToStaticMarkup(
+      <SupportReportActions
+        createLabel="Create support report"
+        onCreate={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("Create support report");
+  });
+
   it("only disables creation while a report itself is being created", () => {
     const available = renderToStaticMarkup(
       <SupportReportActions onCreate={vi.fn()} />,

--- a/apps/control-center/src/components/support-report-actions.tsx
+++ b/apps/control-center/src/components/support-report-actions.tsx
@@ -13,6 +13,7 @@ import {
 
 type Props = {
   align?: "start" | "center";
+  createLabel?: string;
   creating?: boolean;
   diagnostics?: SupportDiagnostics | null;
   emphasis?: "primary" | "secondary";
@@ -21,6 +22,7 @@ type Props = {
 
 export function SupportReportActions({
   align = "start",
+  createLabel = "Create report",
   creating = false,
   diagnostics,
   emphasis = "primary",
@@ -128,7 +130,7 @@ export function SupportReportActions({
             variant={createButtonVariant}
           >
             <FileText data-icon="inline-start" aria-hidden />
-            <span>Create report</span>
+            <span>{createLabel}</span>
           </Button>
         ) : null}
       </div>

--- a/docs/control-center-customer-ui-approval.md
+++ b/docs/control-center-customer-ui-approval.md
@@ -846,3 +846,20 @@ issue scope, or release permission never implies UI permission.
   version at the same time stays exactly as approved on 2026-08-08.
 - Approved files: `updates-screen.tsx`, `updates-screen.test.tsx`, and this
   approval record.
+
+## 2026-08-13 — First-run CodexBar failure becomes actionable
+
+- User approval: The user narrowed issue #339 to the first Mac App setup only
+  and explicitly selected the three recovery actions: `CodexBar reparieren`,
+  `Erneut versuchen`, and `Support-Bericht erstellen`.
+- Approved customer-visible result: If the first authoritative usage check
+  reports that CodexBar is missing, broken, or timed out, setup stops showing
+  an endless live-preview spinner. It instead says `CodexBar needs attention`
+  and offers exactly `Repair CodexBar`, `Try again`, and
+  `Create support report`. Repair restarts the app-managed usage service and
+  returns to the same three actions if that restart or the following usage
+  check fails. A normal pending first frame still keeps the existing waiting
+  screen. Later background collection is unchanged.
+- Approved files: `device-startup-screen.tsx`, `control-center-app.tsx`,
+  `support-report-actions.tsx`, their tests, the customer-flow test, the copy
+  guard, and this approval record.

--- a/macos/VibeTVControlCenter/main.swift
+++ b/macos/VibeTVControlCenter/main.swift
@@ -1265,6 +1265,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
     private var installationReady = false
     private var installationStatus: InstallationStatus?
     private var codexBarRepairRequired = false
+    private var codexBarRepairRestartRequired = false
     private var installationStatusTitle = "Starting Control Center"
     private var installationStatusDetail = "Preparing the Mac App."
     private var installationStatusFailed = false
@@ -1435,8 +1436,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
     }
 
     private func beginCodexBarRepair() {
+        if webView != nil {
+            beginControlCenterCodexBarRepair()
+            return
+        }
         installationReady = false
         codexBarRepairRequired = true
+        codexBarRepairRestartRequired = true
         activeNavigation = nil
         webView = nil
         presentInstallationStatus(
@@ -1445,6 +1451,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
             failed: false
         )
         retryRuntimePreparation()
+    }
+
+    private func beginControlCenterCodexBarRepair() {
+        guard preparationTask == nil else {
+            return
+        }
+        codexBarRepairRequired = true
+        codexBarRepairRestartRequired = true
+        preparationTask = Task { [weak self] in
+            guard let self else {
+                return
+            }
+            let outcome = await self.prepareCompanion()
+            self.preparationTask = nil
+            guard outcome == .nativeRuntimeReady else {
+                self.notifyCodexBarRepairResult(success: false)
+                return
+            }
+            self.codexBarRepairRequired = false
+            self.installationReady = true
+            self.notifyCodexBarRepairResult(success: true)
+        }
     }
 
     @objc private func openSupportLog() {
@@ -1969,6 +1997,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
             if let error {
                 NSLog(
                     "VibeTV Control Center could not report runtime repair result: \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+
+    private func notifyCodexBarRepairResult(success: Bool) {
+        let value = success ? "true" : "false"
+        let script = "window.dispatchEvent(new CustomEvent('vibetv:codexbar-repair-result', { detail: { success: \(value) } })); true"
+        webView?.evaluateJavaScript(script) { _, error in
+            if let error {
+                NSLog(
+                    "VibeTV Control Center could not report CodexBar repair result: \(error.localizedDescription)"
                 )
             }
         }
@@ -2642,6 +2682,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKNa
         guard bundledRuntimeResourcesAreValid() else {
             NSLog("VibeTV Control Center app-managed runtime resources are missing")
             return .failure(.applicationIncomplete)
+        }
+
+        if codexBarRepairRestartRequired {
+            guard await unregisterBundledRuntimeService() else {
+                NSLog("VibeTV Control Center could not stop its runtime before repairing CodexBar")
+                return .failure(.serviceStart)
+            }
+            codexBarRepairRestartRequired = false
         }
 
         guard bootstrapCodexBar() else {

--- a/scripts/test-macos-control-center-app-bundle.sh
+++ b/scripts/test-macos-control-center-app-bundle.sh
@@ -870,6 +870,25 @@ if (
     raise SystemExit(
         "native CodexBar payload must always stage the bundled ZIP, normalize xattrs, validate, publish, then revalidate"
     )
+repair_start = source.find("private func beginCodexBarRepair()")
+repair_end = source.find("@objc private func openSupportLog()", repair_start)
+repair_method = source[repair_start:repair_end]
+if (
+    "beginControlCenterCodexBarRepair()" not in repair_method
+    or "codexBarRepairRestartRequired = true" not in repair_method
+    or "notifyCodexBarRepairResult(success: true)" not in repair_method
+    or "notifyCodexBarRepairResult(success: false)" not in repair_method
+):
+    raise SystemExit(
+        "native CodexBar repair must restart the runtime and report its result to the existing setup screen"
+    )
+repair_restart = prepare_method.find("if codexBarRepairRestartRequired")
+repair_stop = prepare_method.find("await unregisterBundledRuntimeService()", repair_restart)
+codexbar_publish = prepare_method.find("guard bootstrapCodexBar()")
+if not (0 <= repair_restart < repair_stop < codexbar_publish):
+    raise SystemExit(
+        "native CodexBar repair must stop the managed runtime before replacing its private payload"
+    )
 native_ready = prepare_method.find("return .nativeRuntimeReady")
 if not (0 <= prepare_method.find("var health = await waitForHealthyRuntime") < native_ready):
     raise SystemExit(


### PR DESCRIPTION
## What changed

- stop first-run setup from waiting indefinitely when the initial CodexBar usage path reports a missing/broken engine or a CodexBar timeout
- show the three approved recovery actions: `Repair CodexBar`, `Try again`, and `Create support report`
- make `Try again` start exactly one fresh provider readiness attempt
- make native CodexBar repair stop the app-managed runtime and its supervised `codexbar serve`, replace only the private verified CodexBar payload, restart the central runtime, and report the result back to the existing setup screen
- keep setup blocked until a real renderable usage frame arrives; service health or a successful file replacement alone does not complete setup
- keep all three actions available when native repair or the following usage check still fails
- record repair phases in the existing support-report event stream

## Root cause

The first-run gate correctly required the first real usage frame, but a CodexBar setup failure left the customer on an unchanged spinner. The existing native repair action re-ran normal preparation, but an already registered runtime was not forced to restart, so a stuck supervised CodexBar process could survive the repair.

## Customer impact

New customers now get a bounded, actionable setup failure instead of appearing stuck. Repair is meaningful for the reported case because it refreshes both the verified private payload and the running app-managed process, while unrelated customer-owned CodexBar installations remain untouched.

## Validation

- `npm run test:unit` — 218 tests passed
- `npm run test:customer-smoke` — passed, including failed retry, failed native repair, successful native repair, one fresh retry, and first real frame
- `npm run lint -- --quiet`
- `npm run check:customer-ui-copy`
- `npm run check:ui-review`
- `SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk ... ./scripts/test-macos-control-center-app-bundle.sh`
- `git diff --check`

Closes #339
