### PR TITLE
chore: bump firmware to 1.0.41/1.0.36 so devices get the standby build

### DIFF
--- a/release/firmware-versions.json
+++ b/release/firmware-versions.json
@@ -5,14 +5,14 @@
     {
       "firmwareEnv": "esp8266_smalltv_st7789",
       "board": "esp8266-smalltv-st7789",
-      "firmwareVersion": "1.0.40",
+      "firmwareVersion": "1.0.41",
       "severity": "recommended",
       "message": "Firmware update available. Open the VibeTV Mac App."
     },
     {
       "firmwareEnv": "lilygo_t_display_s3",
       "board": "esp32-lilygo-t-display-s3",
-      "firmwareVersion": "1.0.35",
+      "firmwareVersion": "1.0.36",
       "severity": "recommended",
       "message": "Firmware update available. Open the VibeTV Mac App."
     }


### PR DESCRIPTION
## Why

The standby screensaver firmware (#296, merged 2026-08-20) landed without a firmware version bump. `release/firmware-versions.json` still advertises `1.0.40` / `1.0.35` — exactly the versions v1.0.53 already published on 2026-08-11.

The Companion offers a firmware update only when the manifest version is strictly greater than the installed one:

```go
updateAvailable := latestVersion.Compare(installedVersion) > 0
```
`companion/internal/companionapi/server.go:3910`

So a v1.0.54 release would ship new firmware bytes that no device ever requests — every VibeTV on 1.0.40 would report *"Firmware is up to date"* and stay without the standby screensaver.

## What changed

| Board | Before | After |
| --- | --- | --- |
| `esp8266_smalltv_st7789` | 1.0.40 | 1.0.41 |
| `lilygo_t_display_s3` | 1.0.35 | 1.0.36 |

Both boards are bumped: `firmware_esp32` includes `firmware_shared/codexbar_display_core.h`, which changed as part of #296, so the ESP32 binary is functionally changed too.

Nothing else is touched. Theme-pack `minFirmware` and `protocol/compatibility_matrix.json` stay at `1.0.40` — those are minimums for the usage-slots-v1 feature set, not the current version, and raising them would wrongly block packs on existing devices.

## Side effect on the release candidate

Bumping restores the Raw OTA path in the candidate guest matrix. #384 skips it while the firmware is unchanged; with 1.0.41 against the public 1.0.40 baseline, `current_public` and `previous_public` exercise the real update path again.

## Verification

- `scripts/test-macos-control-center-runtime-validation.sh` — passed
- `scripts/test-vibetv-hosted-gates.sh` — passed
- `scripts/test-control-center-release-workflow.sh` — passed (15 tests)

Bench rehearsal (cold + warm) still to run against the candidate built from this SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)