### PR TITLE
CODEX: complete Cable and WiFi customer controls

### DIFF
--- a/apps/control-center/src/components/control-center-app.tsx
+++ b/apps/control-center/src/components/control-center-app.tsx
@@ -394,6 +394,10 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
     useState(false);
   const [connectionModeChoiceRevision, setConnectionModeChoiceRevision] =
     useState(0);
+  const [wifiCredentialsRequired, setWifiCredentialsRequired] =
+    useState(false);
+  const [wifiConnectionInProgress, setWifiConnectionInProgress] =
+    useState(false);
   const [runtimeRecoveryPhase, setRuntimeRecoveryPhase] = useState<
     "repairing" | "failed"
   >("repairing");
@@ -1073,8 +1077,12 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
       device?: DeviceInfo;
     }) => {
       if (payload.connectionModeChoiceRequired === true) {
-        if (connectionModeChoiceSubmitted.current) {
+        if (
+          connectionModeChoiceSubmitted.current &&
+          !wifiCredentialsRequired
+        ) {
           connectionModeChoiceSubmitted.current = false;
+          setWifiConnectionInProgress(false);
           setConnectionModeChoiceRevision((current) => current + 1);
         }
         connectionModeChoiceResolved.current = true;
@@ -1087,7 +1095,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
         setConnectionModeChoiceRequired(choice.required);
       }
     },
-    [],
+    [wifiCredentialsRequired],
   );
 
   const checkCompanion = useCallback(
@@ -1594,7 +1602,10 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
       try {
         const payload = await runCompanion<{
           device?: DeviceInfo;
-          status?: "selected" | "waiting_for_wifi";
+          status?:
+            | "selected"
+            | "waiting_for_wifi"
+            | "wifi_credentials_required";
         }>(
           "/v1/setup/connection-mode",
           {
@@ -1607,10 +1618,16 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
         }
         connectionModeChoiceSubmitted.current = true;
         connectionModeChoiceResolved.current = true;
+        setWifiCredentialsRequired(
+          payload.status === "wifi_credentials_required",
+        );
         const knownWiFiReselected =
           mode === "wifi" &&
           payload.status === "selected" &&
           payload.device?.active === true;
+        setWifiConnectionInProgress(
+          mode === "wifi" && !knownWiFiReselected,
+        );
         if (
           payload.device &&
           (mode === "cable" || knownWiFiReselected)
@@ -1629,7 +1646,9 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
               ? "VibeTV is connected through the data Cable."
               : knownWiFiReselected
                 ? "VibeTV reconnected through its saved WiFi connection."
-              : "VibeTV is restarting into WiFi setup. Keep the Cable connected until the setup screen appears.",
+              : payload.status === "wifi_credentials_required"
+                ? "Enter the WiFi details in this app. The WiFi code stays between this Mac and VibeTV."
+                : "VibeTV is restarting into WiFi setup. Keep the Cable connected until the setup screen appears.",
           tone: mode === "cable" || knownWiFiReselected ? "ready" : "unknown",
         });
         return true;
@@ -1657,11 +1676,54 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
     [acceptDeviceSnapshot, addEvent, runCompanion],
   );
 
+  const configureSetupWiFi = useCallback(
+    async (ssid: string, password: string): Promise<boolean> => {
+      const setupGeneration = setupGenerationRef.current;
+      setBusyAction("wifi-credentials");
+      setLastError(null);
+      try {
+        await runCompanion("/v1/setup/wifi", {
+          method: "POST",
+          body: JSON.stringify({ ssid, password }),
+        });
+        if (setupGeneration !== setupGenerationRef.current) {
+          return false;
+        }
+        setWifiCredentialsRequired(false);
+        setWifiConnectionInProgress(true);
+        addEvent({
+          label: "WiFi details saved",
+          detail:
+            "VibeTV is connecting to WiFi. The app will only continue after the same VibeTV is confirmed.",
+          tone: "unknown",
+        });
+        return true;
+      } catch (error) {
+        if (setupGeneration !== setupGenerationRef.current) {
+          return false;
+        }
+        const normalized = normalizeCaughtError(
+          error,
+          "VibeTV could not save these WiFi details.",
+        );
+        setLastError(normalized);
+        return false;
+      } finally {
+        if (setupGeneration === setupGenerationRef.current) {
+          setBusyAction(null);
+        }
+      }
+    },
+    [addEvent, runCompanion],
+  );
+
   const reopenConnectionModeChoice = useCallback(() => {
     connectionModeChoiceSubmitted.current = false;
     connectionModeChoiceResolved.current = true;
     setConnectionModeChoiceRevision((current) => current + 1);
     setConnectionModeChoiceRequired(true);
+    setWifiCredentialsRequired(false);
+    setWifiConnectionInProgress(false);
   }, []);
 
   useEffect(() => {
@@ -4036,6 +4098,8 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
           device.capabilities.transport.supported.includes("usb")
         }
         connectionModeChoiceRequired={connectionModeChoiceRequired}
+        wifiCredentialsRequired={wifiCredentialsRequired}
+        wifiConnectionInProgress={wifiConnectionInProgress}
         wifiConnectionSupported={
           !device?.capabilities?.transport?.supported ||
           device.capabilities.transport.supported.includes("wifi")
@@ -4062,6 +4126,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
           });
         }}
         onSelectConnectionMode={selectSetupConnectionMode}
+        onConfigureWiFi={configureSetupWiFi}
         onSearch={() => {
           if (deviceRecoveryPickerReason === "confirmed-loss") {
             setDeviceRecoveryGate(

--- a/apps/control-center/src/components/device-startup-screen.test.tsx
+++ b/apps/control-center/src/components/device-startup-screen.test.tsx
@@ -63,6 +63,49 @@ describe("DeviceStartupScreen", () => {
     expect(html).not.toContain("Recommended</span>");
   });
 
+  it("collects WiFi details in the Mac App after Cable selection", () => {
+    const html = renderToStaticMarkup(
+      <DeviceStartupScreen
+        connectionModeChoiceRequired
+        deviceCandidates={[]}
+        deviceSearchState="idle"
+        onConfigureWiFi={vi.fn()}
+        onPair={vi.fn()}
+        onSearch={vi.fn()}
+        onSelect={vi.fn()}
+        onSelectConnectionMode={vi.fn()}
+        wifiCredentialsRequired
+      />,
+    );
+
+    expect(html).toContain("Enter the same WiFi details this Mac uses.");
+    expect(html).toContain('id="startup-wifi-name"');
+    expect(html).toContain('id="startup-wifi-password"');
+    expect(html).toContain("Connect to WiFi</span>");
+    expect(html).not.toContain("VibeTV-Setup");
+    expect(html).not.toContain("192.168.4.1");
+    expect(html).not.toContain("phone");
+  });
+
+  it("keeps the WiFi transition visible after the server clears the chooser", () => {
+    const html = renderToStaticMarkup(
+      <DeviceStartupScreen
+        deviceCandidates={[]}
+        deviceSearchState="idle"
+        onPair={vi.fn()}
+        onSearch={vi.fn()}
+        onSelect={vi.fn()}
+        wifiConnectionInProgress
+      />,
+    );
+
+    expect(html).toContain("Connect VibeTV to WiFi</h1>");
+    expect(html).toContain("VibeTV is connecting</div>");
+    expect(html).toContain("Scan WiFi again</span>");
+    expect(html).not.toContain("Choose how VibeTV connects");
+    expect(html).not.toContain("VibeTV-Setup");
+  });
+
   it("keeps searching as an accessible heading and one focused status", () => {
     const html = renderToStaticMarkup(
       <DeviceStartupScreen

--- a/apps/control-center/src/components/device-startup-screen.tsx
+++ b/apps/control-center/src/components/device-startup-screen.tsx
@@ -10,9 +10,11 @@ import {
   Wifi,
   WifiOff,
 } from "lucide-react";
-import { useState } from "react";
+import { useState, type FormEvent } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
 import {
   normalizedProviderStatus,
   providerRecoveryStatusRows,
@@ -45,6 +47,7 @@ type Props = {
   onRepairUsageService?: () => void;
   onDeviceTargetChange?: (target: string) => void;
   onManualTarget?: (target: string) => void;
+  onConfigureWiFi?: (ssid: string, password: string) => Promise<boolean>;
   onSelectConnectionMode?: (mode: "cable" | "wifi") => Promise<boolean>;
   onPair: () => void;
   onSearch: () => void;
@@ -56,6 +59,8 @@ type Props = {
   supportReportBusy?: boolean;
   cableConnectionSupported?: boolean;
   wifiConnectionSupported?: boolean;
+  wifiCredentialsRequired?: boolean;
+  wifiConnectionInProgress?: boolean;
 };
 
 export function DeviceStartupScreen({
@@ -71,6 +76,7 @@ export function DeviceStartupScreen({
   onRepairUsageService,
   onDeviceTargetChange,
   onManualTarget,
+  onConfigureWiFi,
   onSelectConnectionMode,
   onPair,
   onSearch,
@@ -79,6 +85,8 @@ export function DeviceStartupScreen({
   supportReportBusy = false,
   cableConnectionSupported = true,
   wifiConnectionSupported = true,
+  wifiCredentialsRequired = false,
+  wifiConnectionInProgress = false,
   providerRecovery = false,
   showCodexBarFallback = false,
   providerSetup,
@@ -86,6 +94,9 @@ export function DeviceStartupScreen({
   const [connectionModeChoice, setConnectionModeChoice] = useState<
     "cable" | "wifi" | null
   >(null);
+  const [wifiName, setWifiName] = useState("");
+  const [wifiPassword, setWifiPassword] = useState("");
+  const [wifiValidationError, setWifiValidationError] = useState("");
   const selecting = busyAction === "select";
   const manualConnecting = busyAction === "manual-target";
   const reconnecting = busyAction === "repair";
@@ -150,14 +161,33 @@ export function DeviceStartupScreen({
     (searching || choosing || wifiSetupNeeded || searchFailed || repairFailed) &&
     !legacyRecovery;
   const choosingConnectionMode =
-    connectionModeChoiceRequired && connectionModeChoice === null;
+    connectionModeChoiceRequired &&
+    connectionModeChoice === null &&
+    !wifiCredentialsRequired &&
+    !wifiConnectionInProgress;
   const wifiConnectionModeSelected =
-    connectionModeChoiceRequired && connectionModeChoice === "wifi";
+    wifiCredentialsRequired ||
+    wifiConnectionInProgress ||
+    (connectionModeChoiceRequired && connectionModeChoice === "wifi");
   const connectionModeBusy = busyAction === "connection-mode";
+  const wifiCredentialsBusy = busyAction === "wifi-credentials";
 
   async function selectConnectionMode(mode: "cable" | "wifi") {
     if (await onSelectConnectionMode?.(mode)) {
       setConnectionModeChoice(mode);
+    }
+  }
+
+  async function submitWiFiCredentials(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const ssid = wifiName.trim();
+    if (!ssid) {
+      setWifiValidationError("Enter your WiFi name.");
+      return;
+    }
+    setWifiValidationError("");
+    if (await onConfigureWiFi?.(ssid, wifiPassword)) {
+      setWifiPassword("");
     }
   }
 
@@ -173,7 +203,9 @@ export function DeviceStartupScreen({
       : "This VibeTV connects to this Mac by Cable.";
   } else if (wifiConnectionModeSelected && deviceSearchState === "idle") {
     title = "Connect VibeTV to WiFi";
-    detail = "Set up WiFi on VibeTV, then scan for it again.";
+    detail = wifiCredentialsRequired
+      ? "Enter the same WiFi details this Mac uses."
+      : "VibeTV is connecting. Scan again when it shows WiFi connected.";
   } else if (providerRecoveryView) {
     title = providerRecoveryView.title;
     detail = providerRecoveryView.detail;
@@ -212,17 +244,19 @@ export function DeviceStartupScreen({
 
   const statusLabel = connectionModeBusy
     ? "Changing connection…"
-    : providerRecoveryView?.checking
-      ? "Checking AI setup…"
-      : providerRecoveryView
-        ? undefined
-        : reconnecting
-          ? "Reconnecting…"
-          : waiting
-            ? "Waiting for live preview…"
-            : searching
-              ? "Searching…"
-              : undefined;
+    : wifiCredentialsBusy
+      ? "Saving WiFi details…"
+      : providerRecoveryView?.checking
+        ? "Checking AI setup…"
+        : providerRecoveryView
+          ? undefined
+          : reconnecting
+            ? "Reconnecting…"
+            : waiting
+              ? "Waiting for live preview…"
+              : searching
+                ? "Searching…"
+                : undefined;
 
   const visual = choosingConnectionMode ? (
     <Cable aria-hidden />
@@ -331,6 +365,7 @@ export function DeviceStartupScreen({
         reconnecting ||
         (waiting && !providerRecoveryView) ||
         connectionModeBusy ||
+        wifiCredentialsBusy ||
         providerRecoveryBusy
       }
       description={detail}
@@ -404,9 +439,62 @@ export function DeviceStartupScreen({
           </div>
         ) : null}
 
-        {wifiConnectionModeSelected && deviceSearchState === "idle" ? (
+        {wifiConnectionModeSelected &&
+        wifiCredentialsRequired &&
+        deviceSearchState === "idle" ? (
+          <form className="grid gap-4 text-left" onSubmit={submitWiFiCredentials}>
+            <FieldGroup className="grid gap-4">
+              <Field data-invalid={Boolean(wifiValidationError)}>
+                <FieldLabel htmlFor="startup-wifi-name">WiFi name</FieldLabel>
+                <Input
+                  autoComplete="off"
+                  disabled={wifiCredentialsBusy}
+                  id="startup-wifi-name"
+                  onChange={(event) => {
+                    setWifiName(event.target.value);
+                    setWifiValidationError("");
+                  }}
+                  placeholder="Home WiFi"
+                  value={wifiName}
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="startup-wifi-password">
+                  WiFi code
+                </FieldLabel>
+                <Input
+                  autoComplete="off"
+                  disabled={wifiCredentialsBusy}
+                  id="startup-wifi-password"
+                  onChange={(event) => setWifiPassword(event.target.value)}
+                  type="password"
+                  value={wifiPassword}
+                />
+              </Field>
+            </FieldGroup>
+            {wifiValidationError ? (
+              <p className="text-sm font-medium text-destructive" role="alert">
+                {wifiValidationError}
+              </p>
+            ) : null}
+            <Button disabled={wifiCredentialsBusy} size="lg" type="submit">
+              <span>{wifiCredentialsBusy ? "Saving…" : "Connect to WiFi"}</span>
+            </Button>
+          </form>
+        ) : null}
+
+        {wifiConnectionModeSelected &&
+        !wifiCredentialsRequired &&
+        deviceSearchState === "idle" ? (
           <>
-            <WifiSetupInstructions />
+            <Alert>
+              <Wifi aria-hidden />
+              <AlertTitle>VibeTV is connecting</AlertTitle>
+              <AlertDescription>
+                Keep VibeTV powered on. Continue when its screen says WiFi is
+                connected.
+              </AlertDescription>
+            </Alert>
             <Button className="w-full" onClick={onSearch} size="lg">
               <RefreshCw data-icon="inline-start" aria-hidden />
               <span>Scan WiFi again</span>

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -61,6 +61,7 @@ const (
 	cableDeviceTarget        = "cable://vibetv"
 	deviceTimeout            = 15 * time.Second
 	deviceSearchWindow       = 30 * time.Second
+	cableTransitionWait      = 55 * time.Second
 	repairRequestTimeout     = 110 * time.Second
 	// Device requests are serialized because the ESP8266 serves one request at
 	// a time. A read-only probe can therefore wait behind a frame render before
@@ -192,6 +193,10 @@ type Server struct {
 	refreshCableHello      func() (protocol.DeviceHello, bool)
 	resetCableSender       func()
 	setCableConnectionMode func(string, string, string) error
+	confirmCableMode       func(string, string) error
+	readCableSettings      func(string, string) (protocol.DeviceSettings, error)
+	writeCableSettings     func(string, string, protocol.DeviceSettingsPatch) (protocol.DeviceSettings, error)
+	configureCableWiFi     func(string, string, string, string) error
 	subnetTargets          func() []string
 	defaultWiFiTarget      func() string
 	streamStatus           func(context.Context, string) displayStreamInfo
@@ -942,6 +947,10 @@ func New(opts Options) (*Server, error) {
 		refreshCableHello:      refreshDefaultCableHello,
 		resetCableSender:       usb.CloseDefaultSender,
 		setCableConnectionMode: usb.SetConnectionMode,
+		confirmCableMode:       usb.ConfirmConnectionMode,
+		readCableSettings:      usb.ReadSettings,
+		writeCableSettings:     usb.WriteSettings,
+		configureCableWiFi:     usb.ConfigureWiFi,
 		subnetTargets:          localSubnetTargets,
 		defaultWiFiTarget:      setup.DefaultWiFiTarget,
 		streamStatus:           inspectDisplayStream,
@@ -1045,6 +1054,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/v1/device", s.handleDevice)
 	mux.HandleFunc("/v1/device/pair", s.handleDevicePair)
 	mux.HandleFunc("/v1/setup/connection-mode", s.handleSetupConnectionMode)
+	mux.HandleFunc("/v1/setup/wifi", s.handleSetupWiFi)
 	mux.HandleFunc("/v1/setup/reset", s.handleSetupReset)
 	mux.HandleFunc("/v1/settings", s.handleSettings)
 	mux.HandleFunc("/v1/themes/install", s.handleThemeInstall)
@@ -3414,9 +3424,45 @@ func (s *Server) handleSetupConnectionMode(w http.ResponseWriter, r *http.Reques
 			return
 		}
 	}
+	transitioningFromWiFi := mode == "cable" &&
+		runtimeconfig.NormalizeConnectionMode(cfg.ConnectionMode) == "wifi" &&
+		strings.TrimSpace(cfg.DeviceTarget) != "" && strings.TrimSpace(cfg.DeviceID) != ""
+	if transitioningFromWiFi {
+		hello, helloErr := s.getHelloProbe(r.Context(), cfg.DeviceTarget, cfg.DeviceToken, discoveryProbeTime)
+		if helloErr != nil || !strings.EqualFold(strings.TrimSpace(hello.DeviceID), strings.TrimSpace(cfg.DeviceID)) {
+			writeError(w, http.StatusConflict, "wifi_device_not_found", "The selected WiFi VibeTV is not available.", "Keep VibeTV powered on and retry.")
+			return
+		}
+		if !supportsTransport(hello, "usb") {
+			writeError(w, http.StatusConflict, "connection_mode_unsupported", "This VibeTV does not support Cable mode.", "Keep this VibeTV connected through WiFi.")
+			return
+		}
+		var response struct {
+			OK bool `json:"ok"`
+		}
+		if err := s.doJSON(r.Context(), http.MethodPost, cfg.DeviceTarget, "/api/connection-mode", cfg.DeviceToken, struct {
+			DeviceID string `json:"deviceId"`
+			Mode     string `json:"mode"`
+		}{DeviceID: cfg.DeviceID, Mode: "cable"}, &response); err != nil {
+			writeError(w, http.StatusBadGateway, "connection_mode_switch_failed", "VibeTV could not change its connection.", "Keep VibeTV powered on and retry.")
+			return
+		}
+	}
 	port, err := s.resolveCablePort("", strings.TrimSpace(cfg.DeviceID))
+	if err != nil && transitioningFromWiFi {
+		deadline := time.Now().Add(cableTransitionWait)
+		for err != nil && time.Now().Before(deadline) {
+			select {
+			case <-r.Context().Done():
+				writeError(w, http.StatusRequestTimeout, "connection_mode_switch_cancelled", "The connection change was cancelled.", "Keep VibeTV connected by Cable and try again.")
+				return
+			case <-time.After(500 * time.Millisecond):
+			}
+			port, err = s.resolveCablePort("", strings.TrimSpace(cfg.DeviceID))
+		}
+	}
 	if err != nil {
-		writeError(w, http.StatusConflict, "cable_device_not_found", "No single Cable VibeTV could be selected.", "Connect exactly one VibeTV with a data-capable Cable, then try again.")
+		writeCableResolutionError(w, err)
 		return
 	}
 	hello, err := s.readCableHello(port)
@@ -3425,6 +3471,16 @@ func (s *Server) handleSetupConnectionMode(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	hello = hello.Normalize()
+	if mode == "cable" && hello.Capabilities.Transport.TransitionPending &&
+		strings.EqualFold(hello.Capabilities.Transport.TransitionTo, "cable") {
+		if err := s.confirmCableMode(port, hello.DeviceID); err != nil {
+			writeError(w, http.StatusBadGateway, "connection_mode_confirmation_failed", "VibeTV could not confirm its Cable connection.", "Keep VibeTV connected by Cable and try again before it returns to WiFi.")
+			return
+		}
+		hello.Capabilities.Transport.TransitionPending = false
+		hello.Capabilities.Transport.TransitionFrom = ""
+		hello.Capabilities.Transport.TransitionTo = ""
+	}
 	supportedTransports := append([]string(nil), hello.Capabilities.Transport.Supported...)
 	if expected := strings.TrimSpace(cfg.DeviceID); expected != "" && !strings.EqualFold(expected, hello.DeviceID) {
 		writeError(w, http.StatusConflict, "device_identity_changed", "A different VibeTV answered on Cable.", "Connect the VibeTV you selected, then try again.")
@@ -3441,14 +3497,33 @@ func (s *Server) handleSetupConnectionMode(w http.ResponseWriter, r *http.Reques
 	deviceMode := strings.TrimSpace(strings.ToLower(hello.Capabilities.Transport.Mode))
 	modeAlreadySelected := runtimeconfig.NormalizeConnectionMode(deviceMode) == mode ||
 		(deviceMode == "legacy-wifi-only" && mode == "wifi")
+	knownDevice, known := cfg.KnownDevice(hello.DeviceID)
+	if mode == "wifi" && !modeAlreadySelected && (!known || strings.TrimSpace(knownDevice.Target) == "") {
+		writeJSON(w, http.StatusOK, struct {
+			OK             bool       `json:"ok"`
+			ConnectionMode string     `json:"connectionMode"`
+			Status         string     `json:"status"`
+			Device         deviceInfo `json:"device"`
+		}{
+			OK:             true,
+			ConnectionMode: "wifi",
+			Status:         "wifi_credentials_required",
+			Device: deviceInfo{
+				Target:       cableDeviceTarget,
+				DeviceID:     hello.DeviceID,
+				Active:       true,
+				Paired:       true,
+				Capabilities: &hello.Capabilities,
+			},
+		})
+		return
+	}
 	if !modeAlreadySelected {
 		if err := s.setCableConnectionMode(port, hello.DeviceID, mode); err != nil {
 			writeError(w, http.StatusBadGateway, "connection_mode_switch_failed", "VibeTV could not change its connection.", "Keep VibeTV connected by Cable, then try again.")
 			return
 		}
 	}
-	knownDevice, known := cfg.KnownDevice(hello.DeviceID)
-
 	if mode == "wifi" {
 		if _, err := s.updateConfig(func(current *runtimeconfig.Config) {
 			current.ConnectionMode = ""
@@ -3521,6 +3596,95 @@ func (s *Server) handleSetupConnectionMode(w http.ResponseWriter, r *http.Reques
 		Status         string     `json:"status"`
 		Device         deviceInfo `json:"device"`
 	}{OK: true, ConnectionMode: "cable", Status: "selected", Device: device})
+}
+
+func (s *Server) handleSetupWiFi(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		SSID     string `json:"ssid"`
+		Password string `json:"password"`
+	}
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	req.SSID = strings.TrimSpace(req.SSID)
+	if req.SSID == "" {
+		writeError(w, http.StatusBadRequest, "wifi_name_required", "Enter your WiFi name.", "Enter the WiFi name exactly as it appears on your other devices.")
+		return
+	}
+	if len(req.SSID) >= 33 || len(req.Password) >= 65 {
+		writeError(w, http.StatusBadRequest, "wifi_credentials_too_long", "The WiFi name or password is too long.", "Check the WiFi details and try again.")
+		return
+	}
+	if s.firmwareUpdateActive.Load() {
+		writeError(w, http.StatusConflict, "firmware_update_in_progress", "VibeTV update is still running.", "Wait for the update to finish, then try again.")
+		return
+	}
+
+	s.deviceMaintenanceMu.Lock()
+	defer s.deviceMaintenanceMu.Unlock()
+	s.repairMu.Lock()
+	defer s.repairMu.Unlock()
+	if s.pauseDisplayStream != nil {
+		s.pauseDisplayStream(true)
+		defer s.pauseDisplayStream(false)
+	}
+	cfg, err := s.configForMaintenance()
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if runtimeconfig.NormalizeConnectionMode(cfg.ConnectionMode) != "cable" || strings.TrimSpace(cfg.DeviceID) == "" {
+		writeError(w, http.StatusConflict, "cable_setup_required", "VibeTV is not ready to receive WiFi details by Cable.", "Choose Cable first, then choose WiFi again.")
+		return
+	}
+	port, hello, ok := s.requireCableControlDevice(w, cfg)
+	if !ok {
+		return
+	}
+	if !supportsTransport(hello, "wifi") {
+		writeError(w, http.StatusConflict, "connection_mode_unsupported", "This VibeTV does not support WiFi.", "Keep this VibeTV connected by Cable.")
+		return
+	}
+	if err := s.configureCableWiFi(port, hello.DeviceID, req.SSID, req.Password); err != nil {
+		writeError(w, http.StatusBadGateway, "wifi_configuration_failed", "VibeTV could not save these WiFi details.", "Check the WiFi name and password, keep the Cable connected, then try again.")
+		return
+	}
+	supportedTransports := append([]string(nil), hello.Capabilities.Transport.Supported...)
+	knownDevice, known := cfg.KnownDevice(hello.DeviceID)
+	if _, err := s.updateConfig(func(current *runtimeconfig.Config) {
+		current.ConnectionMode = ""
+		current.DeviceID = strings.TrimSpace(hello.DeviceID)
+		current.CableAutoBindDisabled = true
+		current.ConnectionModeChoiceRequired = false
+		current.DeviceTransports = supportedTransports
+		if known {
+			current.DeviceTarget = knownDevice.Target
+			current.DeviceToken = knownDevice.DeviceToken
+		}
+	}); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, struct {
+		OK             bool       `json:"ok"`
+		ConnectionMode string     `json:"connectionMode"`
+		Status         string     `json:"status"`
+		Device         deviceInfo `json:"device"`
+	}{
+		OK:             true,
+		ConnectionMode: "wifi",
+		Status:         "waiting_for_wifi",
+		Device: deviceInfo{
+			Target:       cableDeviceTarget,
+			DeviceID:     hello.DeviceID,
+			Active:       true,
+			Paired:       true,
+			Capabilities: &hello.Capabilities,
+		},
+	})
 }
 
 func (s *Server) authenticatedKnownWiFiDevice(
@@ -4068,6 +4232,109 @@ func repairDiscoveryErrorIsRetryable(err error) bool {
 	return !errors.As(err, &multiple)
 }
 
+func deviceSettingsFromProtocol(settings protocol.DeviceSettings) deviceSettings {
+	result := deviceSettings{
+		Display: displaySettings{BrightnessPercent: settings.Display.BrightnessPercent},
+	}
+	if settings.Standby != nil {
+		result.Standby = &standbySettings{
+			Enabled:           settings.Standby.Enabled,
+			TimeoutMinutes:    settings.Standby.TimeoutMinutes,
+			BrightnessPercent: settings.Standby.BrightnessPercent,
+			ScreensaverPath:   settings.Standby.ScreensaverPath,
+		}
+	}
+	return result
+}
+
+func settingsPatchForRequest(
+	w http.ResponseWriter,
+	hello protocol.DeviceHello,
+	brightnessPercent int,
+	displayBrightnessPercent int,
+	standbyValue *standbySettings,
+) (protocol.DeviceSettingsPatch, bool) {
+	caps := protocol.CapabilitiesFromHello(hello)
+	if standbyValue != nil {
+		if caps.Known && !caps.SupportsStandby {
+			writeError(w, http.StatusBadRequest, "standby_unsupported", "This VibeTV cannot show a screensaver.", "Update VibeTV, then try again.")
+			return protocol.DeviceSettingsPatch{}, false
+		}
+		return protocol.DeviceSettingsPatch{Standby: &protocol.DeviceStandbySettings{
+			Enabled:           standbyValue.Enabled,
+			TimeoutMinutes:    standbyValue.TimeoutMinutes,
+			BrightnessPercent: standbyValue.BrightnessPercent,
+			ScreensaverPath:   standbyValue.ScreensaverPath,
+		}}, true
+	}
+	brightness := brightnessPercent
+	if brightness == 0 {
+		brightness = displayBrightnessPercent
+	}
+	if caps.Known && !caps.SupportsBrightness {
+		writeError(w, http.StatusBadRequest, "brightness_unsupported", "This VibeTV does not advertise brightness control.", "Update firmware or use a device with brightness support.")
+		return protocol.DeviceSettingsPatch{}, false
+	}
+	minBrightness := protocol.DefaultMinBrightness
+	maxBrightness := protocol.DefaultMaxBrightness
+	if caps.SupportsBrightness {
+		minBrightness = caps.MinBrightnessPercent
+		maxBrightness = caps.MaxBrightnessPercent
+	}
+	if brightness < minBrightness || brightness > maxBrightness {
+		writeError(w, http.StatusBadRequest, "invalid_brightness", fmt.Sprintf("Brightness must be between %d and %d.", minBrightness, maxBrightness), "Choose a supported brightness value and retry.")
+		return protocol.DeviceSettingsPatch{}, false
+	}
+	return protocol.DeviceSettingsPatch{BrightnessPercent: &brightness}, true
+}
+
+func (s *Server) requireCableControlDevice(
+	w http.ResponseWriter,
+	cfg runtimeconfig.Config,
+) (string, protocol.DeviceHello, bool) {
+	expectedDeviceID := strings.TrimSpace(cfg.DeviceID)
+	if expectedDeviceID == "" {
+		writeDeviceNotFound(w)
+		return "", protocol.DeviceHello{}, false
+	}
+	port, err := s.resolveCablePort("", expectedDeviceID)
+	if err != nil {
+		writeCableResolutionError(w, err)
+		return "", protocol.DeviceHello{}, false
+	}
+	hello, err := s.readCableHello(port)
+	hello = hello.Normalize()
+	if err != nil || !cableHelloMatchesConfig(hello, expectedDeviceID) {
+		writeError(w, http.StatusConflict, "cable_identity_unavailable", "The selected Cable VibeTV did not provide its current identity.", "Reconnect the Cable, wait for VibeTV to start, then retry.")
+		return "", protocol.DeviceHello{}, false
+	}
+	return port, hello, true
+}
+
+func writeCableResolutionError(w http.ResponseWriter, err error) {
+	switch errcode.Of(err) {
+	case errcode.TransportMultipleDevices:
+		writeError(w, http.StatusConflict, "multiple_cable_devices", "More than one VibeTV is connected by Cable.", "Leave only the VibeTV you want connected, then try again.")
+	case errcode.TransportForeignDevice:
+		writeError(w, http.StatusConflict, "foreign_serial_device", "The connected USB device is not a VibeTV.", "Disconnect it and connect VibeTV with a data-capable Cable.")
+	default:
+		writeError(w, http.StatusConflict, "cable_device_not_found", "The selected Cable VibeTV is not available.", "Connect that VibeTV with a data-capable Cable and retry.")
+	}
+}
+
+func (s *Server) cableDeviceInfo(ctx context.Context, cfg runtimeconfig.Config, hello protocol.DeviceHello) deviceInfo {
+	stream := s.streamStatus(ctx, cableDeviceTarget)
+	return s.withConfiguredConnectionState(cfg, withDisplayStreamInfo(deviceInfo{
+		Target:       cableDeviceTarget,
+		DeviceID:     hello.DeviceID,
+		Board:        hello.Board,
+		Firmware:     hello.Firmware,
+		Active:       true,
+		Paired:       true,
+		Capabilities: &hello.Capabilities,
+	}, stream), providerSetupStreamForTarget(streamPointer(stream), cableDeviceTarget), false)
+}
+
 func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
@@ -4080,6 +4347,26 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleSettingsGet(w http.ResponseWriter, r *http.Request) {
+	if cfg, err := s.config(); err != nil {
+		writeInternalError(w, err)
+		return
+	} else if runtimeconfig.NormalizeConnectionMode(cfg.ConnectionMode) == "cable" {
+		port, hello, ok := s.requireCableControlDevice(w, cfg)
+		if !ok {
+			return
+		}
+		settings, err := s.readCableSettings(port, hello.DeviceID)
+		if err != nil {
+			writeError(w, http.StatusBadGateway, "settings_read_failed", "Could not read VibeTV settings.", "Keep VibeTV connected by Cable and retry.")
+			return
+		}
+		writeJSON(w, http.StatusOK, settingsResponse{
+			OK:       true,
+			Settings: deviceSettingsFromProtocol(settings),
+			Device:   s.cableDeviceInfo(r.Context(), cfg, hello),
+		})
+		return
+	}
 	cfg, hello, ok := s.requireDevice(w, r)
 	if !ok {
 		return
@@ -4104,10 +4391,6 @@ func (s *Server) handleSettingsGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleSettingsPost(w http.ResponseWriter, r *http.Request) {
-	cfg, hello, ok := s.requireDevice(w, r)
-	if !ok {
-		return
-	}
 	var req struct {
 		BrightnessPercent int `json:"brightnessPercent"`
 		Display           struct {
@@ -4118,48 +4401,60 @@ func (s *Server) handleSettingsPost(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	caps := protocol.CapabilitiesFromHello(hello)
-	form := url.Values{}
-	form.Set("api", "1")
-	if req.Standby != nil {
-		if caps.Known && !caps.SupportsStandby {
-			writeError(w, http.StatusBadRequest, "standby_unsupported", "This VibeTV cannot show a screensaver.", "Update VibeTV, then try again.")
+	cfg, err := s.config()
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if runtimeconfig.NormalizeConnectionMode(cfg.ConnectionMode) == "cable" {
+		port, hello, ok := s.requireCableControlDevice(w, cfg)
+		if !ok {
 			return
 		}
+		patch, ok := settingsPatchForRequest(w, hello, req.BrightnessPercent, req.Display.BrightnessPercent, req.Standby)
+		if !ok {
+			return
+		}
+		settings, err := s.writeCableSettings(port, hello.DeviceID, patch)
+		if err != nil {
+			writeError(w, http.StatusBadGateway, "settings_write_failed", "Could not update VibeTV settings.", "Keep VibeTV connected by Cable and retry.")
+			return
+		}
+		writeJSON(w, http.StatusOK, settingsResponse{
+			OK:       true,
+			Settings: deviceSettingsFromProtocol(settings),
+			Device:   s.cableDeviceInfo(r.Context(), cfg, hello),
+		})
+		return
+	}
+	wifiCfg, hello, ok := s.requireDevice(w, r)
+	if !ok {
+		return
+	}
+	cfg = wifiCfg
+	patch, ok := settingsPatchForRequest(w, hello, req.BrightnessPercent, req.Display.BrightnessPercent, req.Standby)
+	if !ok {
+		return
+	}
+	form := url.Values{}
+	form.Set("api", "1")
+	if patch.Standby != nil {
 		enabled := "0"
-		if req.Standby.Enabled {
+		if patch.Standby.Enabled {
 			enabled = "1"
 		}
 		// The device clamps timeout and screensaver brightness and answers with
 		// the stored values, so the Companion does not repeat that arithmetic.
 		form.Set("sb", enabled)
-		form.Set("st", strconv.Itoa(req.Standby.TimeoutMinutes))
-		form.Set("sbr", strconv.Itoa(req.Standby.BrightnessPercent))
+		form.Set("st", strconv.Itoa(patch.Standby.TimeoutMinutes))
+		form.Set("sbr", strconv.Itoa(patch.Standby.BrightnessPercent))
 		// Omitting screensaverPath leaves the slot as it is; an empty string
 		// clears it. The device rejects a path it has no file for.
-		if req.Standby.ScreensaverPath != nil {
-			form.Set("ss", strings.TrimSpace(*req.Standby.ScreensaverPath))
+		if patch.Standby.ScreensaverPath != nil {
+			form.Set("ss", strings.TrimSpace(*patch.Standby.ScreensaverPath))
 		}
 	} else {
-		brightness := req.BrightnessPercent
-		if brightness == 0 {
-			brightness = req.Display.BrightnessPercent
-		}
-		if caps.Known && !caps.SupportsBrightness {
-			writeError(w, http.StatusBadRequest, "brightness_unsupported", "This VibeTV does not advertise brightness control.", "Update firmware or use a device with brightness support.")
-			return
-		}
-		minBrightness := protocol.DefaultMinBrightness
-		maxBrightness := protocol.DefaultMaxBrightness
-		if caps.SupportsBrightness {
-			minBrightness = caps.MinBrightnessPercent
-			maxBrightness = caps.MaxBrightnessPercent
-		}
-		if brightness < minBrightness || brightness > maxBrightness {
-			writeError(w, http.StatusBadRequest, "invalid_brightness", fmt.Sprintf("Brightness must be between %d and %d.", minBrightness, maxBrightness), "Choose a supported brightness value and retry.")
-			return
-		}
-		form.Set("b", strconv.Itoa(brightness))
+		form.Set("b", strconv.Itoa(*patch.BrightnessPercent))
 	}
 	settings, err := s.updateDeviceSettings(r.Context(), cfg.DeviceTarget, cfg.DeviceToken, form)
 	if err != nil {

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -7520,7 +7520,7 @@ func TestStatusPreservesFreshCableChoiceAndReportsTransportSupport(t *testing.T)
 	}
 }
 
-func TestSetupConnectionModeStartsWiFiTransitionBeforeChangingHostMode(t *testing.T) {
+func TestSetupConnectionModeCollectsWiFiCredentialsBeforeChangingHostMode(t *testing.T) {
 	server := newTestServer(t, runtimeconfig.Config{
 		ConnectionMode: "cable",
 		DeviceID:       "device-cable",
@@ -7536,7 +7536,7 @@ func TestSetupConnectionModeStartsWiFiTransitionBeforeChangingHostMode(t *testin
 			Kind:     "hello",
 			DeviceID: "device-cable",
 			Capabilities: protocol.CapabilityBlock{
-				Transport: protocol.TransportCapabilities{Supported: []string{"usb", "wifi"}},
+				Transport: protocol.TransportCapabilities{Active: "usb", Mode: "cable", Supported: []string{"usb", "wifi"}},
 			},
 		}, nil
 	}
@@ -7553,21 +7553,46 @@ func TestSetupConnectionModeStartsWiFiTransitionBeforeChangingHostMode(t *testin
 	req := httptest.NewRequest(http.MethodPost, "/v1/setup/connection-mode", strings.NewReader(`{"mode":"wifi"}`))
 	req.Header.Set("Content-Type", "application/json")
 	server.Handler().ServeHTTP(rec, req)
-	if rec.Code != http.StatusAccepted {
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "wifi_credentials_required") {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
-	if switchCalls != 1 {
-		t.Fatalf("expected one device transition, got %d", switchCalls)
+	if switchCalls != 0 {
+		t.Fatalf("WiFi transition started before credentials were supplied: %d", switchCalls)
 	}
 	cfg, err := server.config()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.ConnectionMode != "" || !cfg.CableAutoBindDisabled || cfg.DeviceID != "device-cable" {
-		t.Fatalf("host mode changed before WiFi confirmation: %+v", cfg)
+	if cfg.ConnectionMode != "cable" || cfg.CableAutoBindDisabled || cfg.DeviceID != "device-cable" {
+		t.Fatalf("host mode changed before WiFi credentials: %+v", cfg)
 	}
-	if cfg.ConnectionModeChoiceRequired {
-		t.Fatal("explicit WiFi selection must clear the connection chooser")
+
+	configuredSSID := ""
+	configuredPassword := ""
+	server.configureCableWiFi = func(port, deviceID, ssid, password string) error {
+		if port != "/dev/cu.usbserial-vibetv" || deviceID != "device-cable" {
+			t.Fatalf("unexpected Cable WiFi target port=%q device=%q", port, deviceID)
+		}
+		configuredSSID = ssid
+		configuredPassword = password
+		return nil
+	}
+	wifi := httptest.NewRecorder()
+	wifiReq := httptest.NewRequest(http.MethodPost, "/v1/setup/wifi", strings.NewReader(`{"ssid":"Home WiFi","password":"secret pass"}`))
+	wifiReq.Header.Set("Content-Type", "application/json")
+	server.Handler().ServeHTTP(wifi, wifiReq)
+	if wifi.Code != http.StatusAccepted || !strings.Contains(wifi.Body.String(), "waiting_for_wifi") {
+		t.Fatalf("WiFi credentials status=%d body=%s", wifi.Code, wifi.Body.String())
+	}
+	if configuredSSID != "Home WiFi" || configuredPassword != "secret pass" {
+		t.Fatalf("WiFi credentials were not forwarded exactly")
+	}
+	cfg, err = server.config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ConnectionMode != "" || !cfg.CableAutoBindDisabled || cfg.DeviceID != "device-cable" || cfg.ConnectionModeChoiceRequired {
+		t.Fatalf("host did not retain a pending WiFi transition: %+v", cfg)
 	}
 }
 
@@ -7597,6 +7622,81 @@ func TestSetupConnectionModeRejectsWiFiForCableOnlyBoard(t *testing.T) {
 	server.Handler().ServeHTTP(rec, req)
 	if rec.Code != http.StatusConflict || !strings.Contains(rec.Body.String(), "connection_mode_unsupported") {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSetupConnectionModeSwitchesFromWiFiThroughTheActiveHTTPPath(t *testing.T) {
+	const token = "pair-token"
+	var switchCalls int
+	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hello":
+			if r.Header.Get("X-VibeTV-Token") != token {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			_, _ = io.WriteString(w, `{"kind":"hello","deviceId":"wifi-to-cable","board":"esp8266-smalltv-st7789","capabilities":{"transport":{"active":"wifi","mode":"wifi","supported":["usb","wifi"]}}}`)
+		case "/api/connection-mode":
+			switchCalls++
+			if r.Method != http.MethodPost || r.Header.Get("X-VibeTV-Token") != token {
+				t.Fatalf("unexpected WiFi switch request method=%s token=%q", r.Method, r.Header.Get("X-VibeTV-Token"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"ok":true}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer device.Close()
+
+	server := newTestServer(t, runtimeconfig.Config{
+		ConnectionMode: "wifi",
+		DeviceID:       "wifi-to-cable",
+		DeviceTarget:   device.URL,
+		DeviceToken:    token,
+	})
+	server.resolveCablePort = func(explicit, expectedDeviceID string) (string, error) {
+		if explicit != "" || expectedDeviceID != "wifi-to-cable" {
+			t.Fatalf("unexpected Cable confirmation resolution explicit=%q expected=%q", explicit, expectedDeviceID)
+		}
+		return "/dev/cu.usbserial-transition", nil
+	}
+	server.readCableHello = func(string) (protocol.DeviceHello, error) {
+		return protocol.DeviceHello{
+			Kind:     "hello",
+			Board:    "esp8266-smalltv-st7789",
+			DeviceID: "wifi-to-cable",
+			Capabilities: protocol.CapabilityBlock{Transport: protocol.TransportCapabilities{
+				Active: "usb", Mode: "cable", Supported: []string{"usb", "wifi"},
+				TransitionPending: true, TransitionFrom: "wifi", TransitionTo: "cable",
+			}},
+		}, nil
+	}
+	confirmCalls := 0
+	server.confirmCableMode = func(port, deviceID string) error {
+		confirmCalls++
+		if port != "/dev/cu.usbserial-transition" || deviceID != "wifi-to-cable" {
+			t.Fatalf("unexpected Cable confirmation port=%q device=%q", port, deviceID)
+		}
+		return nil
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/setup/connection-mode", strings.NewReader(`{"mode":"cable"}`))
+	req.Header.Set("Content-Type", "application/json")
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if switchCalls != 1 || confirmCalls != 1 {
+		t.Fatalf("expected one WiFi switch and one Cable confirmation, got switch=%d confirm=%d", switchCalls, confirmCalls)
+	}
+	cfg, err := server.config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ConnectionMode != "cable" || cfg.DeviceID != "wifi-to-cable" || cfg.DeviceTarget != device.URL || cfg.DeviceToken != token {
+		t.Fatalf("Cable mode did not preserve the authenticated WiFi profile: %+v", cfg)
 	}
 }
 
@@ -9980,6 +10080,67 @@ func TestThemeInstallCanBeDisabledByLocalEnv(t *testing.T) {
 	}
 	if got.OK || got.Error.Code != "theme_install_disabled" {
 		t.Fatalf("unexpected disabled response: %+v", got)
+	}
+}
+
+func TestCableSettingsUseSerialReadbackWithoutAnHTTPProbe(t *testing.T) {
+	server := newTestServer(t, runtimeconfig.Config{
+		ConnectionMode: "cable",
+		DeviceID:       "cable-settings",
+	})
+	server.resolveCablePort = func(explicit, expectedDeviceID string) (string, error) {
+		if explicit != "" || expectedDeviceID != "cable-settings" {
+			t.Fatalf("unexpected Cable settings resolution explicit=%q expected=%q", explicit, expectedDeviceID)
+		}
+		return "/dev/cu.usbserial-settings", nil
+	}
+	server.readCableHello = func(string) (protocol.DeviceHello, error) {
+		return protocol.DeviceHello{
+			Kind:     "hello",
+			Board:    "esp8266-smalltv-st7789",
+			DeviceID: "cable-settings",
+			Capabilities: protocol.CapabilityBlock{
+				Display: protocol.DisplayCapabilities{
+					Brightness: protocol.DisplayBrightnessCapabilities{Supported: true, MinPercent: 10, MaxPercent: 100},
+				},
+				Transport: protocol.TransportCapabilities{Active: "usb", Mode: "cable", Supported: []string{"usb", "wifi"}},
+			},
+		}, nil
+	}
+	confirmed := protocol.DeviceSettings{
+		Display: protocol.DeviceDisplaySettings{BrightnessPercent: 35},
+		Standby: &protocol.DeviceStandbySettings{Enabled: true, TimeoutMinutes: 15, BrightnessPercent: 10},
+	}
+	server.readCableSettings = func(port, deviceID string) (protocol.DeviceSettings, error) {
+		if port != "/dev/cu.usbserial-settings" || deviceID != "cable-settings" {
+			t.Fatalf("unexpected Cable settings read port=%q device=%q", port, deviceID)
+		}
+		return confirmed, nil
+	}
+	server.writeCableSettings = func(port, deviceID string, patch protocol.DeviceSettingsPatch) (protocol.DeviceSettings, error) {
+		if port != "/dev/cu.usbserial-settings" || deviceID != "cable-settings" || patch.BrightnessPercent == nil || *patch.BrightnessPercent != 60 {
+			t.Fatalf("unexpected Cable settings write port=%q device=%q patch=%+v", port, deviceID, patch)
+		}
+		confirmed.Display.BrightnessPercent = 60
+		return confirmed, nil
+	}
+	server.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("Cable settings must not probe HTTP")
+		return nil, errors.New("unexpected HTTP request")
+	})
+
+	get := httptest.NewRecorder()
+	server.Handler().ServeHTTP(get, httptest.NewRequest(http.MethodGet, "/v1/settings", nil))
+	if get.Code != http.StatusOK || !strings.Contains(get.Body.String(), `"brightnessPercent":35`) {
+		t.Fatalf("Cable settings read status=%d body=%s", get.Code, get.Body.String())
+	}
+
+	post := httptest.NewRecorder()
+	postReq := httptest.NewRequest(http.MethodPost, "/v1/settings", strings.NewReader(`{"brightnessPercent":60}`))
+	postReq.Header.Set("Content-Type", "application/json")
+	server.Handler().ServeHTTP(post, postReq)
+	if post.Code != http.StatusOK || !strings.Contains(post.Body.String(), `"brightnessPercent":60`) {
+		t.Fatalf("Cable settings write status=%d body=%s", post.Code, post.Body.String())
 	}
 }
 

--- a/companion/internal/errcode/errcode.go
+++ b/companion/internal/errcode/errcode.go
@@ -11,6 +11,7 @@ const (
 	TransportNoSerialPorts      Code = "transport/no-serial-ports"
 	TransportNoUSBSerialPorts   Code = "transport/no-usb-serial-ports"
 	TransportNoMatchingDevice   Code = "transport/no-matching-vibetv"
+	TransportForeignDevice      Code = "transport/foreign-serial-device"
 	TransportMultipleDevices    Code = "transport/multiple-vibetvs"
 	TransportSerialOpen         Code = "transport/serial-open"
 	TransportSerialWrite        Code = "transport/serial-write"
@@ -108,6 +109,8 @@ func DefaultRecovery(code Code) string {
 		return "Reconnect the board with a data-capable USB cable and retry."
 	case TransportNoMatchingDevice:
 		return "Connect the expected VibeTV by Cable and retry. Foreign serial devices are ignored."
+	case TransportForeignDevice:
+		return "Disconnect the other serial device and connect VibeTV with a data-capable Cable."
 	case TransportMultipleDevices:
 		return "Leave exactly one matching VibeTV connected and retry."
 	case TransportSerialOpen:

--- a/companion/internal/protocol/device.go
+++ b/companion/internal/protocol/device.go
@@ -96,6 +96,31 @@ type DeviceHello struct {
 	Capabilities              CapabilityBlock `json:"capabilities,omitempty"`
 }
 
+// DeviceSettings is the shared settings payload returned by both the WiFi
+// HTTP API and the Cable control protocol.
+type DeviceSettings struct {
+	Display DeviceDisplaySettings  `json:"display"`
+	Standby *DeviceStandbySettings `json:"standby,omitempty"`
+}
+
+type DeviceDisplaySettings struct {
+	BrightnessPercent int `json:"brightnessPercent"`
+}
+
+type DeviceStandbySettings struct {
+	Enabled           bool    `json:"enabled"`
+	TimeoutMinutes    int     `json:"timeoutMinutes"`
+	BrightnessPercent int     `json:"brightnessPercent"`
+	ScreensaverPath   *string `json:"screensaverPath"`
+}
+
+// DeviceSettingsPatch keeps omitted fields distinct from explicit zero/empty
+// values so Cable and WiFi apply exactly the same partial-update semantics.
+type DeviceSettingsPatch struct {
+	BrightnessPercent *int                   `json:"brightnessPercent,omitempty"`
+	Standby           *DeviceStandbySettings `json:"standby,omitempty"`
+}
+
 func (h DeviceHello) Normalize() DeviceHello {
 	h.Kind = strings.TrimSpace(strings.ToLower(h.Kind))
 	h.Board = strings.TrimSpace(strings.ToLower(h.Board))

--- a/companion/internal/usb/hello_reader.go
+++ b/companion/internal/usb/hello_reader.go
@@ -107,6 +107,47 @@ func readConnectionModeSwitchFromPort(port SerialPort, window time.Duration, dev
 	return nil
 }
 
+func readSettingsFromPort(port SerialPort, window time.Duration, deviceID string) (protocol.DeviceSettings, error) {
+	var settings protocol.DeviceSettings
+	var responseErr error
+	seen := readPortLines(port, window, func(line string) bool {
+		if !strings.HasPrefix(strings.TrimSpace(line), "{") {
+			return false
+		}
+		var reply struct {
+			Kind     string                  `json:"kind"`
+			DeviceID string                  `json:"deviceId"`
+			Settings protocol.DeviceSettings `json:"settings"`
+			Code     string                  `json:"code"`
+			Message  string                  `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(line), &reply); err != nil {
+			return false
+		}
+		switch strings.TrimSpace(reply.Kind) {
+		case "error":
+			responseErr = fmt.Errorf("device rejected settings request: %s: %s", strings.TrimSpace(reply.Code), strings.TrimSpace(reply.Message))
+			return true
+		case "settings":
+			if !strings.EqualFold(strings.TrimSpace(reply.DeviceID), strings.TrimSpace(deviceID)) {
+				responseErr = errors.New("device returned settings for a different identity")
+				return true
+			}
+			settings = reply.Settings
+			return true
+		default:
+			return false
+		}
+	})
+	if responseErr != nil {
+		return protocol.DeviceSettings{}, responseErr
+	}
+	if !seen {
+		return protocol.DeviceSettings{}, errors.New("device did not acknowledge settings request")
+	}
+	return settings, nil
+}
+
 func readPortLines(port SerialPort, window time.Duration, accept func(string) bool) bool {
 	if port == nil || window <= 0 || accept == nil {
 		return false

--- a/companion/internal/usb/resolver.go
+++ b/companion/internal/usb/resolver.go
@@ -169,6 +169,7 @@ func resolveVibeTVCandidatesForControl(
 	allowWiFiMode bool,
 ) (string, error) {
 	matches := make([]string, 0, 1)
+	foreignDeviceAnswered := false
 	for _, candidate := range candidates {
 		hello, err := readHello(candidate)
 		if err != nil {
@@ -176,8 +177,11 @@ func resolveVibeTVCandidatesForControl(
 		}
 		hello = hello.Normalize()
 		mode := hello.Capabilities.Transport.Mode
-		if hello.Kind != "hello" ||
-			!isSupportedCableBoard(hello.Board) ||
+		if hello.Kind == "hello" && strings.TrimSpace(hello.Board) != "" &&
+			!isSupportedCableBoard(hello.Board) {
+			foreignDeviceAnswered = true
+		}
+		if hello.Kind != "hello" || !isSupportedCableBoard(hello.Board) ||
 			hello.DeviceID == "" ||
 			hello.Capabilities.Transport.Active != "usb" ||
 			(mode != "cable" && (!allowWiFiMode || (mode != "wifi" && mode != "legacy-wifi-only"))) {
@@ -193,6 +197,15 @@ func resolveVibeTVCandidatesForControl(
 	case 1:
 		return matches[0], nil
 	case 0:
+		if foreignDeviceAnswered {
+			return "", wrapTransportError(
+				errcode.TransportForeignDevice,
+				"resolve-vibetv",
+				explicit,
+				"Disconnect the other serial device and connect VibeTV with a data-capable Cable.",
+				errors.New("a non-VibeTV serial device answered hello"),
+			)
+		}
 		detail := "no matching Cable VibeTV answered hello"
 		if expectedDeviceID != "" {
 			detail = fmt.Sprintf("VibeTV deviceId %q was not found", expectedDeviceID)

--- a/companion/internal/usb/resolver_identity_test.go
+++ b/companion/internal/usb/resolver_identity_test.go
@@ -54,7 +54,7 @@ func TestResolveVibeTVCandidatesAcceptsLilygoCableIdentity(t *testing.T) {
 	}
 }
 
-func TestResolveVibeTVCandidatesIgnoresForeignAndUnresponsivePorts(t *testing.T) {
+func TestResolveVibeTVCandidatesReportsAResponsiveForeignDevice(t *testing.T) {
 	ports := []string{"/dev/cu.usbserial-foreign", "/dev/cu.usbserial-offline"}
 	_, err := resolveVibeTVCandidates(
 		ports,
@@ -67,8 +67,8 @@ func TestResolveVibeTVCandidatesIgnoresForeignAndUnresponsivePorts(t *testing.T)
 			return protocol.DeviceHello{}, errors.New("no response")
 		},
 	)
-	if errcode.Of(err) != errcode.TransportNoMatchingDevice {
-		t.Fatalf("expected no matching device, got %v", err)
+	if errcode.Of(err) != errcode.TransportForeignDevice {
+		t.Fatalf("expected foreign serial device, got %v", err)
 	}
 }
 

--- a/companion/internal/usb/sender.go
+++ b/companion/internal/usb/sender.go
@@ -1,6 +1,7 @@
 package usb
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -319,6 +320,93 @@ func (s *Sender) SetConnectionMode(path, deviceID, mode string) error {
 	}
 	// The acknowledged switch schedules a reboot, so the old serial handle is
 	// no longer authoritative.
+	s.closeCurrentLocked()
+	return nil
+}
+
+func (s *Sender) ReadSettings(path, deviceID string) (protocol.DeviceSettings, error) {
+	return s.requestSettings(path, deviceID, nil)
+}
+
+func (s *Sender) WriteSettings(path, deviceID string, patch protocol.DeviceSettingsPatch) (protocol.DeviceSettings, error) {
+	return s.requestSettings(path, deviceID, &patch)
+}
+
+func (s *Sender) requestSettings(path, deviceID string, patch *protocol.DeviceSettingsPatch) (protocol.DeviceSettings, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, err := s.ensurePort(path); err != nil {
+		return protocol.DeviceSettings{}, err
+	}
+	request := struct {
+		Kind     string                        `json:"kind"`
+		Op       string                        `json:"op"`
+		DeviceID string                        `json:"deviceId"`
+		Settings *protocol.DeviceSettingsPatch `json:"settings,omitempty"`
+	}{Kind: "request", Op: "settings", DeviceID: strings.TrimSpace(deviceID), Settings: patch}
+	line, err := json.Marshal(request)
+	if err != nil {
+		return protocol.DeviceSettings{}, err
+	}
+	line = append(line, '\n')
+	_ = s.port.ResetInputBuffer()
+	if err := writeWithTimeout(s.port, line, s.writeTimeout); err != nil {
+		s.closeCurrentLocked()
+		return protocol.DeviceSettings{}, wrapTransportError(
+			errcode.TransportSerialWrite,
+			"settings",
+			path,
+			"Keep the selected VibeTV connected by Cable and retry.",
+			err,
+		)
+	}
+	settings, err := readSettingsFromPort(s.port, s.helloWindow, deviceID)
+	if err != nil {
+		return protocol.DeviceSettings{}, fmt.Errorf("settings on %s: %w", path, err)
+	}
+	return settings, nil
+}
+
+func (s *Sender) ConfigureWiFi(path, deviceID, ssid, password string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, err := s.ensurePort(path); err != nil {
+		return err
+	}
+	request := struct {
+		Kind     string `json:"kind"`
+		Op       string `json:"op"`
+		DeviceID string `json:"deviceId"`
+		SSID     string `json:"ssid"`
+		Password string `json:"password"`
+	}{
+		Kind:     "request",
+		Op:       "configure-wifi",
+		DeviceID: strings.TrimSpace(deviceID),
+		SSID:     ssid,
+		Password: password,
+	}
+	line, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+	line = append(line, '\n')
+	_ = s.port.ResetInputBuffer()
+	if err := writeWithTimeout(s.port, line, s.writeTimeout); err != nil {
+		s.closeCurrentLocked()
+		return wrapTransportError(
+			errcode.TransportSerialWrite,
+			"configure-wifi",
+			path,
+			"Keep the selected VibeTV connected by Cable and retry.",
+			err,
+		)
+	}
+	if err := readConnectionModeSwitchFromPort(s.port, s.helloWindow, deviceID, "wifi"); err != nil {
+		return fmt.Errorf("configure WiFi on %s: %w", path, err)
+	}
 	s.closeCurrentLocked()
 	return nil
 }

--- a/companion/internal/usb/usb.go
+++ b/companion/internal/usb/usb.go
@@ -83,6 +83,22 @@ func SetConnectionMode(port, deviceID, mode string) error {
 	return defaultSender.SetConnectionMode(port, deviceID, mode)
 }
 
+func ConfirmConnectionMode(port, deviceID string) error {
+	return defaultSender.ConfirmConnectionMode(port, deviceID)
+}
+
+func ReadSettings(port, deviceID string) (protocol.DeviceSettings, error) {
+	return defaultSender.ReadSettings(port, deviceID)
+}
+
+func WriteSettings(port, deviceID string, patch protocol.DeviceSettingsPatch) (protocol.DeviceSettings, error) {
+	return defaultSender.WriteSettings(port, deviceID, patch)
+}
+
+func ConfigureWiFi(port, deviceID, ssid, password string) error {
+	return defaultSender.ConfigureWiFi(port, deviceID, ssid, password)
+}
+
 func CloseDefaultSender() {
 	defaultSender.Close()
 }

--- a/companion/internal/usb/usb_test.go
+++ b/companion/internal/usb/usb_test.go
@@ -385,6 +385,69 @@ func TestSenderStartsWiFiConnectionModeTransition(t *testing.T) {
 	}
 }
 
+func TestSenderReadsAndWritesConfirmedCableSettings(t *testing.T) {
+	path := "/dev/mock"
+	port := newMockSerialPort()
+	readReply := []byte(`{"kind":"settings","deviceId":"14799300","settings":{"display":{"brightnessPercent":35},"standby":{"enabled":true,"timeoutMinutes":15,"brightnessPercent":10,"screensaverPath":"/themes/s/night-clock.json"}}}` + "\n")
+	writeReply := []byte(`{"kind":"settings","deviceId":"14799300","settings":{"display":{"brightnessPercent":60},"standby":{"enabled":true,"timeoutMinutes":15,"brightnessPercent":10,"screensaverPath":"/themes/s/night-clock.json"}}}` + "\n")
+	port.readQueue = [][]byte{
+		readReply[:100], readReply[100:],
+		writeReply[:100], writeReply[100:],
+	}
+	sender := NewSenderWithConfig(SenderConfig{
+		Opener:      &mockOpener{portsByPath: map[string]SerialPort{path: port}},
+		Sleep:       func(time.Duration) {},
+		HelloWindow: 10 * time.Millisecond,
+	})
+	defer sender.Close()
+
+	settings, err := sender.ReadSettings(path, "14799300")
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if settings.Display.BrightnessPercent != 35 || settings.Standby == nil || settings.Standby.TimeoutMinutes != 15 {
+		t.Fatalf("unexpected settings: %+v", settings)
+	}
+	brightness := 60
+	settings, err = sender.WriteSettings(path, "14799300", protocol.DeviceSettingsPatch{BrightnessPercent: &brightness})
+	if err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	if settings.Display.BrightnessPercent != 60 {
+		t.Fatalf("write did not return confirmed brightness: %+v", settings)
+	}
+	if len(port.writePayloads) != 2 {
+		t.Fatalf("expected two settings requests, got %#v", port.writePayloads)
+	}
+	if got := string(port.writePayloads[0]); got != `{"kind":"request","op":"settings","deviceId":"14799300"}`+"\n" {
+		t.Fatalf("unexpected read request %q", got)
+	}
+	if got := string(port.writePayloads[1]); got != `{"kind":"request","op":"settings","deviceId":"14799300","settings":{"brightnessPercent":60}}`+"\n" {
+		t.Fatalf("unexpected write request %q", got)
+	}
+}
+
+func TestSenderConfiguresWiFiWithoutLoggingOrReusingTheSecret(t *testing.T) {
+	port := newMockSerialPort()
+	port.readQueue = [][]byte{[]byte(`{"kind":"connection-mode","status":"switching","deviceId":"14799300","mode":"wifi"}` + "\n")}
+	sender := NewSenderWithConfig(SenderConfig{
+		Opener:      &mockOpener{portsByPath: map[string]SerialPort{"/dev/mock": port}},
+		Sleep:       func(time.Duration) {},
+		HelloWindow: 10 * time.Millisecond,
+	})
+
+	if err := sender.ConfigureWiFi("/dev/mock", "14799300", "Home WiFi", "secret pass"); err != nil {
+		t.Fatalf("configure WiFi: %v", err)
+	}
+	want := `{"kind":"request","op":"configure-wifi","deviceId":"14799300","ssid":"Home WiFi","password":"secret pass"}` + "\n"
+	if len(port.writePayloads) != 1 || string(port.writePayloads[0]) != want {
+		t.Fatalf("unexpected WiFi configuration request %#v", port.writePayloads)
+	}
+	if port.closeCalls != 1 {
+		t.Fatal("acknowledged WiFi switch must release the rebooting device port")
+	}
+}
+
 type mockOpener struct {
 	mu          sync.Mutex
 	portsByPath map[string]SerialPort

--- a/docs/hardware-contract.md
+++ b/docs/hardware-contract.md
@@ -112,8 +112,9 @@ device-side hash check. A final live identity lookup without a supplied port
 resolved `/dev/cu.usbserial-11230`, protocol 2, and the expected board and
 theme limits.
 
-The local #395 customer-flow development build on 2026-08-27 uses 478,451 bytes
-flash and 47,328 bytes RAM and remains below the release gates. It passed the
+The local #395 customer-flow development build on 2026-08-27 uses 477,531 bytes
+flash and 46,992 bytes RAM; its 481,680-byte image remains below the release
+gates with 320 bytes of binary-image reserve. It passed the
 release-gated ESP8266 build and native suites, but was not flashed to hardware;
 real-screen rehearsal still requires a separate current hardware-write
 approval.

--- a/docs/hardware-contract.md
+++ b/docs/hardware-contract.md
@@ -78,6 +78,15 @@ existing `VibeTV-Setup` portal open for a bounded ten-minute customer-entry
 window. Saving credentials reboots into the normal 60-second association and
 identity-confirmation window. A failed WiFi association or expired setup or
 confirmation window restores the previous mode and reboots once.
+
+The Mac App customer path uses the narrower serial `configure-wifi` request:
+it validates and stores the entered SSID/key through the same credential owner,
+then begins the existing Cable-to-WiFi transaction. The secret is never echoed
+or logged. WiFi-to-Cable starts on the active authenticated HTTP path, then the
+Companion resolves and confirms the same `deviceId` over Cable. Brightness and
+standby use one serial `settings` request in Cable mode and the existing HTTP
+settings endpoint in WiFi mode; both finish in the same firmware validation,
+persistence, apply, and complete readback owner.
 An incomplete power-loss write is discarded on boot when `/cm` does not match
 the mode in `/s`. `legacy-wifi-only` can never start a Cable transition.
 
@@ -102,6 +111,12 @@ That exact image was subsequently flashed at 115200 baud and passed the
 device-side hash check. A final live identity lookup without a supplied port
 resolved `/dev/cu.usbserial-11230`, protocol 2, and the expected board and
 theme limits.
+
+The local #395 customer-flow development build on 2026-08-27 uses 478,451 bytes
+flash and 47,328 bytes RAM and remains below the release gates. It passed the
+release-gated ESP8266 build and native suites, but was not flashed to hardware;
+real-screen rehearsal still requires a separate current hardware-write
+approval.
 
 ## Cutover Migration Contract
 

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -1935,6 +1935,31 @@ void emitSerialStatus() {
   Serial.println(out);
 }
 
+void emitSerialError(const char* code) {
+  String out = "{\"kind\":\"error\",\"code\":\"";
+  out += code;
+  out += "\"}";
+  Serial.println(out);
+}
+
+void emitSerialConnectionMode(
+    const String& status,
+    device_settings::ConnectionMode mode,
+    bool confirmationRequired) {
+  String out = "{\"kind\":\"connection-mode\",\"status\":\"";
+  out += status;
+  out += "\",\"deviceId\":\"";
+  out += deviceID;
+  out += "\",\"mode\":\"";
+  out += device_settings::ConnectionModeName(mode);
+  if (confirmationRequired) {
+    out += "\",\"confirmationRequired\":true}";
+  } else {
+    out += "\"}";
+  }
+  Serial.println(out);
+}
+
 struct DeviceSettingsPatch {
   bool hasBrightness = false;
   int brightnessPercent = 0;
@@ -1955,95 +1980,84 @@ bool handleSerialControlLine(const String& line) {
   if (deserializeJson(doc, line)) {
     return false;
   }
-  const String kind = String(doc["kind"] | "");
-  if (kind != "request") {
+  const char* kind = doc["kind"] | "";
+  if (strcmp(kind, "request") != 0) {
     return false;
   }
 
-  const String op = String(doc["op"] | "");
-  if (op == "hello") {
+  const char* op = doc["op"] | "";
+  if (strcmp(op, "hello") == 0) {
     codexbar_display::app::EmitDeviceHello(makeTransportConfig("usb"));
-  } else if (op == "status") {
+  } else if (strcmp(op, "status") == 0) {
     emitSerialStatus();
-  } else if (op == "set-connection-mode") {
-    const String expectedDeviceID = String(doc["deviceId"] | "");
+  } else if (strcmp(op, "set-connection-mode") == 0) {
+    const char* expectedDeviceID = doc["deviceId"] | "";
     const device_settings::ConnectionMode target =
         requestedConnectionMode(String(doc["mode"] | ""));
     String error;
-    if (expectedDeviceID != deviceID) {
+    if (strcmp(expectedDeviceID, deviceID.c_str()) != 0) {
       error = "deviceId does not match";
     } else if (!beginConnectionTransition(target, error)) {
       // beginConnectionTransition supplies the customer-safe reason.
     }
     if (error.length() > 0) {
-      String out = "{\"kind\":\"error\",\"code\":\"connection-mode-rejected\",\"message\":\"";
-      out += jsonEscape(error);
-      out += "\"}";
-      Serial.println(out);
+      emitSerialError("connection-mode-rejected");
     } else {
-      String out = "{\"kind\":\"connection-mode\",\"status\":\"switching\",\"deviceId\":\"";
-      out += deviceID;
-      out += "\",\"mode\":\"";
-      out += device_settings::ConnectionModeName(target);
-      out += "\",\"confirmationRequired\":true}";
-      Serial.println(out);
+      emitSerialConnectionMode("switching", target, true);
       scheduleReboot("connection_mode_switch");
     }
-  } else if (op == "confirm-connection-mode") {
+  } else if (strcmp(op, "confirm-connection-mode") == 0) {
     String status;
     if (!confirmConnectionTransition(String(doc["deviceId"] | ""), status)) {
-      String out = "{\"kind\":\"error\",\"code\":\"connection-mode-confirmation-rejected\",\"message\":\"";
-      out += jsonEscape(status);
-      out += "\"}";
-      Serial.println(out);
+      emitSerialError("connection-mode-confirmation-rejected");
     } else {
-      String out = "{\"kind\":\"connection-mode\",\"status\":\"";
-      out += status;
-      out += "\",\"deviceId\":\"";
-      out += deviceID;
-      out += "\",\"mode\":\"";
-      out += device_settings::ConnectionModeName(deviceSettings.connectionMode);
-      out += "\"}";
-      Serial.println(out);
+      emitSerialConnectionMode(status, deviceSettings.connectionMode, false);
     }
-  } else if (op == "settings") {
-    const String expectedDeviceID = String(doc["deviceId"] | "");
+  } else if (strcmp(op, "settings") == 0) {
+    const char* expectedDeviceID = doc["deviceId"] | "";
     String error;
-    if (expectedDeviceID != deviceID) {
-      error = "deviceId does not match";
-    } else if (!doc["settings"].isNull()) {
-      const JsonVariantConst settings = doc["settings"];
+    bool rejected = strcmp(expectedDeviceID, deviceID.c_str()) != 0;
+    const char* settingsKey = "settings";
+    const JsonVariantConst settings = doc[settingsKey];
+    if (!rejected && !settings.isNull()) {
       DeviceSettingsPatch patch;
-      if (!settings["brightnessPercent"].isNull()) {
+      const char* brightnessPercent = "brightnessPercent";
+      const JsonVariantConst brightness = settings[brightnessPercent];
+      if (!brightness.isNull()) {
         patch.hasBrightness = true;
-        patch.brightnessPercent = settings["brightnessPercent"].as<int>();
+        patch.brightnessPercent = brightness.as<int>();
       }
-      if (!settings["standby"].isNull()) {
-        const JsonVariantConst standbyPatch = settings["standby"];
-        if (!standbyPatch["enabled"].isNull()) {
+      const char* standby = "standby";
+      const JsonVariantConst standbyPatch = settings[standby];
+      if (!standbyPatch.isNull()) {
+        const char* enabled = "enabled";
+        const JsonVariantConst standbyEnabled = standbyPatch[enabled];
+        if (!standbyEnabled.isNull()) {
           patch.hasStandbyEnabled = true;
-          patch.standbyEnabled = standbyPatch["enabled"].as<bool>();
+          patch.standbyEnabled = standbyEnabled.as<bool>();
         }
-        if (!standbyPatch["timeoutMinutes"].isNull()) {
+        const char* timeoutMinutes = "timeoutMinutes";
+        const JsonVariantConst standbyTimeout = standbyPatch[timeoutMinutes];
+        if (!standbyTimeout.isNull()) {
           patch.hasStandbyTimeout = true;
-          patch.standbyTimeoutMinutes = standbyPatch["timeoutMinutes"].as<int>();
+          patch.standbyTimeoutMinutes = standbyTimeout.as<int>();
         }
-        if (!standbyPatch["brightnessPercent"].isNull()) {
+        const JsonVariantConst standbyBrightness = standbyPatch[brightnessPercent];
+        if (!standbyBrightness.isNull()) {
           patch.hasStandbyBrightness = true;
-          patch.standbyBrightnessPercent = standbyPatch["brightnessPercent"].as<int>();
+          patch.standbyBrightnessPercent = standbyBrightness.as<int>();
         }
-        if (!standbyPatch["screensaverPath"].isNull()) {
+        const char* screensaverPath = "screensaverPath";
+        const JsonVariantConst standbyScreensaver = standbyPatch[screensaverPath];
+        if (!standbyScreensaver.isNull()) {
           patch.hasScreensaverPath = true;
-          patch.screensaverPath = String(standbyPatch["screensaverPath"] | "");
+          patch.screensaverPath = String(standbyScreensaver | "");
         }
       }
-      applyDeviceSettingsPatch(patch, error);
+      rejected = !applyDeviceSettingsPatch(patch, error);
     }
-    if (error.length() > 0) {
-      String out = "{\"kind\":\"error\",\"code\":\"settings-rejected\",\"message\":\"";
-      out += jsonEscape(error);
-      out += "\"}";
-      Serial.println(out);
+    if (rejected) {
+      emitSerialError("settings-rejected");
     } else {
       String out = "{\"kind\":\"settings\",\"deviceId\":\"";
       out += deviceID;
@@ -2052,47 +2066,34 @@ bool handleSerialControlLine(const String& line) {
       out += "}";
       Serial.println(out);
     }
-  } else if (op == "configure-wifi") {
-    const String expectedDeviceID = String(doc["deviceId"] | "");
+  } else if (strcmp(op, "configure-wifi") == 0) {
+    const char* expectedDeviceID = doc["deviceId"] | "";
     String ssid = String(doc["ssid"] | "");
     const String password = String(doc["password"] | "");
     ssid.trim();
     String error;
     const device_settings::ConnectionMode target =
         device_settings::ConnectionMode::kWifi;
-    if (expectedDeviceID != deviceID) {
-      error = "deviceId does not match";
-    } else if (ssid.length() == 0) {
-      error = "WiFi name is required";
-    } else if (ssid.length() >= kWifiSsidBytes || password.length() >= kWifiPasswordBytes) {
-      error = "WiFi credentials are too long";
-    } else if (!device_settings::CanBeginConnectionTransition(
-                   deviceSettings.connectionMode, target)) {
-      error = "WiFi is not supported in the current connection mode";
-    } else if (!saveWifiCredentials(ssid, password)) {
-      error = "WiFi settings could not be saved";
-    } else if (!beginConnectionTransition(target, error)) {
-      // beginConnectionTransition supplies the customer-safe reason.
+    bool rejected = strcmp(expectedDeviceID, deviceID.c_str()) != 0 ||
+                    ssid.length() == 0 ||
+                    ssid.length() >= kWifiSsidBytes ||
+                    password.length() >= kWifiPasswordBytes ||
+                    deviceSettings.connectionMode !=
+                        device_settings::ConnectionMode::kCable;
+    if (!rejected && !saveWifiCredentials(ssid, password)) {
+      rejected = true;
     }
-    if (error.length() > 0) {
-      String out = "{\"kind\":\"error\",\"code\":\"wifi-configuration-rejected\",\"message\":\"";
-      out += jsonEscape(error);
-      out += "\"}";
-      Serial.println(out);
+    if (!rejected && !beginConnectionTransition(target, error)) {
+      rejected = true;
+    }
+    if (rejected) {
+      emitSerialError("wifi-configuration-rejected");
     } else {
-      String out = "{\"kind\":\"connection-mode\",\"status\":\"switching\",\"deviceId\":\"";
-      out += deviceID;
-      out += "\",\"mode\":\"wifi\",\"confirmationRequired\":true}";
-      Serial.println(out);
+      emitSerialConnectionMode("switching", target, true);
       scheduleReboot("wifi_credentials_saved");
     }
   } else {
-    String out;
-    out.reserve(100);
-    out += "{\"kind\":\"error\",\"code\":\"unsupported-request\",\"op\":\"";
-    out += jsonEscape(op);
-    out += "\"}";
-    Serial.println(out);
+    emitSerialError("unsupported-request");
   }
   return true;
 }

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -1935,6 +1935,21 @@ void emitSerialStatus() {
   Serial.println(out);
 }
 
+struct DeviceSettingsPatch {
+  bool hasBrightness = false;
+  int brightnessPercent = 0;
+  bool hasStandbyEnabled = false;
+  bool standbyEnabled = false;
+  bool hasStandbyTimeout = false;
+  int standbyTimeoutMinutes = 0;
+  bool hasStandbyBrightness = false;
+  int standbyBrightnessPercent = 0;
+  bool hasScreensaverPath = false;
+  String screensaverPath;
+};
+
+bool applyDeviceSettingsPatch(const DeviceSettingsPatch& patch, String& error);
+
 bool handleSerialControlLine(const String& line) {
   JsonDocument doc;
   if (deserializeJson(doc, line)) {
@@ -1990,6 +2005,86 @@ bool handleSerialControlLine(const String& line) {
       out += device_settings::ConnectionModeName(deviceSettings.connectionMode);
       out += "\"}";
       Serial.println(out);
+    }
+  } else if (op == "settings") {
+    const String expectedDeviceID = String(doc["deviceId"] | "");
+    String error;
+    if (expectedDeviceID != deviceID) {
+      error = "deviceId does not match";
+    } else if (!doc["settings"].isNull()) {
+      const JsonVariantConst settings = doc["settings"];
+      DeviceSettingsPatch patch;
+      if (!settings["brightnessPercent"].isNull()) {
+        patch.hasBrightness = true;
+        patch.brightnessPercent = settings["brightnessPercent"].as<int>();
+      }
+      if (!settings["standby"].isNull()) {
+        const JsonVariantConst standbyPatch = settings["standby"];
+        if (!standbyPatch["enabled"].isNull()) {
+          patch.hasStandbyEnabled = true;
+          patch.standbyEnabled = standbyPatch["enabled"].as<bool>();
+        }
+        if (!standbyPatch["timeoutMinutes"].isNull()) {
+          patch.hasStandbyTimeout = true;
+          patch.standbyTimeoutMinutes = standbyPatch["timeoutMinutes"].as<int>();
+        }
+        if (!standbyPatch["brightnessPercent"].isNull()) {
+          patch.hasStandbyBrightness = true;
+          patch.standbyBrightnessPercent = standbyPatch["brightnessPercent"].as<int>();
+        }
+        if (!standbyPatch["screensaverPath"].isNull()) {
+          patch.hasScreensaverPath = true;
+          patch.screensaverPath = String(standbyPatch["screensaverPath"] | "");
+        }
+      }
+      applyDeviceSettingsPatch(patch, error);
+    }
+    if (error.length() > 0) {
+      String out = "{\"kind\":\"error\",\"code\":\"settings-rejected\",\"message\":\"";
+      out += jsonEscape(error);
+      out += "\"}";
+      Serial.println(out);
+    } else {
+      String out = "{\"kind\":\"settings\",\"deviceId\":\"";
+      out += deviceID;
+      out += "\",";
+      appendSettingsJSON(out);
+      out += "}";
+      Serial.println(out);
+    }
+  } else if (op == "configure-wifi") {
+    const String expectedDeviceID = String(doc["deviceId"] | "");
+    String ssid = String(doc["ssid"] | "");
+    const String password = String(doc["password"] | "");
+    ssid.trim();
+    String error;
+    const device_settings::ConnectionMode target =
+        device_settings::ConnectionMode::kWifi;
+    if (expectedDeviceID != deviceID) {
+      error = "deviceId does not match";
+    } else if (ssid.length() == 0) {
+      error = "WiFi name is required";
+    } else if (ssid.length() >= kWifiSsidBytes || password.length() >= kWifiPasswordBytes) {
+      error = "WiFi credentials are too long";
+    } else if (!device_settings::CanBeginConnectionTransition(
+                   deviceSettings.connectionMode, target)) {
+      error = "WiFi is not supported in the current connection mode";
+    } else if (!saveWifiCredentials(ssid, password)) {
+      error = "WiFi settings could not be saved";
+    } else if (!beginConnectionTransition(target, error)) {
+      // beginConnectionTransition supplies the customer-safe reason.
+    }
+    if (error.length() > 0) {
+      String out = "{\"kind\":\"error\",\"code\":\"wifi-configuration-rejected\",\"message\":\"";
+      out += jsonEscape(error);
+      out += "\"}";
+      Serial.println(out);
+    } else {
+      String out = "{\"kind\":\"connection-mode\",\"status\":\"switching\",\"deviceId\":\"";
+      out += deviceID;
+      out += "\",\"mode\":\"wifi\",\"confirmationRequired\":true}";
+      Serial.println(out);
+      scheduleReboot("wifi_credentials_saved");
     }
   } else {
     String out;
@@ -2294,45 +2389,73 @@ bool persistDeviceSettings(const DeviceSettings& next) {
   return true;
 }
 
+bool applyDeviceSettingsPatch(const DeviceSettingsPatch& patch, String& error) {
+  DeviceSettings next = deviceSettings;
+  bool changed = false;
+  if (patch.hasBrightness) {
+    next.brightnessPercent = clampBrightnessPercent(patch.brightnessPercent);
+    changed = true;
+  }
+  if (patch.hasStandbyEnabled) {
+    next.standby.enabled = patch.standbyEnabled;
+    changed = true;
+  }
+  if (patch.hasStandbyTimeout) {
+    next.standby.timeoutMinutes = standby::ClampTimeoutMinutes(patch.standbyTimeoutMinutes);
+    changed = true;
+  }
+  if (patch.hasStandbyBrightness) {
+    next.standby.brightnessPercent =
+        standby::ClampBrightnessPercent(patch.standbyBrightnessPercent);
+    changed = true;
+  }
+  if (patch.hasScreensaverPath) {
+    if (!setStandbyScreensaverPath(next.standby, patch.screensaverPath, error)) {
+      return false;
+    }
+    changed = true;
+  }
+  if (!changed) {
+    error = "no settings supplied";
+    return false;
+  }
+  if (!persistDeviceSettings(next)) {
+    error = "save failed";
+    return false;
+  }
+  return true;
+}
+
 void handleSettingsAPI() {
   addCorsHeaders();
   if (!requireWriteAuth()) {
     return;
   }
-  DeviceSettings next = deviceSettings;
   const bool apiResponse = webServer.hasArg("api");
-  bool changed = false;
+  DeviceSettingsPatch patch;
   if (webServer.hasArg("b")) {
-    next.brightnessPercent = clampBrightnessPercent(webServer.arg("b").toInt());
-    changed = true;
+    patch.hasBrightness = true;
+    patch.brightnessPercent = webServer.arg("b").toInt();
   }
   if (webServer.hasArg("sb")) {
-    next.standby.enabled = webServer.arg("sb").toInt() != 0;
-    changed = true;
+    patch.hasStandbyEnabled = true;
+    patch.standbyEnabled = webServer.arg("sb").toInt() != 0;
   }
   if (webServer.hasArg("st")) {
-    next.standby.timeoutMinutes = standby::ClampTimeoutMinutes(webServer.arg("st").toInt());
-    changed = true;
+    patch.hasStandbyTimeout = true;
+    patch.standbyTimeoutMinutes = webServer.arg("st").toInt();
   }
   if (webServer.hasArg("sbr")) {
-    next.standby.brightnessPercent =
-        standby::ClampBrightnessPercent(webServer.arg("sbr").toInt());
-    changed = true;
+    patch.hasStandbyBrightness = true;
+    patch.standbyBrightnessPercent = webServer.arg("sbr").toInt();
   }
   if (webServer.hasArg("ss")) {
-    String error;
-    if (!setStandbyScreensaverPath(next.standby, webServer.arg("ss"), error)) {
-      webServer.send(400, "text/plain; charset=utf-8", error);
-      return;
-    }
-    changed = true;
+    patch.hasScreensaverPath = true;
+    patch.screensaverPath = webServer.arg("ss");
   }
-  if (!changed) {
-    webServer.send(400, "text/plain; charset=utf-8", "bad");
-    return;
-  }
-  if (!persistDeviceSettings(next)) {
-    webServer.send(500, "text/plain; charset=utf-8", "save failed");
+  String error;
+  if (!applyDeviceSettingsPatch(patch, error)) {
+    webServer.send(error == "save failed" ? 500 : 400, "text/plain; charset=utf-8", error);
     return;
   }
   if (!apiResponse && webServer.hasArg("b")) {

--- a/protocol/PROTOCOL.md
+++ b/protocol/PROTOCOL.md
@@ -14,6 +14,30 @@ Status:
 - v2 handshake negotiation and ThemeSpec v1 payload support are available on supported firmware.
 - Negotiation prefers v2 and falls back to v1.
 
+## Cable control requests
+
+Cable control uses the same newline-delimited JSON stream as frames. Every
+request that can read or change customer state carries the expected `deviceId`;
+the firmware rejects a different identity. Control replies are never passed to
+the frame parser.
+
+- `{"kind":"request","op":"hello"}` returns the normal Device Hello.
+- `{"kind":"request","op":"status"}` returns the current Cable mode and
+  transition state.
+- `{"kind":"request","op":"settings","deviceId":"14799300"}` returns a
+  `kind:"settings"` reply containing the persisted display and standby values.
+- The same `settings` request may include a partial `settings` object. The
+  firmware applies it through the same validation, persistence and readback
+  owner as `POST /api/settings`, then returns the complete stored values.
+- `{"kind":"request","op":"configure-wifi","deviceId":"14799300","ssid":"Home WiFi","password":"..."}`
+  stores the credentials through the existing credential owner and begins the
+  bounded Cable-to-WiFi transition. The secret is never echoed or logged. A
+  `kind:"connection-mode",status:"switching"` reply only acknowledges that the
+  transition started; the Mac must still rediscover and confirm the same
+  `deviceId` over WiFi.
+- `set-connection-mode` and `confirm-connection-mode` start and confirm the
+  bounded mode transactions defined in the hardware contract.
+
 ## Host -> Device Frame
 
 Usage frame (v1 or v2, negotiated):


### PR DESCRIPTION
## Summary

Implements the software portion of #395 on top of PR #407:

- collect WiFi name and key in the Mac App while Cable remains active;
- start Cable-to-WiFi only after credentials are saved, then require same-device confirmation;
- start WiFi-to-Cable through the active authenticated WiFi path and confirm by Cable identity;
- read and write brightness/standby over one Cable control request with complete firmware readback;
- distinguish missing, foreign and ambiguous Cable devices;
- keep WiFi-first and legacy portal behavior unchanged.

## Validation

- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- Control Center: 39 files / 320 tests
- complete simulated customer-flow suite
- Next.js production build
- customer-copy guard
- ESP8266 native tests: 13 + 122 plus policy suites
- `pio run -d firmware_esp8266 -e esp8266_smalltv_st7789`
- local rendered browser walkthrough of choice -> credentials -> connecting

## Remaining gates

- explicit approval of the exact visible UI is still required;
- real-device first-run/settings/switch/rollback rehearsal requires separate current hardware-write approval;
- #302 and #396 remain outside this pull request.

No merge, tag, release, deployment, or real-device write is included.