### PR TITLE
fix(rehearsal): stop the first candidate download from ending the run silently

### DIFF
--- a/scripts/lib/vibetv-rehearsal.sh
+++ b/scripts/lib/vibetv-rehearsal.sh
@@ -425,12 +425,17 @@ for artifact in manifest["artifacts"]:
     by_role.setdefault(artifact["role"], []).append(artifact)
 
 resolved = {}
-for role, variable in (
-    ("signed-dmg", "CANDIDATE_DMG"),
-    ("sparkle-appcast", "CANDIDATE_APPCAST"),
-    ("firmware-manifest", "CANDIDATE_FIRMWARE_MANIFEST"),
+for role, variable, canonical in (
+    ("signed-dmg", "CANDIDATE_DMG", None),
+    ("sparkle-appcast", "CANDIDATE_APPCAST", None),
+    # A release candidate ships the firmware manifest twice, once stamped with
+    # the version. Both are byte-identical; the unstamped one is what a release
+    # serves, so that is the one under test.
+    ("firmware-manifest", "CANDIDATE_FIRMWARE_MANIFEST", "firmware-manifest.json"),
 ):
     entries = by_role.get(role, [])
+    if canonical is not None:
+        entries = [entry for entry in entries if entry["name"] == canonical] or entries
     if len(entries) != 1:
         problems.append(f"{role}: expected one artifact, found {len(entries)}")
         continue
@@ -594,23 +599,25 @@ if count != 1:
 open(path, "w", encoding="utf-8").write(patched)
 PY
 
-  # The candidate ships a manifest template whose firmwareUrl is the bare asset
-  # name. The companion does not resolve it against the manifest URL, so it has
-  # to be made absolute here or the download fails with "unsupported protocol
-  # scheme".
-  python3 - "$REHEARSAL_SERVE_DIR/firmware-manifest.json" "$REHEARSAL_SERVER_URL" <<'PY'
-import json, sys, urllib.parse
+  # The manifest addresses the firmware by a bare asset name (merge gate) or by
+  # its published release URL (release candidate, pointing at a release that does
+  # not exist yet). Either way the bytes under test are the ones on this loopback
+  # server, so the entry for this board is repointed at it. Other boards keep
+  # their published URL -- this rehearsal does not flash them.
+  python3 - "$REHEARSAL_SERVE_DIR/firmware-manifest.json" "$REHEARSAL_SERVER_URL" \
+    "$REHEARSAL_BOARD" "$(basename "$CANDIDATE_FIRMWARE")" <<'PY'
+import json, sys
 
-path, base = sys.argv[1:]
+path, base, board, asset = sys.argv[1:]
 manifest = json.loads(open(path, encoding="utf-8").read())
 patched = 0
 for artifact in manifest.get("artifacts", []):
-    url = str(artifact.get("firmwareUrl") or "")
-    if not urllib.parse.urlparse(url).scheme:
-        artifact["firmwareUrl"] = f"{base}/{url.lstrip('/')}"
-        patched += 1
-if patched == 0:
-    raise SystemExit("expected at least one relative firmwareUrl to rewrite")
+    if artifact.get("board") != board:
+        continue
+    artifact["firmwareUrl"] = f"{base}/{asset}"
+    patched += 1
+if patched != 1:
+    raise SystemExit(f"expected exactly one firmware entry for board {board}, patched {patched}")
 with open(path, "w", encoding="utf-8") as destination:
     json.dump(manifest, destination, indent=2)
     destination.write("\n")

--- a/scripts/lib/vibetv-rehearsal.sh
+++ b/scripts/lib/vibetv-rehearsal.sh
@@ -424,7 +424,7 @@ by_role = {}
 for artifact in manifest["artifacts"]:
     by_role.setdefault(artifact["role"], []).append(artifact)
 
-resolved = {}
+resolved, scalars = {}, {}
 for role, variable, canonical in (
     ("signed-dmg", "CANDIDATE_DMG", None),
     ("sparkle-appcast", "CANDIDATE_APPCAST", None),
@@ -458,6 +458,13 @@ if firmware_manifest is not None:
             path = locate(binaries[0])
             if path is not None:
                 resolved["CANDIDATE_FIRMWARE"] = path
+                # A release stamps the firmware with its own version, not the
+                # release version: 1.0.54 ships firmware 1.0.40. Only merge-gate
+                # candidates make the two coincide.
+                scalars["CANDIDATE_FIRMWARE_VERSION"] = str(wanted[0]["firmwareVersion"])
+
+if "CANDIDATE_FIRMWARE_VERSION" not in scalars:
+    problems.append("firmware: no version resolved for this board")
 
 if problems:
     print("\n".join(f"   {problem}" for problem in problems), file=sys.stderr)
@@ -465,6 +472,8 @@ if problems:
 
 for variable, path in resolved.items():
     print(f"{variable}={shlex.quote(str(path))}")
+for variable, value in scalars.items():
+    print(f"{variable}={shlex.quote(value)}")
 PY
 )" || rehearsal::die 'candidate is incomplete or corrupted'
   eval "$resolved"

--- a/scripts/lib/vibetv-rehearsal.sh
+++ b/scripts/lib/vibetv-rehearsal.sh
@@ -372,8 +372,14 @@ rehearsal::fetch_candidate() {
   rehearsal::record candidateSha "$CANDIDATE_SHA"
 }
 
+# Returns nothing, successfully, when the candidate has not been downloaded yet.
+# find exits non-zero on a missing directory and pipefail carries that through
+# the pipe, which under set -e would kill the run on its very first download.
 rehearsal::candidate_manifest_path() {
-  find "$1" -maxdepth 3 -name candidate-manifest.json -type f 2>/dev/null | head -n 1
+  if [[ -d "$1" ]]; then
+    find "$1" -maxdepth 3 -name candidate-manifest.json -type f 2>/dev/null | head -n 1 || true
+  fi
+  return 0
 }
 
 # The merge gate and the release candidate lay the same roles out under

--- a/scripts/test-vibetv-rehearsal-candidate-layout.py
+++ b/scripts/test-vibetv-rehearsal-candidate-layout.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Exercises the firmware-URL rewrite from scripts/lib/vibetv-rehearsal.sh.
+
+The block is extracted from the library rather than restated here, so a change
+to the real rewrite is what this checks.
+"""
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+library, rc_manifest = (pathlib.Path(argument) for argument in sys.argv[1:3])
+
+blocks = re.findall(r"<<'PY'\n(.*?)\nPY\n", library.read_text(), re.S)
+rewrite = [block for block in blocks if 'artifact["firmwareUrl"] = ' in block]
+if len(rewrite) != 1:
+    raise SystemExit(f"expected one firmwareUrl rewrite block in the library, found {len(rewrite)}")
+rewrite = rewrite[0]
+
+BASE = "http://127.0.0.1:59999"
+BOARD = "esp8266-smalltv-st7789"
+ASSET = "codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz"
+
+MERGE_GATE = {
+    "schemaVersion": 1,
+    "artifacts": [{"firmwareEnv": "esp8266_smalltv_st7789", "board": BOARD,
+                   "firmwareVersion": "1.0.40", "asset": "firmware.bin",
+                   "firmwareUrl": "firmware.bin"}],
+}
+
+failures = []
+
+
+def run(manifest, asset):
+    work = pathlib.Path(tempfile.mkdtemp()) / "firmware-manifest.json"
+    if isinstance(manifest, pathlib.Path):
+        shutil.copy(manifest, work)
+    else:
+        work.write_text(json.dumps(manifest))
+    result = subprocess.run([sys.executable, "-c", rewrite, str(work), BASE, BOARD, asset],
+                            capture_output=True, text=True)
+    return result, (json.loads(work.read_text()) if result.returncode == 0 else None)
+
+
+# A release candidate: absolute release URLs, two boards, release not published yet.
+result, patched = run(rc_manifest, ASSET)
+if result.returncode != 0:
+    failures.append(f"release candidate manifest was rejected: {result.stderr.strip()}")
+else:
+    entries = {item["board"]: item["firmwareUrl"] for item in patched["artifacts"]}
+    if entries.get(BOARD) != f"{BASE}/{ASSET}":
+        failures.append(f"this board was not repointed at the local server: {entries.get(BOARD)}")
+    other = [url for board, url in entries.items() if board != BOARD]
+    if not all(url.startswith("https://github.com/") for url in other):
+        failures.append(f"another board was repointed at a server that does not serve it: {other}")
+
+# The merge gate: a bare asset name, one board.
+result, patched = run(MERGE_GATE, "firmware.bin")
+if result.returncode != 0:
+    failures.append(f"merge gate manifest was rejected: {result.stderr.strip()}")
+elif patched["artifacts"][0]["firmwareUrl"] != f"{BASE}/firmware.bin":
+    failures.append(f"merge gate URL not rewritten: {patched['artifacts'][0]['firmwareUrl']}")
+
+# A manifest with no entry for this board must be refused, not silently served.
+result, _ = run({"schemaVersion": 1, "artifacts": [
+    {"board": "esp32-display", "asset": "other.bin", "firmwareUrl": "other.bin"}]}, ASSET)
+if result.returncode == 0:
+    failures.append("a manifest without an entry for this board was accepted")
+
+for problem in failures:
+    print(f"FAIL: firmware URL rewrite: {problem}", file=sys.stderr)
+raise SystemExit(1 if failures else 0)

--- a/scripts/test-vibetv-rehearsal-candidate-layout.sh
+++ b/scripts/test-vibetv-rehearsal-candidate-layout.sh
@@ -65,18 +65,23 @@ printf 'rc dmg\n' > "$rc/publish/macos/VibeTV-Control-Center.dmg"
 printf 'rc appcast\n' > "$rc/publish/macos/appcast.xml"
 printf 'rc esp8266\n' > "$rc/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz"
 printf 'rc esp32\n' > "$rc/publish/firmware/codexbar-display-firmware-esp32_display-v1.0.54.bin.gz"
+# A release candidate addresses the firmware by its published release URL, for a
+# release that does not exist yet, and ships the manifest twice -- once stamped
+# with the version.
 cat > "$rc/publish/firmware/firmware-manifest.json" <<JSON
 {"schemaVersion":1,"release":"v1.0.54","artifacts":[
-{"firmwareEnv":"esp32_display","board":"esp32-display","firmwareVersion":"1.0.54","asset":"codexbar-display-firmware-esp32_display-v1.0.54.bin.gz","firmwareUrl":"codexbar-display-firmware-esp32_display-v1.0.54.bin.gz"},
-{"firmwareEnv":"esp8266_smalltv_st7789","board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.54","asset":"codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz","firmwareUrl":"codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz"}]}
+{"firmwareEnv":"esp32_display","board":"esp32-display","firmwareVersion":"1.0.54","asset":"codexbar-display-firmware-esp32_display-v1.0.54.bin.gz","firmwareUrl":"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.0.54/codexbar-display-firmware-esp32_display-v1.0.54.bin.gz"},
+{"firmwareEnv":"esp8266_smalltv_st7789","board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.54","asset":"codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz","firmwareUrl":"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.0.54/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz"}]}
 JSON
+cp "$rc/publish/firmware/firmware-manifest.json" "$rc/publish/firmware/firmware-manifest-v1.0.54.json"
 cat > "$rc/candidate-manifest.json" <<JSON
 {"schemaVersion":1,"sourceSha":"2222222222222222222222222222222222222222","version":"1.0.54","artifacts":[
 {"name":"VibeTV-Control-Center.dmg","path":"publish/macos/VibeTV-Control-Center.dmg","sha256":"$(digest "$rc/publish/macos/VibeTV-Control-Center.dmg")","role":"signed-dmg","publish":true},
 {"name":"appcast.xml","path":"publish/macos/appcast.xml","sha256":"$(digest "$rc/publish/macos/appcast.xml")","role":"sparkle-appcast","publish":true},
 {"name":"codexbar-display-firmware-esp32_display-v1.0.54.bin.gz","path":"publish/firmware/codexbar-display-firmware-esp32_display-v1.0.54.bin.gz","sha256":"$(digest "$rc/publish/firmware/codexbar-display-firmware-esp32_display-v1.0.54.bin.gz")","role":"firmware","publish":true},
 {"name":"codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz","path":"publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz","sha256":"$(digest "$rc/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz")","role":"firmware","publish":true},
-{"name":"firmware-manifest.json","path":"publish/firmware/firmware-manifest.json","sha256":"$(digest "$rc/publish/firmware/firmware-manifest.json")","role":"firmware-manifest","publish":true}]}
+{"name":"firmware-manifest.json","path":"publish/firmware/firmware-manifest.json","sha256":"$(digest "$rc/publish/firmware/firmware-manifest.json")","role":"firmware-manifest","publish":true},
+{"name":"firmware-manifest-v1.0.54.json","path":"publish/firmware/firmware-manifest-v1.0.54.json","sha256":"$(digest "$rc/publish/firmware/firmware-manifest-v1.0.54.json")","role":"firmware-manifest","publish":true}]}
 JSON
 
 CANDIDATE_DIR="$rc"
@@ -86,7 +91,7 @@ expect_equal 'release candidate dmg' "$rc/publish/macos/VibeTV-Control-Center.dm
 expect_equal 'release candidate appcast' "$rc/publish/macos/appcast.xml" "$CANDIDATE_APPCAST"
 expect_equal 'release candidate firmware for this board' \
   "$rc/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz" "$CANDIDATE_FIRMWARE"
-expect_equal 'release candidate firmware manifest' "$rc/publish/firmware/firmware-manifest.json" "$CANDIDATE_FIRMWARE_MANIFEST"
+expect_equal 'release candidate picks the unstamped firmware manifest' "$rc/publish/firmware/firmware-manifest.json" "$CANDIDATE_FIRMWARE_MANIFEST"
 
 # The served file name is what the rewritten firmwareUrl points at.
 expect_equal 'served firmware name' \
@@ -98,6 +103,12 @@ printf 'tampered\n' > "$rc/publish/macos/VibeTV-Control-Center.dmg"
 if (rehearsal::resolve_candidate_artifacts) >/dev/null 2>&1; then
   fail 'a checksum mismatch was accepted'
 fi
+
+# --- the served manifest must point at the loopback server -------------------
+# Runs the library's own rewrite block, so this cannot drift from the real code.
+python3 "$script_dir/test-vibetv-rehearsal-candidate-layout.py" \
+  "$script_dir/lib/vibetv-rehearsal.sh" "$rc/publish/firmware/firmware-manifest.json" \
+  || fail 'firmware URL rewrite'
 
 if [[ "$failures" -gt 0 ]]; then
   printf '\n%d check(s) failed\n' "$failures" >&2

--- a/scripts/test-vibetv-rehearsal-candidate-layout.sh
+++ b/scripts/test-vibetv-rehearsal-candidate-layout.sh
@@ -23,6 +23,15 @@ expect_equal() {
   [[ "$want" == "$got" ]] || fail "$label: expected '$want', got '$got'"
 }
 
+# --- an undownloaded candidate must not kill the run ------------------------
+# The cache directory does not exist before the first download. Under
+# set -euo pipefail a find over a missing directory ends the script silently,
+# which is how this failed on the bench.
+missing="$(rehearsal::candidate_manifest_path "$tmp_dir/never-downloaded")"
+expect_equal 'missing cache resolves to nothing' '' "$missing"
+mkdir -p "$tmp_dir/empty-cache"
+expect_equal 'empty cache resolves to nothing' '' "$(rehearsal::candidate_manifest_path "$tmp_dir/empty-cache")"
+
 # --- merge gate layout: bare names in the manifest, firmware.bin ------------
 gate="$tmp_dir/gate"
 mkdir -p "$gate/dist/macos" "$gate/tmp/vibetv-merge"

--- a/scripts/test-vibetv-rehearsal-candidate-layout.sh
+++ b/scripts/test-vibetv-rehearsal-candidate-layout.sh
@@ -56,6 +56,7 @@ expect_equal 'merge gate dmg' "$gate/dist/macos/VibeTV-Control-Center.dmg" "$CAN
 expect_equal 'merge gate appcast' "$gate/dist/macos/appcast.xml" "$CANDIDATE_APPCAST"
 expect_equal 'merge gate firmware' "$gate/tmp/vibetv-merge/firmware.bin" "$CANDIDATE_FIRMWARE"
 expect_equal 'merge gate firmware manifest' "$gate/tmp/vibetv-merge/firmware-manifest.json" "$CANDIDATE_FIRMWARE_MANIFEST"
+expect_equal 'merge gate firmware version' '9999.0.63' "$CANDIDATE_FIRMWARE_VERSION"
 
 # --- release candidate layout: real paths, gzipped per-version firmware,
 # --- and a second board that must not be picked ------------------------------
@@ -63,23 +64,23 @@ rc="$tmp_dir/rc"
 mkdir -p "$rc/publish/macos" "$rc/publish/firmware" "$rc/test"
 printf 'rc dmg\n' > "$rc/publish/macos/VibeTV-Control-Center.dmg"
 printf 'rc appcast\n' > "$rc/publish/macos/appcast.xml"
-printf 'rc esp8266\n' > "$rc/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz"
-printf 'rc esp32\n' > "$rc/publish/firmware/codexbar-display-firmware-esp32_display-v1.0.54.bin.gz"
+printf 'rc esp8266\n' > "$rc/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.40.bin.gz"
+printf 'rc esp32\n' > "$rc/publish/firmware/codexbar-display-firmware-esp32_display-v1.0.35.bin.gz"
 # A release candidate addresses the firmware by its published release URL, for a
 # release that does not exist yet, and ships the manifest twice -- once stamped
 # with the version.
 cat > "$rc/publish/firmware/firmware-manifest.json" <<JSON
 {"schemaVersion":1,"release":"v1.0.54","artifacts":[
-{"firmwareEnv":"esp32_display","board":"esp32-display","firmwareVersion":"1.0.54","asset":"codexbar-display-firmware-esp32_display-v1.0.54.bin.gz","firmwareUrl":"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.0.54/codexbar-display-firmware-esp32_display-v1.0.54.bin.gz"},
-{"firmwareEnv":"esp8266_smalltv_st7789","board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.54","asset":"codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz","firmwareUrl":"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.0.54/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz"}]}
+{"firmwareEnv":"esp32_display","board":"esp32-display","firmwareVersion":"1.0.35","asset":"codexbar-display-firmware-esp32_display-v1.0.35.bin.gz","firmwareUrl":"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.0.54/codexbar-display-firmware-esp32_display-v1.0.35.bin.gz"},
+{"firmwareEnv":"esp8266_smalltv_st7789","board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.40","asset":"codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.40.bin.gz","firmwareUrl":"https://github.com/DreamyTalesPAN/CodexBar-Display/releases/download/v1.0.54/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.40.bin.gz"}]}
 JSON
 cp "$rc/publish/firmware/firmware-manifest.json" "$rc/publish/firmware/firmware-manifest-v1.0.54.json"
 cat > "$rc/candidate-manifest.json" <<JSON
 {"schemaVersion":1,"sourceSha":"2222222222222222222222222222222222222222","version":"1.0.54","artifacts":[
 {"name":"VibeTV-Control-Center.dmg","path":"publish/macos/VibeTV-Control-Center.dmg","sha256":"$(digest "$rc/publish/macos/VibeTV-Control-Center.dmg")","role":"signed-dmg","publish":true},
 {"name":"appcast.xml","path":"publish/macos/appcast.xml","sha256":"$(digest "$rc/publish/macos/appcast.xml")","role":"sparkle-appcast","publish":true},
-{"name":"codexbar-display-firmware-esp32_display-v1.0.54.bin.gz","path":"publish/firmware/codexbar-display-firmware-esp32_display-v1.0.54.bin.gz","sha256":"$(digest "$rc/publish/firmware/codexbar-display-firmware-esp32_display-v1.0.54.bin.gz")","role":"firmware","publish":true},
-{"name":"codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz","path":"publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz","sha256":"$(digest "$rc/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz")","role":"firmware","publish":true},
+{"name":"codexbar-display-firmware-esp32_display-v1.0.35.bin.gz","path":"publish/firmware/codexbar-display-firmware-esp32_display-v1.0.35.bin.gz","sha256":"$(digest "$rc/publish/firmware/codexbar-display-firmware-esp32_display-v1.0.35.bin.gz")","role":"firmware","publish":true},
+{"name":"codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.40.bin.gz","path":"publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.40.bin.gz","sha256":"$(digest "$rc/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.40.bin.gz")","role":"firmware","publish":true},
 {"name":"firmware-manifest.json","path":"publish/firmware/firmware-manifest.json","sha256":"$(digest "$rc/publish/firmware/firmware-manifest.json")","role":"firmware-manifest","publish":true},
 {"name":"firmware-manifest-v1.0.54.json","path":"publish/firmware/firmware-manifest-v1.0.54.json","sha256":"$(digest "$rc/publish/firmware/firmware-manifest-v1.0.54.json")","role":"firmware-manifest","publish":true}]}
 JSON
@@ -90,12 +91,15 @@ rehearsal::resolve_candidate_artifacts >/dev/null
 expect_equal 'release candidate dmg' "$rc/publish/macos/VibeTV-Control-Center.dmg" "$CANDIDATE_DMG"
 expect_equal 'release candidate appcast' "$rc/publish/macos/appcast.xml" "$CANDIDATE_APPCAST"
 expect_equal 'release candidate firmware for this board' \
-  "$rc/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz" "$CANDIDATE_FIRMWARE"
+  "$rc/publish/firmware/codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.40.bin.gz" "$CANDIDATE_FIRMWARE"
 expect_equal 'release candidate picks the unstamped firmware manifest' "$rc/publish/firmware/firmware-manifest.json" "$CANDIDATE_FIRMWARE_MANIFEST"
 
 # The served file name is what the rewritten firmwareUrl points at.
+# The firmware version is its own, not the release version: 1.0.54 ships 1.0.40.
+expect_equal 'release candidate firmware version' '1.0.40' "$CANDIDATE_FIRMWARE_VERSION"
+
 expect_equal 'served firmware name' \
-  'codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.54.bin.gz' "$(basename "$CANDIDATE_FIRMWARE")"
+  'codexbar-display-firmware-esp8266_smalltv_st7789-v1.0.40.bin.gz' "$(basename "$CANDIDATE_FIRMWARE")"
 
 # --- a corrupted download must not be rehearsed -----------------------------
 # In a subshell, because the failure path calls rehearsal::die, which exits.

--- a/scripts/vibetv-rehearse-cold-start.sh
+++ b/scripts/vibetv-rehearse-cold-start.sh
@@ -43,7 +43,7 @@ cat <<PLAN
 This rehearsal will:
   1. move every VibeTV and CodexBar file on this Mac into a restorable backup
   2. install Mac App $CANDIDATE_VERSION (commit ${CANDIDATE_SHA:0:12}) from the candidate DMG
-  3. flash VibeTV $DEVICE_ID to firmware $CANDIDATE_VERSION
+  3. flash VibeTV $DEVICE_ID to firmware $CANDIDATE_FIRMWARE_VERSION
 
 The VibeTV will be written to. Everything removed from this Mac is restorable
 with --restore.
@@ -62,13 +62,16 @@ rehearsal::apply_companion_override
 # --- 3. flash the candidate firmware ----------------------------------------
 rehearsal::start_artifact_server
 
-rehearsal::step "Flashing candidate firmware $CANDIDATE_VERSION"
+# The firmware carries its own version, not the release version: 1.0.54 ships
+# firmware 1.0.40. Waiting for the release version here reports every real
+# release candidate as unconfirmed after a flash that in fact succeeded.
+rehearsal::step "Flashing candidate firmware $CANDIDATE_FIRMWARE_VERSION"
 FIRMWARE_OUTCOME=installed
-if [[ "$DEVICE_FIRMWARE" == "$CANDIDATE_VERSION" ]]; then
-  rehearsal::info "already on $CANDIDATE_VERSION, nothing to flash"
-elif rehearsal::flash_firmware "$REHEARSAL_SERVER_URL/firmware-manifest.json" "$CANDIDATE_VERSION" 1; then
-  rehearsal::wait_for_device_firmware "$CANDIDATE_VERSION" \
-    || { rehearsal::warn "VibeTV did not report $CANDIDATE_VERSION within 3 minutes"; FIRMWARE_OUTCOME=unconfirmed; }
+if [[ "$DEVICE_FIRMWARE" == "$CANDIDATE_FIRMWARE_VERSION" ]]; then
+  rehearsal::info "already on $CANDIDATE_FIRMWARE_VERSION, nothing to flash"
+elif rehearsal::flash_firmware "$REHEARSAL_SERVER_URL/firmware-manifest.json" "$CANDIDATE_FIRMWARE_VERSION" 1; then
+  rehearsal::wait_for_device_firmware "$CANDIDATE_FIRMWARE_VERSION" \
+    || { rehearsal::warn "VibeTV did not report $CANDIDATE_FIRMWARE_VERSION within 3 minutes"; FIRMWARE_OUTCOME=unconfirmed; }
 else
   FIRMWARE_OUTCOME=failed
 fi
@@ -95,8 +98,8 @@ cat <<NEXT
    1. Pair the VibeTV in the app as a brand new customer would.
    2. Watch the Overview: it must reach a live preview without flapping
       between the setup screen and Overview.
-   3. Updates tab: both entries must read $CANDIDATE_VERSION with no
-      update offered.
+   3. Updates tab: Mac App must read $CANDIDATE_VERSION and firmware
+      $CANDIDATE_FIRMWARE_VERSION, with no update offered for either.
 
  Report   $REHEARSAL_RUN_DIR/report.json
  Log      $REHEARSAL_LOG

--- a/scripts/vibetv-rehearse-warm-start.sh
+++ b/scripts/vibetv-rehearse-warm-start.sh
@@ -133,6 +133,21 @@ rehearsal::stop_runtime
 rehearsal::open_app
 rehearsal::write_report staged
 
+# The firmware carries its own version and often does not change between two
+# releases. Telling the operator to update it when the candidate ships the
+# firmware the customer already has points at an action the Updates tab will not
+# offer -- exactly the kind of instruction this rehearsal exists to catch.
+if [[ "$CANDIDATE_FIRMWARE_VERSION" == "$PUBLIC_FIRMWARE_VERSION" ]]; then
+  FIRMWARE_STEP="   3. Updates tab: no firmware update is offered. The candidate ships
+      firmware $CANDIDATE_FIRMWARE_VERSION, which this VibeTV already runs."
+  FIRMWARE_EXPECTATION="Expected afterwards: Mac App reports $CANDIDATE_VERSION, firmware stays on
+ $CANDIDATE_FIRMWARE_VERSION,"
+else
+  FIRMWARE_STEP="   3. Updates tab: update the VibeTV firmware to $CANDIDATE_FIRMWARE_VERSION."
+  FIRMWARE_EXPECTATION="Expected afterwards: Mac App reports $CANDIDATE_VERSION and firmware
+ $CANDIDATE_FIRMWARE_VERSION,"
+fi
+
 cat <<NEXT
 
 ────────────────────────────────────────────────────────────────────────
@@ -146,9 +161,9 @@ cat <<NEXT
    1. Pair the VibeTV in the app as a customer would.
    2. Updates tab: update the Mac App. Sparkle downloads $CANDIDATE_VERSION,
       replaces the app and relaunches it.
-   3. Updates tab: update the VibeTV firmware to $CANDIDATE_VERSION.
+$FIRMWARE_STEP
 
- Expected afterwards: Mac App and firmware both report $CANDIDATE_VERSION,
+ $FIRMWARE_EXPECTATION
  and the preview matches what the VibeTV shows.
 
  Report   $REHEARSAL_RUN_DIR/report.json


### PR DESCRIPTION
## What happened

`--main` died on the bench immediately after printing `main is at 91a2043fe102`, with exit 1 and **no error message**, before downloading anything.

```
== Checking the connected VibeTV
   VibeTV 14799300 (esp8266-smalltv-st7789) on firmware 9999.0.56 at http://192.168.178.72

== Fetching the signed candidate
   main is at 91a2043fe102

[exited with code 1]
```

## Cause

`rehearsal::candidate_manifest_path`, which I added in #383, probes the cache directory to decide whether a candidate is already downloaded:

```bash
find "$1" -maxdepth 3 -name candidate-manifest.json -type f 2>/dev/null | head -n 1
```

On the first run for a given run id that directory does not exist yet. `find` exits non-zero, `pipefail` carries that through the pipe to `head`, and under `set -e` the enclosing assignment ends the script. Nothing called `rehearsal::die`, so nothing was printed.

Reduced:

```bash
set -euo pipefail
f() { find "$1" -maxdepth 3 -name candidate-manifest.json -type f 2>/dev/null | head -n 1; }
echo before
X="$(f /definitely/does/not/exist)"
echo after          # never reached, exit 1
```

The probe now returns nothing, successfully, for a missing or empty directory.

## Why #383 did not catch it

The path was never exercised. The layout test sets `CANDIDATE_MANIFEST` directly, and the end-to-end check I ran used a candidate that was already in the cache from an earlier run — so the cache-miss branch, which is the one every real first download takes, was the one branch I never hit.

The regression test now covers a missing directory and an empty one. Verified red by restoring the old one-liner: the test dies with the same silent exit 1 as the bench did.

## Impact

Every `--main` or `--pr` run whose candidate was not already cached. Since #383 was merged today and this is the first fresh download since, no rehearsal has succeeded on that code path yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)