### PR TITLE
fix(rc-gate): stop requiring a Raw OTA when the firmware is unchanged

### DIFF
--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -406,6 +406,10 @@ main() {
     'the runtime must own the paired device before the API firmware update starts'
   assert_contains "$GUEST_TEST" 'api_firmware_update "$OUTPUT/candidate-already-current.json" already_current' \
     'public guest states must prove already_current through the runtime API as well'
+  assert_contains "$GUEST_TEST" 'if expected_uploads and not any(event.get("path") == "/update/firmware.raw"' \
+    'the Raw OTA assertion must be conditional: a candidate whose firmware matches the baseline uploads nothing, and demanding a Raw OTA regardless fails every release that ships no new firmware'
+  assert_contains "$GUEST_TEST" 'expected_uploads = int(sys.argv[2])' \
+    'guest test must read the expected upload count once and reuse it for both state assertions'
   assert_contains "$GUEST_TEST" 'listenerOwner' \
     'guest test must bind the live Companion port to the installed runtime service'
   assert_contains "$GUEST_TEST" 'installationMode' \

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -282,9 +282,13 @@ curl --fail --silent http://127.0.0.1:47834/__virtual/state > "$OUTPUT/virtual-s
 python3 - "$OUTPUT/virtual-state.json" "$expected_uploads" <<'PY'
 import json, sys
 state = json.load(open(sys.argv[1], encoding="utf-8"))
-if state.get("updateUploads") != int(sys.argv[2]) or state.get("violations") or state.get("framesAccepted", 0) < 1:
+expected_uploads = int(sys.argv[2])
+if state.get("updateUploads") != expected_uploads or state.get("violations") or state.get("framesAccepted", 0) < 1:
     raise SystemExit("candidate companion did not complete raw OTA/render/no-op sequence")
-if not any(event.get("path") == "/update/firmware.raw" for event in state.get("events", [])):
+# A candidate whose firmware matches the baseline uploads nothing -- the outcome
+# asserted above is already_current -- so there is no Raw OTA to find. Demanding
+# one regardless fails every release that ships no new firmware.
+if expected_uploads and not any(event.get("path") == "/update/firmware.raw" for event in state.get("events", [])):
     raise SystemExit("candidate companion did not use Raw OTA port 8081")
 PY
 


### PR DESCRIPTION
## Why

The release-candidate gate fails every candidate that ships no new firmware — which is most of them.

Release candidate `1.0.54` from `main` `c03c0c6` hit it today. `build-main`, `sign-and-package`, `guest-test (clean_os)` and `guest-test (previous_public)` all passed. `guest-test (current_public)` failed, so `aggregate-result` marked the candidate **non-publishable** and the release could not proceed.

## Root cause

`scripts/test-vibetv-hosted-guest.sh` derives `expected_uploads` by comparing the candidate firmware against the baseline. When they are equal it *deliberately* switches the asserted outcome to `already_current` and performs no OTA:

```bash
first_outcome=updated
[[ "$expected_uploads" == 0 ]] && first_outcome=already_current
```

The very next assertion then demanded a `/update/firmware.raw` event **unconditionally** — proof of an upload the script had just decided not to make. The virtual device recorded exactly that: `updateUploads: 0`, no `/update` event of any kind, `framesAccepted: 2`, no `violations`.

Only `current_public` trips it, because only there does the baseline already carry the candidate's firmware:

| state | baseline firmware | candidate | uploads | result |
|---|---|---|---|---|
| `clean_os` | 0.0.0 | 1.0.40 | 1 | passes |
| `previous_public` (v1.0.52) | 1.0.39 | 1.0.40 | 1 | passes |
| `current_public` (v1.0.53) | **1.0.40** | **1.0.40** | **0** | **failed** |

The two `installed candidate runtime status did not match the signed DMG` lines in that log are not the failure — `validate_installed_runtime` retries up to 30 times and logs each attempt. The final status is correct: `1.0.54`, `installationMode: dmg`, right `listenerOwner`, valid pid.

## The fix

The Raw OTA assertion is now conditional on an upload being expected. Every other guarantee is untouched: an expected upload that never reaches `/update/firmware.raw` still fails, as does any upload-count or violation mismatch.

## Verification

Ran the harness's **own extracted check** against the real `virtual-state.json` from the failed run:

| input | expected | result |
|---|---|---|
| real `current_public` state, `expected_uploads=0` | pass | ✅ pass |
| same state, `expected_uploads=1` | fail | ✅ fails on upload count |
| uploaded state with raw event, `expected_uploads=1` | pass | ✅ pass |
| uploaded state without raw event, `expected_uploads=1` | fail | ✅ `did not use Raw OTA port 8081` |

`scripts/test-vibetv-hosted-gates.sh` now asserts the guard is present, verified red by removing it. That file is grep-based by design — the harness itself only runs on a macOS runner against real signed artifacts — so this encodes the invariant rather than re-executing the matrix.

## Scope

This does not touch product code, and it does not weaken the gate for any candidate that does ship new firmware. After merge, the `1.0.54` candidate needs a fresh release-candidate run from the new `main` tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)