### PR TITLE
fix(support): stop presenting the loopback Control Center route as a page

### DIFF
--- a/apps/control-center/src/components/control-center-runtime.ts
+++ b/apps/control-center/src/components/control-center-runtime.ts
@@ -18,6 +18,20 @@ export function isNativeControlCenterUserAgent(userAgent: string): boolean {
   return userAgent.startsWith(NATIVE_CONTROL_CENTER_USER_AGENT_PREFIX);
 }
 
+export function nativeControlCenterAppBuild(userAgent: string): {
+  version?: string;
+  build?: string;
+} {
+  if (!isNativeControlCenterUserAgent(userAgent)) {
+    return {};
+  }
+  const [version, build] = userAgent
+    .slice(NATIVE_CONTROL_CENTER_USER_AGENT_PREFIX.length)
+    .trim()
+    .split("+");
+  return { version: version || undefined, build: build || undefined };
+}
+
 export function isNativeControlCenterApp(): boolean {
   return (
     typeof navigator !== "undefined" &&

--- a/apps/control-center/src/components/control-center-types.ts
+++ b/apps/control-center/src/components/control-center-types.ts
@@ -134,6 +134,11 @@ export type SupportDiagnostics = {
       viewport?: string;
       timezone?: string;
       visibility?: string;
+      surface?: "native-mac-app" | "browser";
+      appVersion?: string;
+      appBuild?: string;
+      /** Loopback runtime address. Diagnostic only; not navigable. */
+      internalRuntimeAddress?: string;
       page?: string;
     };
     state: SupportReportClientState;

--- a/apps/control-center/src/components/support-report.test.ts
+++ b/apps/control-center/src/components/support-report.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+//
+// Issue #341: the loopback Control Center route answers 410 Gone in a normal
+// browser, so a support report must never present it as a page to open.
+import { afterEach, describe, expect, it } from "vitest";
+
+import { collectSupportReport, serializeSupportReport } from "./support-report";
+import type {
+  SupportDiagnostics,
+  SupportReportClientState,
+} from "./control-center-types";
+
+const nativeUserAgent = "VibeTVControlCenter/1.4.0+212";
+const browserUserAgent = "Mozilla/5.0 (Macintosh)";
+
+const clientState = {
+  runtimeSurface: "local-control-center",
+  activeTab: "overview",
+  companionStatus: "online",
+  deviceState: "paired",
+  deviceSearchState: "idle",
+  deviceCandidates: [],
+  recentEvents: [],
+} as unknown as SupportReportClientState;
+
+const originalLocation = Object.getOwnPropertyDescriptor(window, "location");
+const originalUserAgent = Object.getOwnPropertyDescriptor(
+  Navigator.prototype,
+  "userAgent",
+);
+
+function visit(url: string, userAgent: string) {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: new URL(url),
+  });
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    value: userAgent,
+  });
+}
+
+async function report(
+  diagnostics: SupportDiagnostics = { ok: true },
+): Promise<SupportDiagnostics> {
+  return collectSupportReport(async () => diagnostics, clientState);
+}
+
+afterEach(() => {
+  if (originalLocation) {
+    Object.defineProperty(window, "location", originalLocation);
+  }
+  if (originalUserAgent) {
+    Object.defineProperty(navigator, "userAgent", originalUserAgent);
+  }
+});
+
+describe("support report surface", () => {
+  it("keeps the native loopback route out of customer-navigable fields", async () => {
+    visit("http://127.0.0.1:47832/control-center", nativeUserAgent);
+
+    const environment = (await report()).client?.environment;
+
+    expect(environment?.page).toBeUndefined();
+    expect(environment?.internalRuntimeAddress).toBe(
+      "http://127.0.0.1:47832/control-center",
+    );
+    expect(environment?.surface).toBe("native-mac-app");
+    expect(environment?.appVersion).toBe("1.4.0");
+    expect(environment?.appBuild).toBe("212");
+  });
+
+  it("treats a loopback browser session as internal too", async () => {
+    visit("http://127.0.0.1:47832/control-center", browserUserAgent);
+
+    const environment = (await report()).client?.environment;
+
+    expect(environment?.page).toBeUndefined();
+    expect(environment?.internalRuntimeAddress).toBe(
+      "http://127.0.0.1:47832/control-center",
+    );
+    expect(environment?.surface).toBe("browser");
+  });
+
+  it("keeps the real public page URL for the hosted report", async () => {
+    visit("https://app.vibetv.shop/setup", browserUserAgent);
+
+    const environment = (await report()).client?.environment;
+
+    expect(environment?.page).toBe("https://app.vibetv.shop/setup");
+    expect(environment?.internalRuntimeAddress).toBeUndefined();
+    expect(environment?.surface).toBe("browser");
+  });
+
+  it("records the native surface even when Mac App diagnostics fail", async () => {
+    visit("http://127.0.0.1:47832/control-center", nativeUserAgent);
+
+    const fallback = await collectSupportReport(async () => {
+      throw new Error("diagnostics unreachable");
+    }, clientState);
+
+    expect(fallback.client?.environment.page).toBeUndefined();
+    expect(fallback.client?.environment.surface).toBe("native-mac-app");
+    expect(serializeSupportReport(fallback)).not.toContain('"page"');
+  });
+});

--- a/apps/control-center/src/components/support-report.ts
+++ b/apps/control-center/src/components/support-report.ts
@@ -2,6 +2,11 @@ import type {
   SupportDiagnostics,
   SupportReportClientState,
 } from "./control-center-types";
+import {
+  isLoopbackHostname,
+  isNativeControlCenterApp,
+  nativeControlCenterAppBuild,
+} from "./control-center-runtime";
 
 export async function collectSupportReport(
   loadDiagnostics: () => Promise<SupportDiagnostics>,
@@ -76,6 +81,9 @@ function readClientEnvironment() {
   if (typeof window === "undefined" || typeof navigator === "undefined") {
     return {};
   }
+  const native = isNativeControlCenterApp();
+  const { version, build } = nativeControlCenterAppBuild(navigator.userAgent);
+  const location = `${window.location.origin}${window.location.pathname}`;
   return {
     userAgent: navigator.userAgent,
     platform: navigator.platform,
@@ -84,7 +92,15 @@ function readClientEnvironment() {
     viewport: `${window.innerWidth}x${window.innerHeight}@${window.devicePixelRatio}`,
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     visibility: document.visibilityState,
-    page: `${window.location.origin}${window.location.pathname}`,
+    surface: native ? "native-mac-app" : "browser",
+    appVersion: version,
+    appBuild: build,
+    // A loopback route is only served to the native Mac App: in a browser the
+    // same URL answers 410 Gone. Keep it as a diagnostic address that names the
+    // runtime owner, never as a page a customer or support can open.
+    ...(native || isLoopbackHostname(window.location.hostname)
+      ? { internalRuntimeAddress: location }
+      : { page: location }),
   };
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,6 +130,11 @@ silently flash firmware.
 - Support diagnostics are created only when requested. They include device/app
   health fields and are designed to avoid secrets, pairing tokens, raw cookie
   values, direct contact data, and tokenized URLs.
+- A support report names its surface (`native-mac-app` or `browser`) plus the
+  Mac App version and build. The loopback runtime address appears only in the
+  internal `internalRuntimeAddress` field, never as a `page` link: that route
+  answers `410 Gone` in a normal browser. A hosted report keeps its real
+  public page URL.
 
 ## Developer Entry Points
 

--- a/docs/control-center-customer-ui-approval.md
+++ b/docs/control-center-customer-ui-approval.md
@@ -830,6 +830,23 @@ issue scope, or release permission never implies UI permission.
 - Approved files: `updates-screen.tsx`, `updates-screen.test.tsx`, and this
   approval record.
 
+## 2026-08-20 — Support reports name the Mac App surface instead of a dead link
+
+- User approval: The user explicitly assigned issue #341 ("Remove the unusable
+  loopback Control Center URL from support reports") in the Codex task of
+  2026-08-20, including its acceptance criteria for the native surface, the
+  non-navigable loopback field, and the unchanged hosted report.
+- Approved customer-visible result: A support report created in the Mac App no
+  longer contains a `page` field pointing at `http://127.0.0.1:47832/control-center`,
+  which answers `410 Gone` in a normal browser. Instead it records the surface
+  (`native-mac-app` or `browser`), the Mac App version and build, and keeps the
+  loopback address only in the clearly internal `internalRuntimeAddress`
+  diagnostic field. A report created on the hosted page keeps its real,
+  openable public page URL. No visible control, screen, or copy changes.
+- Approved files: `support-report.ts`, `support-report.test.ts`,
+  `control-center-runtime.ts`, `control-center-types.ts`, and this approval
+  record.
+
 ## 2026-08-09 — Completed updates stop gating newly discovered releases
 
 - User approval: Covered by the standing bulletproofing mandate for the update


### PR DESCRIPTION
Closes #341

## Problem

The support report recorded `http://127.0.0.1:47832/control-center` in `client.environment.page`. That route only serves the native Mac App user agent; a normal browser gets `410 Gone`. Customers and support treated the field as a link and landed on a dead page.

## Change

`readClientEnvironment` now reports what the surface actually is:

- `surface`: `native-mac-app` or `browser`
- `appVersion` / `appBuild`, parsed from the native `VibeTVControlCenter/<version>+<build>` user agent
- `internalRuntimeAddress` instead of `page` whenever the session runs on loopback — diagnostic only, explicitly non-navigable
- `page` is kept unchanged for the hosted report, where it is a real openable URL

No visible control, screen, or copy changed.

## Verification on the bench Mac

- `apps/control-center`: 219 unit tests pass, including 4 new cases in `support-report.test.ts` (native loopback, loopback browser, hosted, and the diagnostics-failure fallback). Reverting `support-report.ts` makes all four fail.
- `companion/internal/companionapi`: `go test` passes.
- `check:ui-review` and `check:customer-ui-copy` pass.
- Local ad-hoc preview 99.0.788 (`ff17c08`) built from this branch, installed at `/Applications/VibeTV Control Center.app`, launched, first-ever pairing with VibeTV `5863327` (firmware 1.0.40) driven through the app itself. Overview shows a real usage frame (Codex weekly 5%, Spark 0%).
- Live evidence: `/control-center` returns 200 for the native UA and 410 for `Mozilla/5.0` — the exact issue condition. The report created through the visible `Create report` -> `Download` flow contains:

```json
"surface": "native-mac-app",
"appVersion": "99.0.788",
"appBuild": "788",
"internalRuntimeAddress": "http://127.0.0.1:47832/control-center"
```

with no `page` field, and the loopback address appears exactly once in the whole file.

No merge, tag, release, or production deploy performed.