### PR TITLE
fix(rehearsal): make main rehearsable, and stop candidates being mistaken

### DIFF
--- a/.claude/skills/rehearse/SKILL.md
+++ b/.claude/skills/rehearse/SKILL.md
@@ -52,13 +52,21 @@ guardrails in `AGENTS.md` apply: state the device and the command, and get the
 user's explicit approval for this run before starting.
 
 ```bash
+scripts/vibetv-rehearse-cold-start.sh --main
+scripts/vibetv-rehearse-warm-start.sh --main
 scripts/vibetv-rehearse-cold-start.sh --pr <number>
-scripts/vibetv-rehearse-warm-start.sh --pr <number>
 scripts/vibetv-rehearse-cold-start.sh --restore
 ```
 
-A signed merge-gate candidate is only needed for release evidence. For a normal
-validation run, build locally and pass `--companion-override <path>`.
+Name what you are rehearsing. `--main` takes the current `main` tip as the
+candidate -- that is what a release is validated with. `--pr <number>` takes an
+open pull request head. Both verify the candidate's `sourceSha` against what you
+asked for before anything is installed.
+
+Never identify a candidate from a workflow run's head branch or head SHA. The
+merge gate is dispatched from `main`, so every run of it says `main` while
+building a pull request head. `--run-id` on its own rehearses whatever that run
+happened to build, and says so.
 
 Warm start needs one manual Sparkle "Install Update" click from the user -- a
 native macOS dialog that cannot be scripted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,13 +37,19 @@ Green unit tests, green CI, and a healthy Companion API say nothing about what
 the customer sees. A message can point at an action that does not exist in the
 UI, and only the rendered screen shows that.
 
-- `scripts/vibetv-rehearse-cold-start.sh` -- wipes every VibeTV and CodexBar trace from this Mac, then installs the Mac App and firmware from a pull request candidate. No update path: the "unboxed today, already on the new build" state.
+- `scripts/vibetv-rehearse-cold-start.sh` -- wipes every VibeTV and CodexBar trace from this Mac, then installs the Mac App and firmware from the candidate under test. No update path: the "unboxed today, already on the new build" state.
 - `scripts/vibetv-rehearse-warm-start.sh` -- restores today's public customer state (current public Mac App + released firmware), then publishes the candidate so both updates appear in the Updates tab. You drive the visible customer flow yourself: Mac App through Sparkle first, then firmware.
-- Shared logic lives in `scripts/lib/vibetv-rehearsal.sh`. Both take `--pr <number>`, `--run-id`, `--device-target`, `--companion-override`, `--keep-codexbar`, `--restore`, `--yes`; warm start also takes `--skip-firmware-baseline`.
+- Shared logic lives in `scripts/lib/vibetv-rehearsal.sh`. Both take `--main`, `--pr <number>`, `--run-id`, `--device-target`, `--companion-override`, `--keep-codexbar`, `--restore`, `--yes`; warm start also takes `--skip-firmware-baseline`.
+
+`--main` is what a release is validated with: the current `main` tip is the
+candidate, tested against the published customer state. It resolves the release
+candidate built from that exact SHA and stops when there is none, instead of
+reaching for a different candidate.
 
 ```bash
+scripts/vibetv-rehearse-cold-start.sh --main
+scripts/vibetv-rehearse-warm-start.sh --main
 scripts/vibetv-rehearse-cold-start.sh --pr 348
-scripts/vibetv-rehearse-warm-start.sh --pr 348
 scripts/vibetv-rehearse-cold-start.sh --restore
 ```
 
@@ -60,6 +66,8 @@ Known traps, all paid for on the bench:
 - Firmware is not restored; the restore chain only rebuilds the Mac. If the device was on another pull request's candidate, it stays on the last flashed version.
 - If the device already runs the candidate version the script reports "already on X, nothing to flash" and the device keeps its pairing. That is not a real cold start and the new-customer pairing screen will not appear.
 - `PREVIEW UNAVAILABLE` for an active custom theme is not a product bug. A Theme Studio theme lives in `/themes/u/` and its spec exists only in the local app, so after a purge the app cannot reload it from the catalog.
+- A merge-gate run reports `main` as its head branch and main's tip as its head SHA, because the workflow is dispatched from `main` -- but it builds the **pull request head** it was given. Only `candidate-manifest.json`'s `sourceSha` says what a candidate actually contains. Passing `--main` or `--pr` makes the scripts check that themselves; `--run-id` alone rehearses whatever that run happened to build.
+- Only `CODEX Test VibeTV Release Candidate` builds an exact `main` SHA. The merge gate cannot: it takes a `pr_number` and resolves an open pull request head.
 - Quit the app and detach all images before a run; `hdiutil attach` fails transiently while a volume of the same name is still mounted. Check for foreign listeners with `lsof -nP -iTCP:47832 -sTCP:LISTEN`.
 - Warm start needs one manual Sparkle "Install Update" click. That is a native macOS dialog and cannot be scripted headlessly.
 

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -577,8 +577,16 @@ artifacts and logs land in `~/.vibetv-selftest/runs/<timestamp>/`.
 This is the firmware/Companion tool. For the full **customer** rehearsal that
 also drives the Mac App update through Sparkle, use
 `scripts/vibetv-rehearse-warm-start.sh` / `vibetv-rehearse-cold-start.sh`;
-those need a signed merge-gate candidate and one manual Sparkle "Install
-Update" click (a native macOS dialog that cannot be scripted headlessly).
+those need a signed candidate and one manual Sparkle "Install Update" click (a
+native macOS dialog that cannot be scripted headlessly).
+
+Pass `--main` to rehearse what a release would ship: it resolves the release
+candidate built from the current `main` tip and refuses to run when there is
+none, rather than falling back to some other candidate. `--pr <number>` uses the
+merge-gate candidate for an open pull request. Either way the candidate's
+`sourceSha` is compared against what was asked for before anything is installed
+— a merge-gate run reports `main` as its head branch even though it builds a
+pull request head, so run metadata cannot be used to identify a candidate.
 
 ## Error Code Recovery Map
 

--- a/scripts/lib/vibetv-rehearsal.sh
+++ b/scripts/lib/vibetv-rehearsal.sh
@@ -23,6 +23,8 @@ REHEARSAL_BOARD="${REHEARSAL_BOARD:-esp8266-smalltv-st7789}"
 
 # Populated by rehearsal::parse_args.
 REHEARSAL_MODE=""
+REHEARSAL_MAIN=0
+REHEARSAL_MAIN_SHA=""
 REHEARSAL_PR=""
 REHEARSAL_RUN_ID=""
 REHEARSAL_DEVICE_TARGET=""
@@ -89,8 +91,10 @@ rehearsal::usage() {
   cat <<USAGE
 Usage: $(basename "$0") [options]
 
+  --main                 Rehearse the current main tip against the published
+                         release: its release candidate is the candidate
   --pr <number>          Pull request whose merge-gate candidate to install (default: $REHEARSAL_PR)
-  --run-id <id>          Use an explicit CODEX Test VibeTV Merge run instead of the newest for --pr
+  --run-id <id>          Use an explicit candidate run instead of resolving one
   --device-target <url>  VibeTV base URL, e.g. http://192.168.178.72 (default: autodetect)
   --companion-override <path>
                          Swap the installed app's companion helper for a locally
@@ -109,6 +113,7 @@ USAGE
 rehearsal::parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
+      --main) REHEARSAL_MAIN=1; shift ;;
       --pr) [[ -n "${2:-}" ]] || rehearsal::die '--pr needs a value'; REHEARSAL_PR="$2"; shift 2 ;;
       --run-id) [[ -n "${2:-}" ]] || rehearsal::die '--run-id needs a value'; REHEARSAL_RUN_ID="$2"; shift 2 ;;
       --device-target) [[ -n "${2:-}" ]] || rehearsal::die '--device-target needs a value'; REHEARSAL_DEVICE_TARGET="$2"; shift 2 ;;
@@ -322,48 +327,44 @@ rehearsal::restore() {
 
 # --------------------------------------------------------------- candidate artifacts
 
-# Resolves the newest successful merge-gate run and downloads its signed candidate.
+# Downloads the signed candidate for whatever was asked for and resolves its
+# artifacts. Both candidate workflows are accepted; see rehearsal::resolve_run_id.
 rehearsal::fetch_candidate() {
-  rehearsal::step 'Fetching the signed merge-gate candidate'
+  rehearsal::step 'Fetching the signed candidate'
   rehearsal::require_tools gh
 
-  if [[ -z "$REHEARSAL_RUN_ID" ]]; then
-    rehearsal::info "looking for the newest successful CODEX Test VibeTV Merge run"
-    REHEARSAL_RUN_ID="$(gh run list --repo "$REHEARSAL_REPOSITORY" \
-      --workflow vibetv-merge-gate.yml --status success --limit 1 \
-      --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
-  fi
-  [[ -n "$REHEARSAL_RUN_ID" ]] || rehearsal::die 'no successful merge-gate run found; pass --run-id'
+  rehearsal::resolve_run_id
 
   local cache="$REHEARSAL_STATE_DIR/candidates/$REHEARSAL_RUN_ID"
-  if [[ -f "$cache/dist/macos/candidate-manifest.json" ]]; then
+  CANDIDATE_DIR="$cache"
+  CANDIDATE_MANIFEST="$(rehearsal::candidate_manifest_path "$cache")"
+
+  if [[ -n "$CANDIDATE_MANIFEST" ]]; then
     rehearsal::info "reusing cached candidate $REHEARSAL_RUN_ID"
   else
+    # The merge gate builds an open pull request head and suffixes its artifact
+    # with the run id. The release candidate builds the exact main SHA and does
+    # not suffix it. Only main is releasable, so both have to be rehearsable.
+    local artifact
+    artifact="$(gh api "repos/$REHEARSAL_REPOSITORY/actions/runs/$REHEARSAL_RUN_ID/artifacts" \
+      --jq '.artifacts[].name' 2>/dev/null \
+      | grep -Fx -e "CODEX-vibetv-merge-candidate-$REHEARSAL_RUN_ID" -e vibetv-release-candidate \
+      | head -n 1)"
+    [[ -n "$artifact" ]] || rehearsal::die "run $REHEARSAL_RUN_ID carries no rehearsable candidate artifact"
     mkdir -p "$cache"
-    rehearsal::info "downloading candidate artifacts of run $REHEARSAL_RUN_ID (~110 MB)"
+    rehearsal::info "downloading $artifact of run $REHEARSAL_RUN_ID (~110 MB)"
     gh run download "$REHEARSAL_RUN_ID" --repo "$REHEARSAL_REPOSITORY" \
-      -n "CODEX-vibetv-merge-candidate-$REHEARSAL_RUN_ID" -D "$cache" \
-      || rehearsal::die "could not download candidate artifacts of run $REHEARSAL_RUN_ID (expired?)"
+      -n "$artifact" -D "$cache" \
+      || rehearsal::die "could not download $artifact of run $REHEARSAL_RUN_ID (expired?)"
+    CANDIDATE_MANIFEST="$(rehearsal::candidate_manifest_path "$cache")"
+    [[ -n "$CANDIDATE_MANIFEST" ]] || rehearsal::die "$artifact carries no candidate-manifest.json"
   fi
-
-  CANDIDATE_DIR="$cache"
-  CANDIDATE_MANIFEST="$cache/dist/macos/candidate-manifest.json"
-  CANDIDATE_DMG="$cache/dist/macos/VibeTV-Control-Center.dmg"
-  CANDIDATE_APPCAST="$cache/dist/macos/appcast.xml"
-  CANDIDATE_FIRMWARE="$cache/tmp/vibetv-merge/firmware.bin"
-  CANDIDATE_FIRMWARE_MANIFEST="$cache/tmp/vibetv-merge/firmware-manifest.json"
-
-  local file
-  for file in "$CANDIDATE_MANIFEST" "$CANDIDATE_DMG" "$CANDIDATE_APPCAST" \
-              "$CANDIDATE_FIRMWARE" "$CANDIDATE_FIRMWARE_MANIFEST"; do
-    [[ -f "$file" ]] || rehearsal::die "candidate is incomplete, missing $(basename "$file")"
-  done
 
   CANDIDATE_SHA="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["sourceSha"])' "$CANDIDATE_MANIFEST")"
   CANDIDATE_VERSION="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["version"])' "$CANDIDATE_MANIFEST")"
 
-  rehearsal::verify_candidate_checksums
-  rehearsal::check_candidate_matches_pr
+  rehearsal::resolve_candidate_artifacts
+  rehearsal::check_candidate_target
 
   rehearsal::info "candidate version $CANDIDATE_VERSION from commit ${CANDIDATE_SHA:0:12}"
   rehearsal::record candidateRunId "$REHEARSAL_RUN_ID"
@@ -371,53 +372,156 @@ rehearsal::fetch_candidate() {
   rehearsal::record candidateSha "$CANDIDATE_SHA"
 }
 
-# The manifest carries a sha256 per artifact; a mismatch means a corrupted download.
-rehearsal::verify_candidate_checksums() {
-  python3 - "$CANDIDATE_MANIFEST" "$CANDIDATE_DIR" <<'PY' || rehearsal::die 'candidate checksum verification failed'
-import hashlib, json, pathlib, sys
-
-manifest_path, root = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
-manifest = json.loads(manifest_path.read_text())
-locations = {
-    "signed-dmg": "dist/macos/VibeTV-Control-Center.dmg",
-    "sparkle-appcast": "dist/macos/appcast.xml",
-    "companion": "tmp/vibetv-merge/codexbar-display",
-    "firmware": "tmp/vibetv-merge/firmware.bin",
-    "firmware-manifest": "tmp/vibetv-merge/firmware-manifest.json",
-    "virtual-vibetv": "tmp/vibetv-merge/virtual-vibetv",
+rehearsal::candidate_manifest_path() {
+  find "$1" -maxdepth 3 -name candidate-manifest.json -type f 2>/dev/null | head -n 1
 }
-failed = False
+
+# The merge gate and the release candidate lay the same roles out under
+# different directories, so the manifest is the only reliable index: it names
+# every file and carries its checksum. Resolving through it replaces a
+# hard-coded path map and verifies the download in the same pass. The firmware
+# binary is taken from the firmware manifest entry for this board, because a
+# release candidate publishes one binary per board.
+rehearsal::resolve_candidate_artifacts() {
+  local resolved
+  resolved="$(python3 - "$CANDIDATE_MANIFEST" "$CANDIDATE_DIR" "$REHEARSAL_BOARD" <<'PY'
+import hashlib, json, pathlib, shlex, sys
+
+manifest_path, root, board = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2]), sys.argv[3]
+manifest = json.loads(manifest_path.read_text())
+
+by_name = {}
+for path in root.rglob("*"):
+    if path.is_file():
+        by_name.setdefault(path.name, []).append(path)
+
+problems = []
+
+
+def locate(artifact):
+    # The release candidate records a path relative to the artifact root, the
+    # merge gate records the bare file name.
+    path = root / artifact["path"]
+    if not path.is_file():
+        matches = by_name.get(artifact["name"], [])
+        if len(matches) != 1:
+            problems.append(f"{artifact['name']}: expected one copy, found {len(matches)}")
+            return None
+        path = matches[0]
+    if hashlib.sha256(path.read_bytes()).hexdigest() != artifact["sha256"]:
+        problems.append(f"{artifact['name']}: checksum mismatch")
+        return None
+    return path
+
+
+by_role = {}
 for artifact in manifest["artifacts"]:
-    relative = locations.get(artifact["role"])
-    if relative is None:
+    by_role.setdefault(artifact["role"], []).append(artifact)
+
+resolved = {}
+for role, variable in (
+    ("signed-dmg", "CANDIDATE_DMG"),
+    ("sparkle-appcast", "CANDIDATE_APPCAST"),
+    ("firmware-manifest", "CANDIDATE_FIRMWARE_MANIFEST"),
+):
+    entries = by_role.get(role, [])
+    if len(entries) != 1:
+        problems.append(f"{role}: expected one artifact, found {len(entries)}")
         continue
-    path = root / relative
-    if not path.exists():
-        print(f"   missing {relative}")
-        failed = True
-        continue
-    digest = hashlib.sha256(path.read_bytes()).hexdigest()
-    if digest != artifact["sha256"]:
-        print(f"   checksum mismatch for {relative}")
-        failed = True
-raise SystemExit(1 if failed else 0)
+    path = locate(entries[0])
+    if path is not None:
+        resolved[variable] = path
+
+firmware_manifest = resolved.get("CANDIDATE_FIRMWARE_MANIFEST")
+if firmware_manifest is not None:
+    entries = json.loads(firmware_manifest.read_text())["artifacts"]
+    wanted = [entry for entry in entries if entry.get("board") == board]
+    if len(wanted) != 1:
+        problems.append(f"firmware manifest lists {len(wanted)} entries for board {board}")
+    else:
+        asset = pathlib.PurePosixPath(wanted[0].get("asset") or wanted[0]["firmwareUrl"]).name
+        binaries = [item for item in by_role.get("firmware", []) if item["name"] == asset]
+        if len(binaries) != 1:
+            problems.append(f"firmware: {asset} is not in the candidate manifest")
+        else:
+            path = locate(binaries[0])
+            if path is not None:
+                resolved["CANDIDATE_FIRMWARE"] = path
+
+if problems:
+    print("\n".join(f"   {problem}" for problem in problems), file=sys.stderr)
+    raise SystemExit(1)
+
+for variable, path in resolved.items():
+    print(f"{variable}={shlex.quote(str(path))}")
 PY
+)" || rehearsal::die 'candidate is incomplete or corrupted'
+  eval "$resolved"
   rehearsal::info 'candidate checksums verified against the signed manifest'
 }
 
-# Guards against rehearsing a candidate that no longer matches the PR head.
-rehearsal::check_candidate_matches_pr() {
-  [[ -n "$REHEARSAL_PR" ]] || return 0
-  local head
-  head="$(gh pr view "$REHEARSAL_PR" --repo "$REHEARSAL_REPOSITORY" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
-  [[ -n "$head" ]] || { rehearsal::warn "could not read PR #$REHEARSAL_PR head; skipping match check"; return 0; }
-  rehearsal::record prHeadSha "$head"
-  if [[ "$head" != "$CANDIDATE_SHA" ]]; then
-    rehearsal::warn "candidate is ${CANDIDATE_SHA:0:12} but PR #$REHEARSAL_PR head is ${head:0:12}"
-    rehearsal::warn 're-run the merge gate for this PR to rehearse the exact head'
-    rehearsal::confirm 'Continue with the older candidate anyway?'
+# Resolves which candidate run to rehearse. main is the only releasable state,
+# so it gets a first-class path: the release candidate builds the SHA it runs
+# on, which makes its head SHA the built SHA. The merge gate cannot serve here
+# -- it only ever builds an open pull request head.
+rehearsal::resolve_run_id() {
+  [[ -z "$REHEARSAL_RUN_ID" ]] || return 0
+
+  if [[ "$REHEARSAL_MAIN" == 1 ]]; then
+    rehearsal::main_sha >/dev/null
+    rehearsal::info "main is at ${REHEARSAL_MAIN_SHA:0:12}"
+    REHEARSAL_RUN_ID="$(gh run list --repo "$REHEARSAL_REPOSITORY" \
+      --workflow vibetv-release-candidate.yml --status success --limit 20 \
+      --json databaseId,headSha \
+      --jq "[.[] | select(.headSha == \"$REHEARSAL_MAIN_SHA\")][0].databaseId" 2>/dev/null || true)"
+    [[ -n "$REHEARSAL_RUN_ID" && "$REHEARSAL_RUN_ID" != null ]] || rehearsal::die \
+      "no successful CODEX Test VibeTV Release Candidate run for main ${REHEARSAL_MAIN_SHA:0:12}; dispatch that workflow for this commit first"
+    return 0
+  fi
+
+  [[ -n "$REHEARSAL_PR" ]] || rehearsal::die 'nothing to rehearse; pass --main, --pr <number> or --run-id <id>'
+
+  rehearsal::info 'looking for the newest successful CODEX Test VibeTV Merge run'
+  REHEARSAL_RUN_ID="$(gh run list --repo "$REHEARSAL_REPOSITORY" \
+    --workflow vibetv-merge-gate.yml --status success --limit 1 \
+    --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
+  [[ -n "$REHEARSAL_RUN_ID" ]] || rehearsal::die 'no successful merge-gate run found; pass --run-id'
+}
+
+rehearsal::main_sha() {
+  if [[ -z "$REHEARSAL_MAIN_SHA" ]]; then
+    rehearsal::require_tools git
+    REHEARSAL_MAIN_SHA="$(git ls-remote "https://github.com/$REHEARSAL_REPOSITORY" refs/heads/main 2>/dev/null | awk 'NR==1{print $1}')"
+    [[ -n "$REHEARSAL_MAIN_SHA" ]] || rehearsal::die 'could not read the main tip'
+  fi
+  printf '%s\n' "$REHEARSAL_MAIN_SHA"
+}
+
+# Guards against rehearsing something other than what was asked for. The merge
+# gate is dispatched from main, so every one of its runs reports main as the
+# head branch even though it builds a pull request head. Only the candidate
+# manifest is truthful, so the comparison happens against that.
+rehearsal::check_candidate_target() {
+  local label expected
+  if [[ "$REHEARSAL_MAIN" == 1 ]]; then
+    label=main
+    expected="$(rehearsal::main_sha)"
+  elif [[ -n "$REHEARSAL_PR" ]]; then
+    label="PR #$REHEARSAL_PR"
+    expected="$(gh pr view "$REHEARSAL_PR" --repo "$REHEARSAL_REPOSITORY" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
+    [[ -n "$expected" ]] || { rehearsal::warn "could not read PR #$REHEARSAL_PR head; skipping match check"; return 0; }
+    rehearsal::record prHeadSha "$expected"
   else
-    rehearsal::info "candidate matches PR #$REHEARSAL_PR head exactly"
+    rehearsal::warn "rehearsing ${CANDIDATE_SHA:0:12} without --main or --pr, so what it is stays unverified"
+    return 0
+  fi
+
+  rehearsal::record candidateTarget "$label"
+  if [[ "$expected" != "$CANDIDATE_SHA" ]]; then
+    rehearsal::warn "candidate is ${CANDIDATE_SHA:0:12} but $label is ${expected:0:12}"
+    rehearsal::confirm "Continue with a candidate that is not $label?"
+  else
+    rehearsal::info "candidate matches $label exactly (${CANDIDATE_SHA:0:12})"
   fi
 }
 
@@ -433,8 +537,11 @@ rehearsal::start_artifact_server() {
   mkdir -p "$REHEARSAL_SERVE_DIR"
   cp "$CANDIDATE_DMG" "$REHEARSAL_SERVE_DIR/VibeTV-Control-Center.dmg"
   cp "$CANDIDATE_APPCAST" "$REHEARSAL_SERVE_DIR/appcast.xml"
-  cp "$CANDIDATE_FIRMWARE" "$REHEARSAL_SERVE_DIR/firmware.bin"
   cp "$CANDIDATE_FIRMWARE_MANIFEST" "$REHEARSAL_SERVE_DIR/firmware-manifest.json"
+  # The firmware is resolved through the manifest that names it, so its own file
+  # name is the asset name the rewritten URL below will point at. A release
+  # candidate names it per version and gzips it, not firmware.bin.
+  cp "$CANDIDATE_FIRMWARE" "$REHEARSAL_SERVE_DIR/$(basename "$CANDIDATE_FIRMWARE")"
 
   # The Updates tab reads the available Mac App version from the GitHub releases
   # API, not from the Sparkle appcast, so the candidate has to be announced here

--- a/scripts/test-vibetv-rehearsal-candidate-layout.sh
+++ b/scripts/test-vibetv-rehearsal-candidate-layout.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# The merge gate and the release candidate ship the same roles under different
+# directories and, for the firmware, under different file names. Both have to
+# resolve, because only the release candidate builds an exact main SHA and main
+# is the only releasable state.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/vibetv-rehearsal.sh
+source "$script_dir/lib/vibetv-rehearsal.sh"
+
+tmp_dir="$(mktemp -d)"
+cleanup() { rm -rf "$tmp_dir"; }
+trap cleanup EXIT
+
+failures=0
+fail() { printf 'FAIL: %s\n' "$1" >&2; failures=$((failures + 1)); }
+
+digest() { shasum -a 256 "$1" | awk '{print $1}'; }
+
+expect_equal() {
+  local label="$1" want="$2" got="$3"
+  [[ "$want" == "$got" ]] || fail "$label: expected '$want', got '$got'"
+}
+
+# --- merge gate layout: bare names in the manifest, firmware.bin ------------
+gate="$tmp_dir/gate"
+mkdir -p "$gate/dist/macos" "$gate/tmp/vibetv-merge"
+printf 'dmg\n' > "$gate/dist/macos/VibeTV-Control-Center.dmg"
+printf 'appcast\n' > "$gate/dist/macos/appcast.xml"
+printf 'firmware\n' > "$gate/tmp/vibetv-merge/firmware.bin"
+cat > "$gate/tmp/vibetv-merge/firmware-manifest.json" <<JSON
+{"schemaVersion":1,"artifacts":[{"firmwareEnv":"esp8266_smalltv_st7789","board":"esp8266-smalltv-st7789","firmwareVersion":"9999.0.63","asset":"firmware.bin","firmwareUrl":"firmware.bin"}]}
+JSON
+cat > "$gate/dist/macos/candidate-manifest.json" <<JSON
+{"schemaVersion":1,"sourceSha":"1111111111111111111111111111111111111111","version":"9999.0.63","artifacts":[
+{"name":"VibeTV-Control-Center.dmg","path":"VibeTV-Control-Center.dmg","sha256":"$(digest "$gate/dist/macos/VibeTV-Control-Center.dmg")","role":"signed-dmg"},
+{"name":"appcast.xml","path":"appcast.xml","sha256":"$(digest "$gate/dist/macos/appcast.xml")","role":"sparkle-appcast"},
+{"name":"firmware.bin","path":"firmware.bin","sha256":"$(digest "$gate/tmp/vibetv-merge/firmware.bin")","role":"firmware"},
+{"name":"firmware-manifest.json","path":"firmware-manifest.json","sha256":"$(digest "$gate/tmp/vibetv-merge/firmware-manifest.json")","role":"firmware-manifest"}]}
+JSON
+
+CANDIDATE_DIR="$gate"
+CANDIDATE_MANIFEST="$gate/dist/macos/candidate-manifest.json"
+rehearsal::resolve_candidate_artifacts >/dev/null
+expect_equal 'merge gate dmg' "$gate/dist/macos/VibeTV-Control-Center.dmg" "$CANDIDATE_DMG"
+expect_equal 'merge gate appcast' "$gate/dist/macos/appcast.xml" "$CANDIDATE_APPCAST"
+expect_equal 'merge gate firmware' "$gate/tmp/vibetv-merge/firmware.bin" "$CANDIDATE_FIRMWARE"
+expect_equal 'merge gate firmware manifest' "$gate/tmp/vibetv-merge/firmware-manifest.json" "$CANDIDATE_FIRMWARE_MANIFEST"
+
+# --- release candidate layout: real paths, gzipped per-version firmware,
+# --- and a second board that must not be picked ------------------------------
+rc="$tmp_dir/rc"
+mkdir -p "$rc/publish/macos" "$rc/publish/firmware" "$rc/test"
+printf 'rc dmg\n' > "$rc/publish/macos/VibeTV-Control-Center.dmg"
+printf 'rc appcast\n' > "$rc/publish/macos/appcast.xml"
+printf 'rc esp8266\n' > "$rc/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz"
+printf 'rc esp32\n' > "$rc/publish/firmware/codexbar-display-firmware-esp32_display-v1.0.54.bin.gz"
+cat > "$rc/publish/firmware/firmware-manifest.json" <<JSON
+{"schemaVersion":1,"release":"v1.0.54","artifacts":[
+{"firmwareEnv":"esp32_display","board":"esp32-display","firmwareVersion":"1.0.54","asset":"codexbar-display-firmware-esp32_display-v1.0.54.bin.gz","firmwareUrl":"codexbar-display-firmware-esp32_display-v1.0.54.bin.gz"},
+{"firmwareEnv":"esp8266_smalltv_st7789","board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.54","asset":"codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz","firmwareUrl":"codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz"}]}
+JSON
+cat > "$rc/candidate-manifest.json" <<JSON
+{"schemaVersion":1,"sourceSha":"2222222222222222222222222222222222222222","version":"1.0.54","artifacts":[
+{"name":"VibeTV-Control-Center.dmg","path":"publish/macos/VibeTV-Control-Center.dmg","sha256":"$(digest "$rc/publish/macos/VibeTV-Control-Center.dmg")","role":"signed-dmg","publish":true},
+{"name":"appcast.xml","path":"publish/macos/appcast.xml","sha256":"$(digest "$rc/publish/macos/appcast.xml")","role":"sparkle-appcast","publish":true},
+{"name":"codexbar-display-firmware-esp32_display-v1.0.54.bin.gz","path":"publish/firmware/codexbar-display-firmware-esp32_display-v1.0.54.bin.gz","sha256":"$(digest "$rc/publish/firmware/codexbar-display-firmware-esp32_display-v1.0.54.bin.gz")","role":"firmware","publish":true},
+{"name":"codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz","path":"publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz","sha256":"$(digest "$rc/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz")","role":"firmware","publish":true},
+{"name":"firmware-manifest.json","path":"publish/firmware/firmware-manifest.json","sha256":"$(digest "$rc/publish/firmware/firmware-manifest.json")","role":"firmware-manifest","publish":true}]}
+JSON
+
+CANDIDATE_DIR="$rc"
+CANDIDATE_MANIFEST="$rc/candidate-manifest.json"
+rehearsal::resolve_candidate_artifacts >/dev/null
+expect_equal 'release candidate dmg' "$rc/publish/macos/VibeTV-Control-Center.dmg" "$CANDIDATE_DMG"
+expect_equal 'release candidate appcast' "$rc/publish/macos/appcast.xml" "$CANDIDATE_APPCAST"
+expect_equal 'release candidate firmware for this board' \
+  "$rc/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz" "$CANDIDATE_FIRMWARE"
+expect_equal 'release candidate firmware manifest' "$rc/publish/firmware/firmware-manifest.json" "$CANDIDATE_FIRMWARE_MANIFEST"
+
+# The served file name is what the rewritten firmwareUrl points at.
+expect_equal 'served firmware name' \
+  'codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz' "$(basename "$CANDIDATE_FIRMWARE")"
+
+# --- a corrupted download must not be rehearsed -----------------------------
+# In a subshell, because the failure path calls rehearsal::die, which exits.
+printf 'tampered\n' > "$rc/publish/macos/VibeTV-Control-Center.dmg"
+if (rehearsal::resolve_candidate_artifacts) >/dev/null 2>&1; then
+  fail 'a checksum mismatch was accepted'
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf 'candidate layout resolution: all checks passed\n'


### PR DESCRIPTION
## Why

Rehearsing `main` was not possible, and asking for it silently got you something else.

`gh run list` reports **every** `CODEX Test VibeTV Merge` run as `headBranch: main` with main's tip as `headSha`, because the workflow is dispatched from `main`. But it takes a `pr_number` and builds an **open pull request head**. Picking a run from that listing installs a pull request onto the bench while every piece of run metadata claims it is main.

That is not hypothetical. On the bench today a release rehearsal for `main` (`cf182e8`) installed and flashed `13aaabc` — the head of the open #373 — and only `candidate-manifest.json`'s `sourceSha` revealed it.

Nothing could have rehearsed `main` anyway. `fetch_candidate` hard-coded the merge-gate artifact name and its `dist/macos` + `tmp/vibetv-merge` layout, and the merge gate is the one workflow that *cannot* build `main`. The workflow that builds an exact main SHA is `CODEX Test VibeTV Release Candidate`, whose artifact is named differently, laid out under `publish/` and `test/`, and ships firmware gzipped and named per version rather than as `firmware.bin`.

## What changed

- **`--main`** resolves the release candidate built from the current `main` tip and stops with an actionable message when there is none, instead of reaching for a different candidate. This is what a release is validated with: main is the candidate, tested against the published customer state.
- **The candidate's `sourceSha` is verified against what was asked for** — for `--main` and `--pr` alike — before anything is installed. `--run-id` on its own now states that what it built stays unverified, rather than implying otherwise.
- **Artifacts are resolved through the candidate manifest** instead of a hard-coded path map, so both layouts work and checksum verification happens in the same pass. The firmware binary is taken from the firmware-manifest entry for this board, because a release candidate publishes one per board.
- **The firmware is served under the name its manifest references**, so the rewritten absolute URL points at a file that is actually there.

## Verification

`scripts/test-vibetv-rehearsal-candidate-layout.sh` covers both artifact layouts, the per-board firmware choice, and a tampered download.

- Verified **red** by making the board match take the first entry — both firmware assertions fail on the wrong board.
- Checked against the **real cached merge-gate candidate** (run `32492658944`): resolves to exactly the files the old hard-coded map named, so the existing path does not regress.
- `--main` against the current tip correctly reports `main is at cf182e8f0297` and refuses: no release-candidate run exists for that commit.

Not covered by an end-to-end bench run: no release-candidate artifact currently exists to download, since the last successful one is from 2026-08-11 and retention is 7 days. The release-candidate path is exercised against a reconstructed fixture, not a live artifact.

## Note

`AGENTS.md` still claims a signed DMG is not required for a normal validation run and that `--companion-override` covers it. That is contradicted by bench findings from 2026-08-20 (ad-hoc signing breaks the `SMAppService` registration). Left untouched here to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)