### PR TITLE
CODEX: Add reliable Cable bulk transfer

### DIFF
--- a/apps/control-center/src/components/control-center-app.tsx
+++ b/apps/control-center/src/components/control-center-app.tsx
@@ -202,7 +202,7 @@ type FirmwareUpdateJob = {
   phase: "installing" | "complete" | "attention" | "error";
   stage?: string;
   outcome?: string;
-  retryPolicy?: "power_cycle";
+  retryPolicy?: "power_cycle" | "reconnect_cable";
   message?: string;
   progress?: number;
   startedAt?: string;
@@ -3022,7 +3022,9 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
         progress: 100,
         logs: [...initialLogs, normalized.message, normalized.nextAction],
         error: normalized.nextAction,
-        retryAllowed: normalized.code !== "firmware_update_restart_required",
+        retryAllowed:
+          normalized.code !== "firmware_update_restart_required" &&
+          normalized.code !== "firmware_update_cable_interrupted",
       });
       addEvent({
         label: "VibeTV update failed",
@@ -4549,7 +4551,9 @@ function firmwareUpdateStatusFromJob(
     phase,
     stage: job.stage,
     outcome: job.outcome,
-    retryAllowed: job.retryPolicy !== "power_cycle",
+    retryAllowed:
+      job.retryPolicy !== "power_cycle" &&
+      job.retryPolicy !== "reconnect_cable",
     startedAt: job.startedAt || fallbackStartedAt,
     finishedAt: finished ? job.finishedAt || formatTime() : undefined,
     message:

--- a/apps/control-center/src/components/control-center-app.tsx
+++ b/apps/control-center/src/components/control-center-app.tsx
@@ -3023,8 +3023,7 @@ export function ControlCenterApp({ catalog, initialThemeId }: Props) {
         logs: [...initialLogs, normalized.message, normalized.nextAction],
         error: normalized.nextAction,
         retryAllowed:
-          normalized.code !== "firmware_update_restart_required" &&
-          normalized.code !== "firmware_update_cable_interrupted",
+          normalized.code !== "firmware_update_restart_required",
       });
       addEvent({
         label: "VibeTV update failed",
@@ -4552,8 +4551,7 @@ function firmwareUpdateStatusFromJob(
     stage: job.stage,
     outcome: job.outcome,
     retryAllowed:
-      job.retryPolicy !== "power_cycle" &&
-      job.retryPolicy !== "reconnect_cable",
+      job.retryPolicy !== "power_cycle",
     startedAt: job.startedAt || fallbackStartedAt,
     finishedAt: finished ? job.finishedAt || formatTime() : undefined,
     message:

--- a/apps/control-center/src/components/updates-screen.test.tsx
+++ b/apps/control-center/src/components/updates-screen.test.tsx
@@ -271,7 +271,7 @@ describe("UpdatesScreen VibeTV update card", () => {
     expect(html).toContain("Update failed");
   });
 
-  it("shows Cable reconnect recovery without an immediate retry button", () => {
+  it("shows Cable reconnect recovery with a manual retry button", () => {
     const html = renderToStaticMarkup(
       <UpdatesScreen
         companionStatus="online"
@@ -290,7 +290,7 @@ describe("UpdatesScreen VibeTV update card", () => {
           stage: "uploading",
           startedAt: "2026-08-27T10:00:00Z",
           finishedAt: "2026-08-27T10:01:00Z",
-          retryAllowed: false,
+          retryAllowed: true,
           error: "Reconnect VibeTV with a data-capable Cable, wait for it to start, then try the update once.",
           logs: [],
         }}
@@ -298,7 +298,7 @@ describe("UpdatesScreen VibeTV update card", () => {
     );
 
     expect(html).toContain("Reconnect VibeTV with a data-capable Cable");
-    expect(html).not.toContain("Try again");
+    expect(html).toContain("Try again");
     expect(html).toContain("Create report");
   });
 });

--- a/apps/control-center/src/components/updates-screen.test.tsx
+++ b/apps/control-center/src/components/updates-screen.test.tsx
@@ -270,6 +270,37 @@ describe("UpdatesScreen VibeTV update card", () => {
 
     expect(html).toContain("Update failed");
   });
+
+  it("shows Cable reconnect recovery without an immediate retry button", () => {
+    const html = renderToStaticMarkup(
+      <UpdatesScreen
+        companionStatus="online"
+        device={{ connected: true, board: "esp8266-smalltv-st7789", firmware: "1.0.40" }}
+        firmwareUpdate={{
+          checkedAt: "2026-08-27T10:00:00Z",
+          installedFirmware: "1.0.40",
+          latestFirmware: "1.0.41",
+          updateAvailable: true,
+          status: "update_available",
+        }}
+        onCreateReport={() => undefined}
+        onInstallUpdate={() => undefined}
+        updateStatus={{
+          phase: "error",
+          stage: "uploading",
+          startedAt: "2026-08-27T10:00:00Z",
+          finishedAt: "2026-08-27T10:01:00Z",
+          retryAllowed: false,
+          error: "Reconnect VibeTV with a data-capable Cable, wait for it to start, then try the update once.",
+          logs: [],
+        }}
+      />,
+    );
+
+    expect(html).toContain("Reconnect VibeTV with a data-capable Cable");
+    expect(html).not.toContain("Try again");
+    expect(html).toContain("Create report");
+  });
 });
 
 // The mixed state (new firmware + old Mac App) renders slot-bound theme

--- a/companion/cmd/codexbar-display/release_commands.go
+++ b/companion/cmd/codexbar-display/release_commands.go
@@ -70,6 +70,11 @@ var (
 	discoverWiFiDeviceFn                               = transportlayer.DiscoverWiFiDevice
 	flashReleaseFirmwareImageFn                        = flashReleaseFirmwareImage
 	uploadFirmwareOTAFn                                = uploadFirmwareOTA
+	resolveCableFirmwarePortFn                         = usb.ResolveVibeTVControlPort
+	readCableFirmwareHelloFn                           = usb.ReadDeviceHello
+	transferCableFirmwareFn                            = usb.TransferFirmware
+	cableFirmwareVerifyTimeout                         = 120 * time.Second
+	cableFirmwareVerifyPollInterval                    = time.Second
 	firmwareRawDialContextFn                           = dialFirmwareRawConnection
 	firmwareRawOTAPort                                 = "8081"
 	firmwareHTTPVerifyPollInterval                     = 2 * time.Second
@@ -550,14 +555,8 @@ func runInstallUpdate(args []string) (retErr error) {
 	if err != nil {
 		return &commandError{Op: "resolve-home", Code: errcode.UpgradeStateWrite, Err: err}
 	}
-	base, err := normalizeHTTPBaseURL(*target)
-	if err != nil {
-		return &commandError{Op: "resolve-target", Code: errcode.UpgradeFlashFirmware, Err: err}
-	}
-	// Quiesce gate: concurrent device traffic during an OTA upload is fatal
-	// (see otherRuntimeWriterAlive). Runs before the first device request. The
-	// API job pauses the stream itself and marks the child via
-	// VIBETV_UPDATE_PARENT_PAUSED=1.
+	// Concurrent device traffic during any firmware transfer is fatal. This
+	// gate must run before the first WiFi or Cable device request.
 	if !*stoppedAllWriters && os.Getenv(firmwareUpdateParentPausedEnvVar) != "1" && otherRuntimeWriterAlive() {
 		return &commandError{
 			Op:   "quiesce-device-writers",
@@ -566,14 +565,44 @@ func runInstallUpdate(args []string) (retErr error) {
 			Hint: "quit the VibeTV Mac App (or stop the companion daemon), then retry; pass --i-stopped-all-writers only after every device writer is stopped",
 		}
 	}
-
-	hello, err := fetchDeviceHelloHTTP(ctx, base)
-	if err != nil {
-		return &commandError{
-			Op:   "device-hello",
-			Code: errcode.UpgradeFlashFirmware,
-			Err:  err,
-			Hint: "open http://<device-ip>/health or pass --target http://<device-ip>",
+	cableMode := strings.EqualFold(strings.TrimRight(strings.TrimSpace(*target), "/"), "cable://vibetv")
+	base := "cable://vibetv"
+	var cablePort string
+	var deviceToken string
+	var hello protocol.DeviceHello
+	if cableMode {
+		cfg, loadErr := runtimeconfig.Load(home)
+		if loadErr != nil {
+			return &commandError{Op: "load-cable-config", Code: errcode.UpgradeFlashFirmware, Err: loadErr}
+		}
+		if runtimeconfig.NormalizeConnectionMode(cfg.ConnectionMode) != "cable" ||
+			strings.TrimSpace(cfg.DeviceID) == "" || strings.TrimSpace(cfg.DeviceToken) == "" {
+			return &commandError{Op: "cable-preflight", Code: errcode.UpgradeFlashFirmware, Err: errors.New("paired Cable VibeTV is required")}
+		}
+		cablePort, err = resolveCableFirmwarePortFn("", cfg.DeviceID)
+		if err == nil {
+			hello, err = readCableFirmwareHelloFn(cablePort)
+		}
+		if err == nil && !strings.EqualFold(strings.TrimSpace(hello.DeviceID), strings.TrimSpace(cfg.DeviceID)) {
+			err = fmt.Errorf("cable VibeTV identity changed from %s to %s", strings.TrimSpace(cfg.DeviceID), strings.TrimSpace(hello.DeviceID))
+		}
+		if err != nil {
+			return &commandError{Op: "cable-device-hello", Code: errcode.UpgradeFlashFirmware, Err: err}
+		}
+		deviceToken = strings.TrimSpace(cfg.DeviceToken)
+	} else {
+		base, err = normalizeHTTPBaseURL(*target)
+		if err != nil {
+			return &commandError{Op: "resolve-target", Code: errcode.UpgradeFlashFirmware, Err: err}
+		}
+		hello, err = fetchDeviceHelloHTTP(ctx, base)
+		if err != nil {
+			return &commandError{
+				Op:   "device-hello",
+				Code: errcode.UpgradeFlashFirmware,
+				Err:  err,
+				Hint: "open http://<device-ip>/health or pass --target http://<device-ip>",
+			}
 		}
 	}
 	caps := protocol.CapabilitiesFromHello(hello)
@@ -650,13 +679,15 @@ func runInstallUpdate(args []string) (retErr error) {
 		HelloVerified:     true,
 	})
 
-	deviceToken, err := ensureFirmwareUpdateDeviceToken(ctx, home, base, deviceID)
-	if err != nil {
-		return &commandError{
-			Op:   "device-auth-preflight",
-			Code: errcode.UpgradeFlashFirmware,
-			Err:  err,
-			Hint: "keep VibeTV powered and on the same WiFi, then retry",
+	if !cableMode {
+		deviceToken, err = ensureFirmwareUpdateDeviceToken(ctx, home, base, deviceID)
+		if err != nil {
+			return &commandError{
+				Op:   "device-auth-preflight",
+				Code: errcode.UpgradeFlashFirmware,
+				Err:  err,
+				Hint: "keep VibeTV powered and on the same WiFi, then retry",
+			}
 		}
 	}
 
@@ -667,20 +698,45 @@ func runInstallUpdate(args []string) (retErr error) {
 	}
 
 	fmt.Println("Uploading firmware...")
-	uploadErr := uploadFirmwareOTAFn(ctx, base, imagePath, deviceToken, caps.Firmware)
-	uploadInterrupted := firmwareUploadConnectionInterrupted(uploadErr)
-	uploadErr = recoverInterruptedFirmwareUpload(
-		ctx,
-		base,
-		targetVersion,
-		deviceID,
-		uploadErr,
-	)
+	var uploadErr error
+	uploadInterrupted := false
+	if cableMode {
+		var image []byte
+		image, uploadErr = os.ReadFile(imagePath)
+		if uploadErr == nil {
+			uploadErr = transferCableFirmwareFn(ctx, cablePort, deviceID, deviceToken, image)
+		}
+		uploadInterrupted = errors.Is(uploadErr, usb.ErrCableTransferInterrupted)
+	} else {
+		uploadErr = uploadFirmwareOTAFn(ctx, base, imagePath, deviceToken, caps.Firmware)
+		uploadInterrupted = firmwareUploadConnectionInterrupted(uploadErr)
+		uploadErr = recoverInterruptedFirmwareUpload(
+			ctx,
+			base,
+			targetVersion,
+			deviceID,
+			uploadErr,
+		)
+	}
 	if uploadErr != nil {
-		if uploadInterrupted {
+		if uploadInterrupted && !cableMode {
 			restoreStoredThemeAfterAbortedUpload(ctx, base, deviceToken)
 		}
 		hint := "keep VibeTV powered and on the same WiFi, then retry"
+		if cableMode {
+			hint = "reconnect VibeTV with a data-capable Cable, wait for it to start, then retry once"
+			if uploadInterrupted {
+				emitFirmwareUpdateEvent(firmwareUpdateEvent{
+					Stage:       "uploading",
+					Phase:       "attention",
+					Outcome:     "interrupted",
+					RetryPolicy: "reconnect_cable",
+					Firmware:    targetVersion,
+					Target:      base,
+					DeviceID:    deviceID,
+				})
+			}
+		}
 		if errors.Is(uploadErr, errFirmwareUploadRestartRequired) {
 			hint = "disconnect VibeTV from power for 10 seconds, reconnect it, wait until the picture returns, then retry once"
 			emitFirmwareUpdateEvent(firmwareUpdateEvent{
@@ -710,16 +766,27 @@ func runInstallUpdate(args []string) (retErr error) {
 	})
 	fmt.Println("Restarting VibeTV...")
 
-	verifiedBase, err := waitForHTTPFirmwareVersionWithDiscovery(ctx, home, base, targetVersion, deviceID, 120*time.Second)
-	if err != nil {
+	verifiedBase := base
+	var verifiedHello protocol.DeviceHello
+	var helloErr error
+	if cableMode {
+		verifiedHello, helloErr = waitForCableFirmwareVersion(ctx, targetVersion, deviceID, cableFirmwareVerifyTimeout)
+	} else {
+		verifiedBase, err = waitForHTTPFirmwareVersionWithDiscovery(ctx, home, base, targetVersion, deviceID, 120*time.Second)
+		if err == nil {
+			verifiedHello, helloErr = fetchDeviceHelloHTTP(ctx, verifiedBase)
+		} else {
+			helloErr = err
+		}
+	}
+	if helloErr != nil {
 		return &commandError{
 			Op:   "post-update-verify",
 			Code: errcode.UpgradeFlashFirmware,
-			Err:  err,
-			Hint: "wait one minute, then open http://<device-ip>/health",
+			Err:  helloErr,
+			Hint: "wait one minute, then reconnect VibeTV",
 		}
 	}
-	verifiedHello, helloErr := fetchDeviceHelloHTTP(ctx, verifiedBase)
 	if helloErr != nil || !strings.EqualFold(strings.TrimSpace(verifiedHello.DeviceID), deviceID) {
 		return &commandError{
 			Op:   "post-update-device-identity",
@@ -739,7 +806,7 @@ func runInstallUpdate(args []string) (retErr error) {
 		UploadAccepted:    true,
 		HelloVerified:     true,
 	})
-	if verifiedBase != base {
+	if !cableMode && verifiedBase != base {
 		base = verifiedBase
 		if _, err := ensureFirmwareUpdateDeviceToken(ctx, home, base, deviceID); err != nil {
 			fmt.Printf("warning: firmware updated, but saving the rediscovered VibeTV address failed: %v\n", err)
@@ -747,6 +814,42 @@ func runInstallUpdate(args []string) (retErr error) {
 	}
 	fmt.Printf("Done: firmware %s installed\n", targetVersion)
 	return nil
+}
+
+func waitForCableFirmwareVersion(
+	ctx context.Context,
+	targetVersion,
+	deviceID string,
+	timeout time.Duration,
+) (protocol.DeviceHello, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return protocol.DeviceHello{}, err
+		}
+		port, err := resolveCableFirmwarePortFn("", deviceID)
+		if err == nil {
+			var hello protocol.DeviceHello
+			hello, err = readCableFirmwareHelloFn(port)
+			if err == nil {
+				if !strings.EqualFold(strings.TrimSpace(hello.DeviceID), strings.TrimSpace(deviceID)) {
+					err = fmt.Errorf("cable VibeTV identity changed from %s to %s", strings.TrimSpace(deviceID), strings.TrimSpace(hello.DeviceID))
+				} else if normalizeReleaseVersion(hello.Firmware) == normalizeReleaseVersion(targetVersion) {
+					return hello, nil
+				} else {
+					err = fmt.Errorf("cable VibeTV still reports firmware %s", strings.TrimSpace(hello.Firmware))
+				}
+			}
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return protocol.DeviceHello{}, ctx.Err()
+		case <-time.After(cableFirmwareVerifyPollInterval):
+		}
+	}
+	return protocol.DeviceHello{}, fmt.Errorf("cable VibeTV did not report firmware %s: %v", targetVersion, lastErr)
 }
 
 func ensureFirmwareUpdateDeviceToken(ctx context.Context, home, base, expectedDeviceID string) (string, error) {
@@ -1543,12 +1646,19 @@ func fetchDeviceHelloHTTPWithToken(ctx context.Context, base, token string) (pro
 }
 
 func uploadFirmwareOTA(ctx context.Context, base, imagePath, token, currentFirmware string) error {
+	if !usesLegacyRawFirmwareUpload(currentFirmware) {
+		return uploadFirmwareOTAMultipart(ctx, base, imagePath, token)
+	}
 	if err := uploadFirmwareOTARaw(ctx, base, imagePath, token, currentFirmware); err == nil {
 		return nil
 	} else if !rawFirmwareUploadUnavailable(err) {
 		return err
 	}
 	return uploadFirmwareOTAMultipart(ctx, base, imagePath, token)
+}
+
+func usesLegacyRawFirmwareUpload(currentFirmware string) bool {
+	return normalizeReleaseVersion(currentFirmware) == "1.0.36"
 }
 
 func uploadFirmwareOTAMultipart(ctx context.Context, base, imagePath, token string) error {

--- a/companion/cmd/codexbar-display/release_commands_test.go
+++ b/companion/cmd/codexbar-display/release_commands_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/runtimeconfig"
 	transportlayer "github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/transport"
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/usb"
 )
 
 type recordingWriter struct {
@@ -115,6 +116,24 @@ func TestFirmwareRawWritePauseIsPositiveForEveryFirmwareVersion(t *testing.T) {
 	for _, firmware := range []string{"1.0.37", "1.0.39", "9999.0.24", ""} {
 		if got := firmwareRawWritePause(firmware); got <= 0 {
 			t.Fatalf("firmware %q write pause = %s, want > 0 (unpaced RAW uploads fail on real hardware)", firmware, got)
+		}
+	}
+}
+
+func TestLegacyRawFirmwareUploadIsLimitedToPublic1036(t *testing.T) {
+	for _, test := range []struct {
+		firmware string
+		want     bool
+	}{
+		{firmware: "1.0.36", want: true},
+		{firmware: "v1.0.36", want: true},
+		{firmware: "1.0.36-dev.1", want: false},
+		{firmware: "1.0.37", want: false},
+		{firmware: "1.0.40-dev", want: false},
+		{firmware: "", want: false},
+	} {
+		if got := usesLegacyRawFirmwareUpload(test.firmware); got != test.want {
+			t.Fatalf("usesLegacyRawFirmwareUpload(%q)=%t want=%t", test.firmware, got, test.want)
 		}
 	}
 }
@@ -896,6 +915,156 @@ func TestRunInstallUpdateAlreadyCurrentSkipsOTAUpload(t *testing.T) {
 	if !strings.Contains(output, `"outcome":"already_current"`) {
 		t.Fatalf("expected typed already-current outcome, got:\n%s", output)
 	}
+}
+
+func TestRunInstallUpdateCableHappyPath(t *testing.T) {
+	home, manifestURL, firmwareVersion := prepareCableFirmwareUpdateTest(t)
+	if err := runtimeconfig.Save(home, runtimeconfig.Config{
+		ConnectionMode: "cable",
+		DeviceID:       "device-cable",
+		DeviceToken:    "pair-token",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	transferCableFirmwareFn = func(_ context.Context, port, deviceID, token string, image []byte) error {
+		if port != "/dev/mock-cable" || deviceID != "device-cable" || token != "pair-token" || string(image) != "cable firmware" {
+			t.Fatalf("unexpected Cable transfer port=%q id=%q token=%q image=%q", port, deviceID, token, image)
+		}
+		*firmwareVersion = "1.0.1"
+		return nil
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runInstallUpdate([]string{"--target", "cable://vibetv", "--manifest-url", manifestURL, "--skip-launchagent-pause"})
+	})
+	if err != nil {
+		t.Fatalf("Cable update: %v", err)
+	}
+	if !strings.Contains(output, `"uploadAccepted":true`) || !strings.Contains(output, `"observedFirmware":"1.0.1"`) {
+		t.Fatalf("Cable update did not report accepted and verified firmware:\n%s", output)
+	}
+}
+
+func TestRunInstallUpdateCableAlreadyCurrentSkipsTransfer(t *testing.T) {
+	home, manifestURL, firmwareVersion := prepareCableFirmwareUpdateTest(t)
+	*firmwareVersion = "1.0.1"
+	if err := runtimeconfig.Save(home, runtimeconfig.Config{ConnectionMode: "cable", DeviceID: "device-cable", DeviceToken: "pair-token"}); err != nil {
+		t.Fatal(err)
+	}
+	transferCableFirmwareFn = func(context.Context, string, string, string, []byte) error {
+		t.Fatal("already-current Cable firmware must not transfer")
+		return nil
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runInstallUpdate([]string{"--target", "cable://vibetv", "--manifest-url", manifestURL, "--skip-launchagent-pause"})
+	})
+	if err != nil || !strings.Contains(output, `"outcome":"already_current"`) {
+		t.Fatalf("Cable already-current result err=%v output=%s", err, output)
+	}
+}
+
+func TestRunInstallUpdateCableReportsInterruptedTransferWithoutRetry(t *testing.T) {
+	home, manifestURL, _ := prepareCableFirmwareUpdateTest(t)
+	if err := runtimeconfig.Save(home, runtimeconfig.Config{ConnectionMode: "cable", DeviceID: "device-cable", DeviceToken: "pair-token"}); err != nil {
+		t.Fatal(err)
+	}
+	transferCalls := 0
+	transferCableFirmwareFn = func(context.Context, string, string, string, []byte) error {
+		transferCalls++
+		return fmt.Errorf("%w: Cable disconnected", usb.ErrCableTransferInterrupted)
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runInstallUpdate([]string{"--target", "cable://vibetv", "--manifest-url", manifestURL, "--skip-launchagent-pause"})
+	})
+	if err == nil || transferCalls != 1 {
+		t.Fatalf("interrupted Cable transfer err=%v calls=%d", err, transferCalls)
+	}
+	if !strings.Contains(output, `"outcome":"interrupted"`) || !strings.Contains(output, `"retryPolicy":"reconnect_cable"`) {
+		t.Fatalf("Cable interruption was not reported truthfully:\n%s", output)
+	}
+	if !strings.Contains(errcode.Recovery(err), "data-capable Cable") {
+		t.Fatalf("Cable interruption returned the wrong recovery action: %v", err)
+	}
+}
+
+func TestRunInstallUpdateCableRejectsChangedIdentity(t *testing.T) {
+	home, _, _ := prepareCableFirmwareUpdateTest(t)
+	if err := runtimeconfig.Save(home, runtimeconfig.Config{ConnectionMode: "cable", DeviceID: "device-cable", DeviceToken: "pair-token"}); err != nil {
+		t.Fatal(err)
+	}
+	readCableFirmwareHelloFn = func(string) (protocol.DeviceHello, error) {
+		return protocol.DeviceHello{DeviceID: "other-device", Board: "esp8266-smalltv-st7789", Firmware: "1.0.0"}, nil
+	}
+
+	err := runInstallUpdate([]string{"--target", "cable://vibetv", "--manifest-url", "https://example.invalid/manifest.json", "--skip-launchagent-pause"})
+	if err == nil || !strings.Contains(err.Error(), "identity changed") {
+		t.Fatalf("expected changed Cable identity rejection, got %v", err)
+	}
+}
+
+func TestRunInstallUpdateCableRejectsPostRebootVersionMismatch(t *testing.T) {
+	home, manifestURL, _ := prepareCableFirmwareUpdateTest(t)
+	if err := runtimeconfig.Save(home, runtimeconfig.Config{ConnectionMode: "cable", DeviceID: "device-cable", DeviceToken: "pair-token"}); err != nil {
+		t.Fatal(err)
+	}
+	transferCableFirmwareFn = func(context.Context, string, string, string, []byte) error { return nil }
+	cableFirmwareVerifyTimeout = 5 * time.Millisecond
+	cableFirmwareVerifyPollInterval = time.Millisecond
+
+	err := runInstallUpdate([]string{"--target", "cable://vibetv", "--manifest-url", manifestURL, "--skip-launchagent-pause"})
+	if err == nil || !strings.Contains(err.Error(), "still reports firmware 1.0.0") {
+		t.Fatalf("expected post-reboot Cable version mismatch, got %v", err)
+	}
+}
+
+func prepareCableFirmwareUpdateTest(t *testing.T) (string, string, *string) {
+	t.Helper()
+	pinNoOtherRuntimeWriter(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	previousResolve := resolveCableFirmwarePortFn
+	previousRead := readCableFirmwareHelloFn
+	previousTransfer := transferCableFirmwareFn
+	previousTimeout := cableFirmwareVerifyTimeout
+	previousPoll := cableFirmwareVerifyPollInterval
+	previousHTTPClient := releaseHTTPClient
+	t.Cleanup(func() {
+		resolveCableFirmwarePortFn = previousResolve
+		readCableFirmwareHelloFn = previousRead
+		transferCableFirmwareFn = previousTransfer
+		cableFirmwareVerifyTimeout = previousTimeout
+		cableFirmwareVerifyPollInterval = previousPoll
+		releaseHTTPClient = previousHTTPClient
+	})
+	firmwareVersion := "1.0.0"
+	resolveCableFirmwarePortFn = func(explicit, expectedDeviceID string) (string, error) {
+		if explicit != "" || expectedDeviceID != "device-cable" {
+			t.Fatalf("unexpected Cable resolution explicit=%q id=%q", explicit, expectedDeviceID)
+		}
+		return "/dev/mock-cable", nil
+	}
+	readCableFirmwareHelloFn = func(port string) (protocol.DeviceHello, error) {
+		if port != "/dev/mock-cable" {
+			t.Fatalf("unexpected Cable port %q", port)
+		}
+		return protocol.DeviceHello{DeviceID: "device-cable", Board: "esp8266-smalltv-st7789", Firmware: firmwareVersion}, nil
+	}
+	image := "cable firmware"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			_, _ = fmt.Fprintf(w, `{"schemaVersion":1,"release":"v1.0.1","artifacts":[{"firmwareEnv":"esp8266_smalltv_st7789","board":"esp8266-smalltv-st7789","firmwareVersion":"1.0.1","asset":"firmware.bin","firmwareUrl":"%s/firmware.bin","sha256":"%s"}]}`, "http://"+r.Host, sha256String(image))
+		case "/firmware.bin":
+			_, _ = io.WriteString(w, image)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	releaseHTTPClient = server.Client()
+	return home, server.URL + "/manifest.json", &firmwareVersion
 }
 
 func TestRunInstallUpdateRediscoverAfterFirmwareRebootIPChange(t *testing.T) {

--- a/companion/cmd/codexbar-display/virtual_vibetv_test.go
+++ b/companion/cmd/codexbar-display/virtual_vibetv_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -17,16 +16,16 @@ import (
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/virtualvibetv"
 )
 
-func TestRunInstallUpdateUsesDedicatedRawOTAAndDoesNotFlashAlreadyCurrentDevice(t *testing.T) {
+func TestRunInstallUpdateUsesMultipartOTAAndDoesNotFlashAlreadyCurrentDevice(t *testing.T) {
 	pinNoOtherRuntimeWriter(t)
-	previousClient, previousPoll, previousPort := releaseHTTPClient, firmwareHTTPVerifyPollInterval, firmwareRawOTAPort
+	previousClient, previousPoll := releaseHTTPClient, firmwareHTTPVerifyPollInterval
 	t.Cleanup(func() {
-		releaseHTTPClient, firmwareHTTPVerifyPollInterval, firmwareRawOTAPort = previousClient, previousPoll, previousPort
+		releaseHTTPClient, firmwareHTTPVerifyPollInterval = previousClient, previousPoll
 	})
 	t.Setenv("HOME", t.TempDir())
 	firmwareHTTPVerifyPollInterval = time.Millisecond
 
-	image := []byte("virtual raw OTA candidate")
+	image := []byte("virtual multipart OTA candidate")
 	cfg := virtualvibetv.DefaultConfig()
 	cfg.HTTPListenAddr, cfg.RawOTAListenAddr = "127.0.0.1:0", "127.0.0.1:0"
 	cfg.RebootUnavailableRequests = 0
@@ -38,16 +37,11 @@ func TestRunInstallUpdateUsesDedicatedRawOTAAndDoesNotFlashAlreadyCurrentDevice(
 	}
 	t.Cleanup(func() { _ = device.Close() })
 
-	rawURL, err := url.Parse(device.RawOTAURL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	firmwareRawOTAPort = rawURL.Port()
 	manifestURL := virtualFirmwareManifestServer(t, image)
 	releaseHTTPClient = &http.Client{Timeout: time.Second}
 	args := []string{"--target", device.HTTPURL, "--manifest-url", manifestURL, "--skip-launchagent-pause"}
 	if _, err := captureStdout(t, func() error { return runInstallUpdate(args) }); err != nil {
-		t.Fatalf("install through raw OTA listener: %v", err)
+		t.Fatalf("install through multipart OTA: %v", err)
 	}
 	output, err := captureStdout(t, func() error { return runInstallUpdate(args) })
 	if err != nil {
@@ -58,23 +52,23 @@ func TestRunInstallUpdateUsesDedicatedRawOTAAndDoesNotFlashAlreadyCurrentDevice(
 	}
 	state := device.Snapshot()
 	if state.UpdateUploads != 1 || len(state.Violations) != 0 {
-		t.Fatalf("OTA was repeated or not raw: %+v", state)
+		t.Fatalf("OTA was repeated: %+v", state)
 	}
-	if !hasEvent(state.Events, "/update/firmware.raw") {
-		t.Fatalf("raw OTA listener was not exercised: %+v", state.Events)
+	if !hasEvent(state.Events, "/update/firmware") {
+		t.Fatalf("multipart OTA endpoint was not exercised: %+v", state.Events)
 	}
 }
 
-func TestRunInstallUpdateAcceptsDroppedRawOTAResponseWithoutSecondFlash(t *testing.T) {
+func TestRunInstallUpdateAcceptsDroppedMultipartOTAResponseWithoutSecondFlash(t *testing.T) {
 	pinNoOtherRuntimeWriter(t)
-	previousClient, previousPoll, previousPort, previousTimeout := releaseHTTPClient, firmwareHTTPVerifyPollInterval, firmwareRawOTAPort, firmwareInterruptedVerifyTimeout
+	previousClient, previousPoll, previousTimeout := releaseHTTPClient, firmwareHTTPVerifyPollInterval, firmwareInterruptedVerifyTimeout
 	t.Cleanup(func() {
-		releaseHTTPClient, firmwareHTTPVerifyPollInterval, firmwareRawOTAPort, firmwareInterruptedVerifyTimeout = previousClient, previousPoll, previousPort, previousTimeout
+		releaseHTTPClient, firmwareHTTPVerifyPollInterval, firmwareInterruptedVerifyTimeout = previousClient, previousPoll, previousTimeout
 	})
 	t.Setenv("HOME", t.TempDir())
 	firmwareHTTPVerifyPollInterval, firmwareInterruptedVerifyTimeout = time.Millisecond, 100*time.Millisecond
 
-	image := []byte("accepted raw OTA then disconnected")
+	image := []byte("accepted multipart OTA then disconnected")
 	cfg := virtualvibetv.DefaultConfig()
 	cfg.HTTPListenAddr, cfg.RawOTAListenAddr = "127.0.0.1:0", "127.0.0.1:0"
 	cfg.DropUpdateResponseAfterAccept, cfg.RebootUnavailableRequests = true, 0
@@ -85,11 +79,6 @@ func TestRunInstallUpdateAcceptsDroppedRawOTAResponseWithoutSecondFlash(t *testi
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = device.Close() })
-	rawURL, err := url.Parse(device.RawOTAURL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	firmwareRawOTAPort = rawURL.Port()
 	releaseHTTPClient = &http.Client{Timeout: time.Second}
 
 	if _, err := captureStdout(t, func() error {

--- a/companion/internal/companionapi/server.go
+++ b/companion/internal/companionapi/server.go
@@ -197,6 +197,7 @@ type Server struct {
 	readCableSettings      func(string, string) (protocol.DeviceSettings, error)
 	writeCableSettings     func(string, string, protocol.DeviceSettingsPatch) (protocol.DeviceSettings, error)
 	configureCableWiFi     func(string, string, string, string) error
+	transferCableAsset     func(context.Context, string, string, string, string, string, []byte) error
 	subnetTargets          func() []string
 	defaultWiFiTarget      func() string
 	streamStatus           func(context.Context, string) displayStreamInfo
@@ -951,6 +952,7 @@ func New(opts Options) (*Server, error) {
 		readCableSettings:      usb.ReadSettings,
 		writeCableSettings:     usb.WriteSettings,
 		configureCableWiFi:     usb.ConfigureWiFi,
+		transferCableAsset:     usb.TransferAsset,
 		subnetTargets:          localSubnetTargets,
 		defaultWiFiTarget:      setup.DefaultWiFiTarget,
 		streamStatus:           inspectDisplayStream,
@@ -4292,23 +4294,44 @@ func (s *Server) requireCableControlDevice(
 	w http.ResponseWriter,
 	cfg runtimeconfig.Config,
 ) (string, protocol.DeviceHello, bool) {
-	expectedDeviceID := strings.TrimSpace(cfg.DeviceID)
-	if expectedDeviceID == "" {
+	if s.firmwareUpdateActive.Load() {
+		writeError(w, http.StatusConflict, "firmware_update_in_progress", "VibeTV update is still running.", "Wait for the update to finish, then try again.")
+		return "", protocol.DeviceHello{}, false
+	}
+	port, hello, err := s.cableControlDevice(cfg)
+	if err == nil {
+		return port, hello, true
+	}
+	if strings.TrimSpace(cfg.DeviceID) == "" {
 		writeDeviceNotFound(w)
 		return "", protocol.DeviceHello{}, false
 	}
-	port, err := s.resolveCablePort("", expectedDeviceID)
-	if err != nil {
+	if errcode.Of(err) != "" {
 		writeCableResolutionError(w, err)
 		return "", protocol.DeviceHello{}, false
+	}
+	writeError(w, http.StatusConflict, "cable_identity_unavailable", "The selected Cable VibeTV did not provide its current identity.", "Reconnect the Cable, wait for VibeTV to start, then retry.")
+	return "", protocol.DeviceHello{}, false
+}
+
+func (s *Server) cableControlDevice(cfg runtimeconfig.Config) (string, protocol.DeviceHello, error) {
+	expectedDeviceID := strings.TrimSpace(cfg.DeviceID)
+	if expectedDeviceID == "" {
+		return "", protocol.DeviceHello{}, errors.New("cable device identity is unavailable")
+	}
+	port, err := s.resolveCablePort("", expectedDeviceID)
+	if err != nil {
+		return "", protocol.DeviceHello{}, err
 	}
 	hello, err := s.readCableHello(port)
 	hello = hello.Normalize()
 	if err != nil || !cableHelloMatchesConfig(hello, expectedDeviceID) {
-		writeError(w, http.StatusConflict, "cable_identity_unavailable", "The selected Cable VibeTV did not provide its current identity.", "Reconnect the Cable, wait for VibeTV to start, then retry.")
-		return "", protocol.DeviceHello{}, false
+		if err == nil {
+			err = errors.New("cable device identity changed")
+		}
+		return "", protocol.DeviceHello{}, err
 	}
-	return port, hello, true
+	return port, hello, nil
 }
 
 func writeCableResolutionError(w http.ResponseWriter, err error) {
@@ -4481,6 +4504,9 @@ func (s *Server) handleThemeInstall(w http.ResponseWriter, r *http.Request) {
 	case "mac_app_restarting":
 		writeError(w, http.StatusConflict, refusal, "Mac App is restarting.", "Wait a moment, then start the theme install again.")
 		return
+	case "firmware_update_in_progress":
+		writeError(w, http.StatusConflict, refusal, "VibeTV update is still running.", "Wait for the update to finish, then install the theme again.")
+		return
 	default:
 		writeError(w, http.StatusConflict, refusal, "Another theme install is already running.", "Wait for the current theme install to finish, then retry.")
 		return
@@ -4542,7 +4568,16 @@ func (s *Server) handleThemeInstall(w http.ResponseWriter, r *http.Request) {
 	} else {
 		var hello protocol.DeviceHello
 		var ok bool
-		cfg, hello, ok = s.requireDevice(w, r)
+		cfg, err = s.config()
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		if runtimeconfig.NormalizeConnectionMode(cfg.ConnectionMode) == "cable" {
+			_, hello, ok = s.requireCableControlDevice(w, cfg)
+		} else {
+			cfg, hello, ok = s.requireDevice(w, r)
+		}
 		if !ok {
 			return
 		}
@@ -4825,7 +4860,18 @@ func (s *Server) handleFirmwareUpdateInstall(w http.ResponseWriter, r *http.Requ
 		)
 		return
 	}
-	cfg, hello, ok := s.requireDevice(w, r)
+	cfg, err := s.config()
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	var hello protocol.DeviceHello
+	var ok bool
+	if runtimeconfig.NormalizeConnectionMode(cfg.ConnectionMode) == "cable" {
+		_, hello, ok = s.requireCableControlDevice(w, cfg)
+	} else {
+		cfg, hello, ok = s.requireDevice(w, r)
+	}
 	if !ok {
 		return
 	}
@@ -4986,7 +5032,10 @@ func (s *Server) runThemeInstall(ctx context.Context, cfg runtimeconfig.Config, 
 		return themeinstall.Result{}, err
 	}
 	cfg = latestCfg
-	if strings.TrimSpace(cfg.DeviceTarget) == "" || strings.TrimSpace(cfg.DeviceToken) == "" {
+	cableMode := runtimeconfig.NormalizeConnectionMode(cfg.ConnectionMode) == "cable"
+	if strings.TrimSpace(cfg.DeviceToken) == "" ||
+		(cableMode && strings.TrimSpace(cfg.DeviceID) == "") ||
+		(!cableMode && strings.TrimSpace(cfg.DeviceTarget) == "") {
 		return themeinstall.Result{}, &statusAPIError{
 			status: http.StatusForbidden,
 			api: apiError{
@@ -5000,7 +5049,7 @@ func (s *Server) runThemeInstall(ctx context.Context, cfg runtimeconfig.Config, 
 	// render to baseline and verify against afterwards.
 	live := req.Slot != themepack.UsageScreensaver
 	var baseline deviceHealth
-	if live {
+	if live && !cableMode {
 		s.clearDisplayVerification(cfg.DeviceTarget)
 		baseline, err = s.captureDisplayRenderBaseline(ctx, cfg.DeviceTarget, cfg.DeviceToken)
 		if err != nil {
@@ -5021,6 +5070,19 @@ func (s *Server) runThemeInstall(ctx context.Context, cfg runtimeconfig.Config, 
 		skipFirmwareUpdate = *req.SkipFirmwareUpdate
 	}
 	pairedDuringThemeInstall := false
+	var cableInstall *themeinstall.CableInstallOptions
+	if cableMode {
+		port, hello, cableErr := s.cableControlDevice(cfg)
+		if cableErr != nil {
+			return themeinstall.Result{}, cableErr
+		}
+		cableInstall = &themeinstall.CableInstallOptions{
+			Capabilities: protocol.CapabilitiesFromHello(hello),
+			Upload: func(ctx context.Context, devicePath string, payload []byte, activation string) error {
+				return s.transferCableAsset(ctx, port, hello.DeviceID, cfg.DeviceToken, devicePath, activation, payload)
+			},
+		}
+	}
 	deviceInstallStartedAt := time.Now()
 	result, err := s.installTheme(ctx, themeinstall.Options{
 		Slot:               req.Slot,
@@ -5035,6 +5097,7 @@ func (s *Server) runThemeInstall(ctx context.Context, cfg runtimeconfig.Config, 
 		Verbose:            true,
 		Out:                out,
 		HTTPClient:         s.client,
+		Cable:              cableInstall,
 		PairTokenStore: func(target, token string) error {
 			pairedDuringThemeInstall = true
 			target = normalizeTarget(target)
@@ -5060,6 +5123,10 @@ func (s *Server) runThemeInstall(ctx context.Context, cfg runtimeconfig.Config, 
 		} else {
 			fmt.Fprintln(out, "Preview cache: ready")
 		}
+	}
+	if cableMode {
+		resumeStream()
+		return result, nil
 	}
 	if !live {
 		// The live theme rendered throughout, so there is no new image to wait
@@ -5385,6 +5452,9 @@ func (s *Server) tryStartThemeInstall() string {
 	if s.updateHoldActive() {
 		return "mac_app_restarting"
 	}
+	if _, running := s.activeFirmwareUpdateJob(); running {
+		return "firmware_update_in_progress"
+	}
 	s.installJobsMu.Lock()
 	defer s.installJobsMu.Unlock()
 	if s.themeInstallActive {
@@ -5673,6 +5743,11 @@ func (s *Server) startFirmwareUpdateJob(_ context.Context, jobID string, cfg run
 			s.pauseDisplayStream(true)
 			streamPaused = true
 		}
+		if runtimeconfig.NormalizeConnectionMode(cfg.ConnectionMode) == "cable" && s.resetCableSender != nil {
+			// The updater is a child process. Release the parent's exclusive
+			// serial handle after pausing its writer so the child can open it.
+			s.resetCableSender()
+		}
 		resumeStream := func() {
 			if !streamPaused {
 				return
@@ -5693,6 +5768,22 @@ func (s *Server) startFirmwareUpdateJob(_ context.Context, jobID string, cfg run
 
 		snapshot, _ := s.firmwareUpdateJobSnapshot(jobID)
 		shouldVerify := err == nil || (snapshot.Result != nil && snapshot.Result.UploadAccepted)
+		if shouldVerify && runtimeconfig.NormalizeConnectionMode(cfg.ConnectionMode) == "cable" {
+			finishedAt := time.Now().UTC()
+			s.updateFirmwareUpdateJob(jobID, func(job *firmwareUpdateJob) {
+				outcome := strings.TrimSpace(job.Outcome)
+				if outcome == "" {
+					outcome = "updated"
+				}
+				job.Phase = "complete"
+				job.Progress = 100
+				job.FinishedAt = &finishedAt
+				job.Outcome = outcome
+				job.Message = "Update complete."
+				appendFirmwareUpdateJobLog(job, "Update complete.")
+			})
+			return
+		}
 		if shouldVerify {
 			outcome, attentionMessage, verifyErr := s.verifyFirmwareUpdateResult(ctx, jobID, cfg)
 			if verifyErr == nil {
@@ -6486,6 +6577,13 @@ func firmwareUpdateErrorPayload(err error, retryPolicy string) apiError {
 			NextAction: "Disconnect VibeTV from power for 10 seconds, reconnect it, and wait until the picture returns before trying again.",
 		}
 	}
+	if strings.TrimSpace(retryPolicy) == "reconnect_cable" {
+		return apiError{
+			Code:       "firmware_update_cable_interrupted",
+			Message:    "Cable update was interrupted.",
+			NextAction: "Reconnect VibeTV with a data-capable Cable, wait for it to start, then try the update once.",
+		}
+	}
 	return apiError{
 		Code:       "firmware_update_failed",
 		Message:    "VibeTV update failed.",
@@ -6589,6 +6687,9 @@ func runFirmwareUpdateCommand(ctx context.Context, home string, cfg runtimeconfi
 		return err
 	}
 	target := publicTarget(cfg.DeviceTarget)
+	if runtimeconfig.NormalizeConnectionMode(cfg.ConnectionMode) == "cable" {
+		target = cableDeviceTarget
+	}
 	if target == "" {
 		return errors.New("device target is empty")
 	}
@@ -6675,6 +6776,9 @@ func (s *Server) requireThemeInstallPreflight(w http.ResponseWriter, r *http.Req
 			"Update VibeTV firmware or use a device that supports ThemeSpec v1.",
 		)
 		return false
+	}
+	if runtimeconfig.NormalizeConnectionMode(cfg.ConnectionMode) == "cable" {
+		return true
 	}
 
 	if _, err := s.getHealth(r.Context(), cfg.DeviceTarget, cfg.DeviceToken); err != nil {

--- a/companion/internal/companionapi/server_test.go
+++ b/companion/internal/companionapi/server_test.go
@@ -7520,6 +7520,39 @@ func TestStatusPreservesFreshCableChoiceAndReportsTransportSupport(t *testing.T)
 	}
 }
 
+func TestCableControlRequestsStayOffSerialDuringFirmwareUpdate(t *testing.T) {
+	cfg := runtimeconfig.Config{ConnectionMode: "cable", DeviceID: "device-cable", DeviceToken: "pair-token"}
+	server := newTestServer(t, cfg)
+	serialCalls := 0
+	server.resolveCablePort = func(string, string) (string, error) {
+		serialCalls++
+		return "/dev/mock", nil
+	}
+	server.firmwareUpdateActive.Store(true)
+
+	settings := httptest.NewRecorder()
+	server.Handler().ServeHTTP(settings, httptest.NewRequest(http.MethodGet, "/v1/settings", nil))
+	if settings.Code != http.StatusConflict || !strings.Contains(settings.Body.String(), "firmware_update_in_progress") {
+		t.Fatalf("Cable settings must wait for firmware update: status=%d body=%s", settings.Code, settings.Body.String())
+	}
+	if serialCalls != 0 {
+		t.Fatalf("Cable settings reopened serial during firmware update: calls=%d", serialCalls)
+	}
+
+	server.firmwareUpdateActive.Store(false)
+	server.createFirmwareUpdateJob(cfg)
+	theme := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/v1/themes/install", strings.NewReader(`{"themeId":"classic"}`))
+	request.Header.Set("Content-Type", "application/json")
+	server.Handler().ServeHTTP(theme, request)
+	if theme.Code != http.StatusConflict || !strings.Contains(theme.Body.String(), "firmware_update_in_progress") {
+		t.Fatalf("Cable theme install must not overlap firmware update: status=%d body=%s", theme.Code, theme.Body.String())
+	}
+	if serialCalls != 0 {
+		t.Fatalf("Cable theme install reopened serial during firmware update: calls=%d", serialCalls)
+	}
+}
+
 func TestSetupConnectionModeCollectsWiFiCredentialsBeforeChangingHostMode(t *testing.T) {
 	server := newTestServer(t, runtimeconfig.Config{
 		ConnectionMode: "cable",
@@ -8570,6 +8603,50 @@ func TestThemeInstallDelegatesToThemeInstallLogic(t *testing.T) {
 	}
 }
 
+func TestThemeInstallUsesCableTransferWithoutWiFiDeviceCalls(t *testing.T) {
+	server := newTestServer(t, runtimeconfig.Config{
+		ConnectionMode: "cable",
+		DeviceID:       "cable-device",
+		DeviceToken:    "pair-token",
+	})
+	server.resolveCablePort = func(_, expectedID string) (string, error) {
+		if expectedID != "cable-device" {
+			t.Fatalf("unexpected expected device %q", expectedID)
+		}
+		return "/dev/mock", nil
+	}
+	var hello protocol.DeviceHello
+	if err := json.Unmarshal([]byte(`{"kind":"hello","protocolVersion":2,"deviceId":"cable-device","board":"esp8266-smalltv-st7789","features":["theme-spec-v1"],"capabilities":{"theme":{"supportsThemeSpecV1":true,"maxStoredSpecBytes":4096,"maxPrimitives":32},"standby":{"supported":true},"transport":{"active":"usb","mode":"cable","supported":["usb","wifi"]}}}`), &hello); err != nil {
+		t.Fatal(err)
+	}
+	server.readCableHello = func(string) (protocol.DeviceHello, error) { return hello, nil }
+	type upload struct {
+		path       string
+		activation string
+	}
+	var uploads []upload
+	server.transferCableAsset = func(_ context.Context, port, deviceID, token, devicePath, activation string, payload []byte) error {
+		if port != "/dev/mock" || deviceID != "cable-device" || token != "pair-token" || len(payload) == 0 {
+			t.Fatalf("unexpected Cable upload port=%q id=%q token=%q bytes=%d", port, deviceID, token, len(payload))
+		}
+		uploads = append(uploads, upload{path: devicePath, activation: activation})
+		return nil
+	}
+
+	result, err := server.runThemeInstall(
+		context.Background(),
+		runtimeconfig.Config{},
+		themeInstallRequest{PackBytes: testThemePackZip(t)},
+		io.Discard,
+	)
+	if err != nil {
+		t.Fatalf("run Cable theme install: %v", err)
+	}
+	if result.Target != cableDeviceTarget || len(uploads) == 0 || uploads[len(uploads)-1].activation != "theme" {
+		t.Fatalf("unexpected Cable result=%+v uploads=%+v", result, uploads)
+	}
+}
+
 func TestThemeInstallCapturesRenderBaselineBeforeActivation(t *testing.T) {
 	var healthCalls atomic.Int32
 	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -9172,6 +9249,68 @@ func TestFirmwareUpdateAsyncReportsCustomerProgress(t *testing.T) {
 	}
 }
 
+func TestFirmwareUpdateCablePreflightPreservesAlreadyCurrentOutcome(t *testing.T) {
+	cfg := runtimeconfig.Config{
+		ConnectionMode: "cable",
+		DeviceID:       "device-cable-update",
+		DeviceToken:    "pair-token",
+	}
+	server := newTestServer(t, cfg)
+	server.resolveCablePort = func(explicit, expectedDeviceID string) (string, error) {
+		if explicit != "" || expectedDeviceID != cfg.DeviceID {
+			t.Fatalf("unexpected Cable resolution explicit=%q device=%q", explicit, expectedDeviceID)
+		}
+		return "/dev/mock-cable", nil
+	}
+	server.readCableHello = func(port string) (protocol.DeviceHello, error) {
+		if port != "/dev/mock-cable" {
+			t.Fatalf("unexpected Cable port %q", port)
+		}
+		var hello protocol.DeviceHello
+		if err := json.Unmarshal([]byte(`{"kind":"hello","protocolVersion":2,"deviceId":"device-cable-update","board":"esp8266-smalltv-st7789","firmware":"1.0.40","capabilities":{"transport":{"active":"usb","mode":"cable","supported":["usb","wifi"]}}}`), &hello); err != nil {
+			t.Fatal(err)
+		}
+		return hello, nil
+	}
+	parentPortClosed := make(chan struct{})
+	server.resetCableSender = func() { close(parentPortClosed) }
+	server.updateFirmware = func(_ context.Context, _ string, got runtimeconfig.Config, _ firmwareUpdateRequest, out io.Writer) error {
+		select {
+		case <-parentPortClosed:
+		default:
+			t.Fatal("parent Cable handle must close before the child updater starts")
+		}
+		if runtimeconfig.NormalizeConnectionMode(got.ConnectionMode) != "cable" || got.DeviceID != cfg.DeviceID {
+			t.Fatalf("unexpected Cable update config: %+v", got)
+		}
+		_, _ = io.WriteString(out, `CODEX_FIRMWARE_UPDATE_EVENT {"stage":"verifying_health","phase":"complete","outcome":"already_current","firmware":"1.0.40","observedFirmware":"1.0.40","target":"cable://vibetv","deviceId":"device-cable-update","artifactValidated":true,"helloVerified":true}`+"\n")
+		return nil
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/updates/install", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected Cable update to start without a WiFi target, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var started firmwareUpdateJobResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	var job firmwareUpdateJob
+	for attempt := 0; attempt < 100; attempt++ {
+		job, _ = server.firmwareUpdateJobSnapshot(started.Job.ID)
+		if job.Phase == "complete" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if job.Phase != "complete" || job.Outcome != "already_current" {
+		t.Fatalf("Cable already-current result was not preserved: %+v", job)
+	}
+}
+
 func TestFirmwareUpdatePausesDisplayTrafficUntilJobFinishes(t *testing.T) {
 	var deviceCalls atomic.Int32
 	device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -9704,6 +9843,48 @@ func TestFirmwareUpdateAsyncRequiresPowerCycleAfterUnsafeUpload(t *testing.T) {
 	}
 	if job.RetryPolicy != "power_cycle" || !strings.Contains(job.Error.NextAction, "Disconnect VibeTV from power") {
 		t.Fatalf("missing typed power-cycle recovery: %+v", job)
+	}
+}
+
+func TestFirmwareUpdateAsyncRequiresCableReconnectAfterInterruptedTransfer(t *testing.T) {
+	cfg := runtimeconfig.Config{ConnectionMode: "cable", DeviceID: "device-cable", DeviceToken: "pair-token"}
+	server := newTestServer(t, cfg)
+	server.resolveCablePort = func(string, string) (string, error) { return "/dev/mock", nil }
+	var hello protocol.DeviceHello
+	if err := json.Unmarshal([]byte(`{"kind":"hello","deviceId":"device-cable","board":"esp8266-smalltv-st7789","firmware":"1.0.40","capabilities":{"transport":{"active":"usb","mode":"cable"}}}`), &hello); err != nil {
+		t.Fatal(err)
+	}
+	server.readCableHello = func(string) (protocol.DeviceHello, error) { return hello, nil }
+	server.updateFirmware = func(_ context.Context, _ string, _ runtimeconfig.Config, _ firmwareUpdateRequest, out io.Writer) error {
+		event, err := json.Marshal(firmwareUpdateEvent{Stage: "uploading", Phase: "attention", Outcome: "interrupted", RetryPolicy: "reconnect_cable"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = fmt.Fprintf(out, "%s%s\n", firmwareupdate.EventPrefix, event)
+		return errors.New("Cable disconnected")
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/updates/install", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	server.Handler().ServeHTTP(rec, req)
+	var started firmwareUpdateJobResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	var job firmwareUpdateJob
+	for attempt := 0; attempt < 50; attempt++ {
+		job, _ = server.firmwareUpdateJobSnapshot(started.Job.ID)
+		if job.Phase == "error" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if job.Error == nil || job.Error.Code != "firmware_update_cable_interrupted" || job.RetryPolicy != "reconnect_cable" {
+		t.Fatalf("interrupted Cable update lost typed recovery: %+v", job)
+	}
+	if !strings.Contains(job.Error.NextAction, "data-capable Cable") {
+		t.Fatalf("interrupted Cable update has wrong next action: %+v", job.Error)
 	}
 }
 

--- a/companion/internal/themeinstall/themeinstall.go
+++ b/companion/internal/themeinstall/themeinstall.go
@@ -45,6 +45,11 @@ var installingThemeSpec = json.RawMessage(`{"v":1,"id":"installing","rev":1,"p":
 type FirmwareUpdater func(ctx context.Context, target, manifestURL string) error
 type PairTokenStore func(target, token string) error
 
+type CableInstallOptions struct {
+	Capabilities protocol.DeviceCapabilities
+	Upload       func(context.Context, string, []byte, string) error
+}
+
 type Options struct {
 	// Slot is themepack.UsageLive or themepack.UsageScreensaver. Empty means
 	// the live theme slot.
@@ -67,6 +72,7 @@ type Options struct {
 	UploadSettleDelay   time.Duration
 	Now                 func() time.Time
 	FetchLiveFrame      func(context.Context) (protocol.Frame, error)
+	Cable               *CableInstallOptions
 }
 
 type Result struct {
@@ -176,6 +182,9 @@ func Install(ctx context.Context, opts Options) (result Result, retErr error) {
 		themeName = pack.Manifest.ID
 	}
 	fmt.Fprintf(out, "Preparing theme: %s\n", themeName)
+	if opts.Cable != nil {
+		return installCablePack(ctx, pack, slot, themeName, opts.Cable, out)
+	}
 	if opts.Verbose {
 		themeSource := resolvedPack
 		if opts.PackBytes == nil {
@@ -401,6 +410,54 @@ func Install(ctx context.Context, opts Options) (result Result, retErr error) {
 		ActivePath:        pack.ThemeSpecFile.Entry.Path,
 		ThemeRevision:     pack.ThemeSpec.ThemeRev,
 		CapabilitiesKnown: caps.Known,
+	}, nil
+}
+
+func installCablePack(
+	ctx context.Context,
+	pack *themepack.Pack,
+	slot,
+	themeName string,
+	cable *CableInstallOptions,
+	out io.Writer,
+) (Result, error) {
+	if cable == nil || cable.Upload == nil {
+		return Result{}, errors.New("cable theme transfer is unavailable")
+	}
+	if err := pack.ValidateAgainstCapabilities(cable.Capabilities); err != nil {
+		return Result{}, themePackCapabilitiesError(err)
+	}
+	if slot == themepack.UsageScreensaver && cable.Capabilities.Known && !cable.Capabilities.SupportsStandby {
+		return Result{}, &InstallError{
+			Op:   "theme-pack/capabilities",
+			Code: errcode.ProtocolThemeSpecIncompatible,
+			Err:  errors.New("VibeTV does not advertise a screensaver slot"),
+		}
+	}
+
+	fmt.Fprintln(out, "Uploading theme files by Cable...")
+	for _, asset := range pack.Assets {
+		if err := cable.Upload(ctx, asset.Entry.Path, asset.Data, ""); err != nil {
+			return Result{}, &InstallError{Op: "theme-pack/upload", Code: errcode.UpgradeFlashFirmware, Err: err}
+		}
+	}
+	activation := "theme"
+	if slot == themepack.UsageScreensaver {
+		activation = "screensaver"
+	}
+	if err := cable.Upload(ctx, pack.ThemeSpecFile.Entry.Path, pack.ThemeSpecRaw, activation); err != nil {
+		return Result{}, &InstallError{Op: "theme-pack/activate", Code: errcode.UpgradeFlashFirmware, Err: err}
+	}
+	fmt.Fprintln(out, "Theme transferred and activated by Cable.")
+	return Result{
+		ThemeID:           pack.ThemeSpec.ThemeID,
+		PackID:            pack.Manifest.ID,
+		Name:              themeName,
+		Slot:              slot,
+		Target:            "cable://vibetv",
+		ActivePath:        pack.ThemeSpecFile.Entry.Path,
+		ThemeRevision:     pack.ThemeSpec.ThemeRev,
+		CapabilitiesKnown: cable.Capabilities.Known,
 	}, nil
 }
 

--- a/companion/internal/themeinstall/themeinstall_test.go
+++ b/companion/internal/themeinstall/themeinstall_test.go
@@ -94,6 +94,48 @@ func TestInstallUsesValidInMemoryPackBytes(t *testing.T) {
 	}
 }
 
+func TestInstallUsesOneCableUploadPathAndActivatesOnlyTheStoredSpec(t *testing.T) {
+	packBytes := zipMinimalThemePack(t, writeMinimalThemePack(t))
+	type upload struct {
+		path       string
+		activation string
+		bytes      int
+	}
+	var uploads []upload
+	result, err := Install(context.Background(), Options{
+		PackBytes: packBytes,
+		Out:       io.Discard,
+		Cable: &CableInstallOptions{
+			Capabilities: FallbackThemeSpecCapabilities(),
+			Upload: func(_ context.Context, devicePath string, payload []byte, activation string) error {
+				uploads = append(uploads, upload{path: devicePath, activation: activation, bytes: len(payload)})
+				return nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Install by Cable: %v", err)
+	}
+	if result.Target != "cable://vibetv" || result.ActivePath != "/themes/u/synth.json" {
+		t.Fatalf("unexpected Cable result %+v", result)
+	}
+	if len(uploads) < 1 {
+		t.Fatal("expected Cable uploads")
+	}
+	for index, got := range uploads {
+		if got.bytes == 0 {
+			t.Fatalf("upload %d is empty", index)
+		}
+		wantActivation := ""
+		if index == len(uploads)-1 {
+			wantActivation = "theme"
+		}
+		if got.activation != wantActivation {
+			t.Fatalf("upload %d activation=%q want=%q", index, got.activation, wantActivation)
+		}
+	}
+}
+
 func TestInstallRejectsScreensaverPackInLiveSlotBeforeDeviceAccess(t *testing.T) {
 	_, err := Install(context.Background(), Options{
 		PackBytes: zipThemePackFiles(t, screensaverPackFiles),

--- a/companion/internal/usb/transfer.go
+++ b/companion/internal/usb/transfer.go
@@ -1,0 +1,221 @@
+package usb
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/errcode"
+)
+
+const cableTransferChunkBytes = 128
+
+var ErrCableTransferInterrupted = errors.New("cable transfer interrupted")
+
+var errCableTransferRejected = errors.New("cable transfer rejected")
+
+type TransferSink string
+
+const (
+	TransferSinkAsset    TransferSink = "asset"
+	TransferSinkFirmware TransferSink = "firmware"
+)
+
+type transferReply struct {
+	Kind   string `json:"kind"`
+	Status string `json:"status"`
+	Next   int    `json:"next"`
+	Code   string `json:"code"`
+}
+
+func (s *Sender) Transfer(ctx context.Context, pathName, deviceID, token string, sink TransferSink, destination, activation string, payload []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if sink != TransferSinkAsset && sink != TransferSinkFirmware {
+		return fmt.Errorf("unsupported Cable transfer sink %q", sink)
+	}
+	deviceID = strings.TrimSpace(deviceID)
+	token = strings.TrimSpace(token)
+	destination = strings.TrimSpace(destination)
+	activation = strings.TrimSpace(activation)
+	if deviceID == "" {
+		return errors.New("cable transfer deviceId is required")
+	}
+	if token == "" {
+		return errors.New("cable transfer pairing token is required")
+	}
+	if sink == TransferSinkAsset && (destination == "" || path.Clean(destination) != destination) {
+		return errors.New("cable asset destination is invalid")
+	}
+	if len(payload) == 0 {
+		return errors.New("cable transfer payload is empty")
+	}
+
+	if _, err := s.ensurePort(pathName); err != nil {
+		return err
+	}
+	digest := md5.Sum(payload)
+	digestHex := hex.EncodeToString(digest[:])
+	abort := true
+	defer func() {
+		if abort {
+			s.abortTransferLocked()
+		}
+	}()
+
+	start := struct {
+		Kind     string       `json:"kind"`
+		Op       string       `json:"op"`
+		DeviceID string       `json:"deviceId"`
+		Token    string       `json:"token"`
+		Sink     TransferSink `json:"sink"`
+		Path     string       `json:"path,omitempty"`
+		Activate string       `json:"activate,omitempty"`
+		Bytes    int          `json:"bytes"`
+		Hash     string       `json:"hash"`
+	}{
+		Kind:     "request",
+		Op:       "transfer-start",
+		DeviceID: deviceID,
+		Token:    token,
+		Sink:     sink,
+		Path:     destination,
+		Activate: activation,
+		Bytes:    len(payload),
+		Hash:     digestHex,
+	}
+	if err := s.sendTransferRequestLocked(pathName, start, "ready", 0); err != nil {
+		if errors.Is(err, errCableTransferRejected) {
+			return err
+		}
+		return fmt.Errorf("%w: %w", ErrCableTransferInterrupted, err)
+	}
+
+	sequence := 0
+	for offset := 0; offset < len(payload); offset += cableTransferChunkBytes {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("%w: %w", ErrCableTransferInterrupted, err)
+		}
+		end := offset + cableTransferChunkBytes
+		if end > len(payload) {
+			end = len(payload)
+		}
+		chunk := payload[offset:end]
+		request := struct {
+			Kind     string `json:"kind"`
+			Op       string `json:"op"`
+			Seq      int    `json:"seq"`
+			Data     string `json:"data"`
+			Checksum string `json:"checksum"`
+		}{
+			Kind:     "request",
+			Op:       "transfer-chunk",
+			Seq:      sequence,
+			Data:     hex.EncodeToString(chunk),
+			Checksum: chunkChecksum(chunk),
+		}
+		sequence++
+		if err := s.sendTransferRequestLocked(pathName, request, "chunk", sequence); err != nil {
+			return fmt.Errorf("%w: %w", ErrCableTransferInterrupted, err)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("%w: %w", ErrCableTransferInterrupted, err)
+	}
+
+	finish := struct {
+		Kind string `json:"kind"`
+		Op   string `json:"op"`
+	}{Kind: "request", Op: "transfer-finish"}
+	reply, err := s.sendTransferRequestForReplyLocked(pathName, finish)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrCableTransferInterrupted, err)
+	}
+	if reply.Status != "complete" {
+		return fmt.Errorf("%w: completion did not match the payload", ErrCableTransferInterrupted)
+	}
+	abort = false
+	if sink == TransferSinkFirmware {
+		s.closeCurrentLocked()
+	}
+	return nil
+}
+
+func chunkChecksum(chunk []byte) string {
+	digest := md5.Sum(chunk)
+	return hex.EncodeToString(digest[:4])
+}
+
+func (s *Sender) sendTransferRequestLocked(pathName string, request any, status string, next int) error {
+	reply, err := s.sendTransferRequestForReplyLocked(pathName, request)
+	if err != nil {
+		return err
+	}
+	if reply.Status != status || reply.Next != next {
+		return fmt.Errorf("cable transfer returned unexpected acknowledgement")
+	}
+	return nil
+}
+
+func (s *Sender) sendTransferRequestForReplyLocked(pathName string, request any) (transferReply, error) {
+	line, err := json.Marshal(request)
+	if err != nil {
+		return transferReply{}, err
+	}
+	line = append(line, '\n')
+	if err := writeWithTimeout(s.port, line, s.writeTimeout); err != nil {
+		s.closeCurrentLocked()
+		return transferReply{}, wrapTransportError(
+			errcode.TransportSerialWrite,
+			"cable-transfer",
+			pathName,
+			"Keep the selected VibeTV connected by Cable and retry.",
+			err,
+		)
+	}
+
+	var reply transferReply
+	seen := readPortLines(s.port, s.helloWindow, func(line string) bool {
+		if json.Unmarshal([]byte(line), &reply) != nil {
+			return false
+		}
+		return strings.TrimSpace(reply.Kind) == "transfer" || strings.TrimSpace(reply.Kind) == "error"
+	})
+	if !seen {
+		return transferReply{}, errors.New("VibeTV did not acknowledge the Cable transfer")
+	}
+	if strings.TrimSpace(reply.Kind) == "error" {
+		return transferReply{}, fmt.Errorf("%w: %s", errCableTransferRejected, strings.TrimSpace(reply.Code))
+	}
+	return reply, nil
+}
+
+func (s *Sender) abortTransferLocked() {
+	if s.port == nil {
+		return
+	}
+	request := struct {
+		Kind string `json:"kind"`
+		Op   string `json:"op"`
+	}{Kind: "request", Op: "transfer-abort"}
+	line, err := json.Marshal(request)
+	if err == nil {
+		line = append(line, '\n')
+		_ = writeWithTimeout(s.port, line, s.writeTimeout)
+	}
+	// The device replies to abort. Closing here discards that reply so it
+	// cannot be mistaken for the acknowledgement of the next transfer.
+	s.closeCurrentLocked()
+}

--- a/companion/internal/usb/transfer_test.go
+++ b/companion/internal/usb/transfer_test.go
@@ -1,0 +1,203 @@
+package usb
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	serial "go.bug.st/serial"
+)
+
+func TestSenderTransfersAssetWithOneAcknowledgedChunkInFlight(t *testing.T) {
+	payload := make([]byte, cableTransferChunkBytes+3)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	digest := md5.Sum(payload)
+	digestHex := hex.EncodeToString(digest[:])
+	transferID := digestHex[:16]
+	port := newMockSerialPort()
+	port.readQueue = [][]byte{
+		[]byte(`{"kind":"transfer","id":"` + transferID + `","status":"ready","next":0}` + "\n"),
+		[]byte(`{"kind":"transfer","id":"` + transferID + `","status":"chunk","next":1}` + "\n"),
+		[]byte(`{"kind":"transfer","id":"` + transferID + `","status":"chunk","next":2}` + "\n"),
+		[]byte(`{"kind":"transfer","id":"` + transferID + `","status":"complete","next":2}` + "\n"),
+	}
+	sender := NewSenderWithConfig(SenderConfig{
+		Opener:      &mockOpener{portsByPath: map[string]SerialPort{"/dev/mock": port}},
+		Sleep:       func(time.Duration) {},
+		HelloWindow: 10 * time.Millisecond,
+	})
+
+	if err := sender.Transfer(context.Background(), "/dev/mock", "14799300", "paired-token", TransferSinkAsset, "/themes/u/test.cba", "theme", payload); err != nil {
+		t.Fatalf("transfer asset: %v", err)
+	}
+	if len(port.writePayloads) != 4 {
+		t.Fatalf("writes=%d want=4", len(port.writePayloads))
+	}
+	var start struct {
+		Op       string       `json:"op"`
+		DeviceID string       `json:"deviceId"`
+		Token    string       `json:"token"`
+		Sink     TransferSink `json:"sink"`
+		Path     string       `json:"path"`
+		Activate string       `json:"activate"`
+		Bytes    int          `json:"bytes"`
+		Hash     string       `json:"hash"`
+	}
+	if err := json.Unmarshal(port.writePayloads[0], &start); err != nil {
+		t.Fatal(err)
+	}
+	if start.Op != "transfer-start" || start.DeviceID != "14799300" || start.Token != "paired-token" ||
+		start.Sink != TransferSinkAsset || start.Path != "/themes/u/test.cba" || start.Activate != "theme" ||
+		start.Bytes != len(payload) || start.Hash != digestHex {
+		t.Fatalf("unexpected start request %+v", start)
+	}
+	for index, want := range [][]byte{payload[:cableTransferChunkBytes], payload[cableTransferChunkBytes:]} {
+		var chunk struct {
+			Op       string `json:"op"`
+			Seq      int    `json:"seq"`
+			Data     string `json:"data"`
+			Checksum string `json:"checksum"`
+		}
+		if err := json.Unmarshal(port.writePayloads[index+1], &chunk); err != nil {
+			t.Fatal(err)
+		}
+		decoded, err := hex.DecodeString(chunk.Data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if chunk.Op != "transfer-chunk" || chunk.Seq != index ||
+			string(decoded) != string(want) || chunk.Checksum != chunkChecksum(want) {
+			t.Fatalf("unexpected chunk %d: %+v bytes=%v", index, chunk, decoded)
+		}
+	}
+}
+
+func TestSenderAbortsWhenDeviceRejectsChunkBeforeAcknowledgement(t *testing.T) {
+	payload := []byte("payload")
+	digest := md5.Sum(payload)
+	transferID := hex.EncodeToString(digest[:])[:16]
+	port := newMockSerialPort()
+	port.readQueue = [][]byte{
+		[]byte(`{"kind":"transfer","id":"` + transferID + `","status":"ready","next":0}` + "\n"),
+		[]byte(`{"kind":"error","code":"transfer-crc"}` + "\n"),
+	}
+	sender := NewSenderWithConfig(SenderConfig{
+		Opener:      &mockOpener{portsByPath: map[string]SerialPort{"/dev/mock": port}},
+		Sleep:       func(time.Duration) {},
+		HelloWindow: 10 * time.Millisecond,
+	})
+
+	err := sender.Transfer(context.Background(), "/dev/mock", "14799300", "paired-token", TransferSinkFirmware, "", "", payload)
+	if err == nil {
+		t.Fatal("expected rejected chunk")
+	}
+	if !errors.Is(err, ErrCableTransferInterrupted) {
+		t.Fatalf("rejected in-flight chunk must report interrupted transfer: %v", err)
+	}
+	if len(port.writePayloads) != 3 {
+		t.Fatalf("writes=%d want start, chunk and abort", len(port.writePayloads))
+	}
+	var abort struct {
+		Op string `json:"op"`
+	}
+	if err := json.Unmarshal(port.writePayloads[2], &abort); err != nil {
+		t.Fatal(err)
+	}
+	if abort.Op != "transfer-abort" {
+		t.Fatalf("unexpected abort request %+v", abort)
+	}
+	if port.closeCalls != 1 {
+		t.Fatal("failed transfer must close the port and discard the abort reply")
+	}
+}
+
+func TestSenderCanTransferAfterRejectedTransfer(t *testing.T) {
+	failedPort := newMockSerialPort()
+	failedPort.readQueue = [][]byte{
+		[]byte(`{"kind":"transfer","status":"ready","next":0}` + "\n"),
+		[]byte(`{"kind":"error","code":"transfer-crc"}` + "\n"),
+		[]byte(`{"kind":"transfer","status":"aborted","next":0}` + "\n"),
+	}
+	successPort := newMockSerialPort()
+	successPort.readQueue = [][]byte{
+		[]byte(`{"kind":"transfer","status":"ready","next":0}` + "\n"),
+		[]byte(`{"kind":"transfer","status":"chunk","next":1}` + "\n"),
+		[]byte(`{"kind":"transfer","status":"complete","next":1}` + "\n"),
+	}
+	ports := []SerialPort{failedPort, successPort}
+	opener := &mockOpener{openFn: func(string, *serial.Mode) (SerialPort, error) {
+		if len(ports) == 0 {
+			return nil, errors.New("unexpected open")
+		}
+		port := ports[0]
+		ports = ports[1:]
+		return port, nil
+	}}
+	sender := NewSenderWithConfig(SenderConfig{
+		Opener:      opener,
+		Sleep:       func(time.Duration) {},
+		HelloWindow: 10 * time.Millisecond,
+	})
+
+	if err := sender.Transfer(context.Background(), "/dev/mock", "14799300", "paired-token", TransferSinkAsset, "/themes/u/first.cba", "", []byte("first")); err == nil {
+		t.Fatal("expected first transfer to fail")
+	}
+	if err := sender.Transfer(context.Background(), "/dev/mock", "14799300", "paired-token", TransferSinkAsset, "/themes/u/second.cba", "theme", []byte("second")); err != nil {
+		t.Fatalf("second transfer: %v", err)
+	}
+	if opener.openCount("/dev/mock") != 2 {
+		t.Fatal("second transfer must reopen a clean serial connection")
+	}
+}
+
+func TestSenderReportsMissingStartAcknowledgementAsInterrupted(t *testing.T) {
+	port := newMockSerialPort()
+	sender := NewSenderWithConfig(SenderConfig{
+		Opener:      &mockOpener{portsByPath: map[string]SerialPort{"/dev/mock": port}},
+		Sleep:       func(time.Duration) {},
+		HelloWindow: time.Millisecond,
+	})
+
+	err := sender.Transfer(context.Background(), "/dev/mock", "14799300", "paired-token", TransferSinkFirmware, "", "", []byte("firmware"))
+	if !errors.Is(err, ErrCableTransferInterrupted) {
+		t.Fatalf("missing ready acknowledgement must report interrupted transfer: %v", err)
+	}
+	if len(port.writePayloads) != 2 || port.closeCalls != 1 {
+		t.Fatalf("start timeout must abort and close: writes=%d closes=%d", len(port.writePayloads), port.closeCalls)
+	}
+}
+
+func TestSenderAbortsWhenContextIsCanceledAfterAcknowledgedChunk(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	port := newMockSerialPort()
+	port.readQueue = [][]byte{
+		[]byte(`{"kind":"transfer","status":"ready","next":0}` + "\n"),
+		[]byte(`{"kind":"transfer","status":"chunk","next":1}` + "\n"),
+	}
+	port.readHook = func(call int) {
+		if call == 2 {
+			cancel()
+		}
+	}
+	sender := NewSenderWithConfig(SenderConfig{
+		Opener:      &mockOpener{portsByPath: map[string]SerialPort{"/dev/mock": port}},
+		Sleep:       func(time.Duration) {},
+		HelloWindow: 10 * time.Millisecond,
+	})
+	payload := make([]byte, cableTransferChunkBytes+1)
+
+	err := sender.Transfer(ctx, "/dev/mock", "14799300", "paired-token", TransferSinkAsset, "/themes/u/test.cba", "theme", payload)
+	if !errors.Is(err, ErrCableTransferInterrupted) || !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled transfer must be interrupted: %v", err)
+	}
+	if len(port.writePayloads) != 3 {
+		t.Fatalf("canceled transfer must write start, one chunk, abort; got %d writes", len(port.writePayloads))
+	}
+}

--- a/companion/internal/usb/usb.go
+++ b/companion/internal/usb/usb.go
@@ -1,6 +1,7 @@
 package usb
 
 import (
+	"context"
 	"time"
 
 	"github.com/DreamyTalesPAN/CodexBar-Display/companion/internal/protocol"
@@ -97,6 +98,14 @@ func WriteSettings(port, deviceID string, patch protocol.DeviceSettingsPatch) (p
 
 func ConfigureWiFi(port, deviceID, ssid, password string) error {
 	return defaultSender.ConfigureWiFi(port, deviceID, ssid, password)
+}
+
+func TransferAsset(ctx context.Context, port, deviceID, token, destination, activation string, payload []byte) error {
+	return defaultSender.Transfer(ctx, port, deviceID, token, TransferSinkAsset, destination, activation, payload)
+}
+
+func TransferFirmware(ctx context.Context, port, deviceID, token string, payload []byte) error {
+	return defaultSender.Transfer(ctx, port, deviceID, token, TransferSinkFirmware, "", "", payload)
 }
 
 func CloseDefaultSender() {

--- a/companion/internal/usb/usb_test.go
+++ b/companion/internal/usb/usb_test.go
@@ -482,6 +482,8 @@ type mockSerialPort struct {
 	mu sync.Mutex
 
 	readQueue     [][]byte
+	readCalls     int
+	readHook      func(int)
 	writeCalls    int
 	writePayloads [][]byte
 	writeErr      error
@@ -495,13 +497,27 @@ func newMockSerialPort() *mockSerialPort {
 
 func (m *mockSerialPort) Read(p []byte) (int, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.readCalls++
+	readCall := m.readCalls
+	hook := m.readHook
 	if len(m.readQueue) == 0 {
+		m.mu.Unlock()
+		if hook != nil {
+			hook(readCall)
+		}
 		return 0, io.EOF
 	}
 	next := m.readQueue[0]
-	m.readQueue = m.readQueue[1:]
 	n := copy(p, next)
+	if n == len(next) {
+		m.readQueue = m.readQueue[1:]
+	} else {
+		m.readQueue[0] = next[n:]
+	}
+	m.mu.Unlock()
+	if hook != nil {
+		hook(readCall)
+	}
 	return n, nil
 }
 

--- a/docs/control-center-customer-ui-approval.md
+++ b/docs/control-center-customer-ui-approval.md
@@ -2062,3 +2062,16 @@ issue scope, or release permission never implies UI permission.
   available until the device is identified; Cable stays recommended.
 - Approved files: the Companion reset/status endpoints and tests, runtime
   configuration transaction and reset logic, and this approval record.
+
+## 2026-08-27 — Interrupted Cable update keeps a manual retry
+
+- User approval: After reviewing the exact Cable-interruption message and
+  pointing out that a customer cannot retry without a button, the user approved
+  the corrected visible result with `ok ist so freigegeben, mach`.
+- Approved customer-visible result: If a Cable firmware transfer is
+  interrupted, the update card shows `Update failed` and `Reconnect VibeTV with
+  a data-capable Cable, wait for it to start, then try the update once.` The
+  customer can then click `Try again` manually. The app never retries the
+  firmware transfer automatically. `Create report` remains available.
+- Approved files: `control-center-app.tsx`, `updates-screen.test.tsx`, the
+  Companion Cable-interruption error and tests, and this approval record.

--- a/docs/firmware-ota-contract.md
+++ b/docs/firmware-ota-contract.md
@@ -8,7 +8,7 @@ handlers.
 
 - The radio must run 802.11g (`docs/hardware-contract.md`, "WiFi PHY mode").
   Under 802.11n the AP can aggregate frames the ESP8266 silently drops, which
-  stalls the RAW OTA at the TCP level while `/hello` still answers. Devices on
+  stalls a WiFi firmware upload at the TCP level while `/hello` still answers. Devices on
   firmware `< 1.0.40` still run 11n, so their first update can hit this; a
   power cycle immediately before the update starts a fresh, unaggregated
   association. Run `codexbar-display net-probe --target http://<ip>` when an
@@ -23,9 +23,11 @@ handlers.
 - Treat device URL, `deviceId`, and pairing token as one identity tuple. When a
   target changes, update all three together; never reuse an unverified token
   from the previous target.
-- Validate the selected token with an authenticated `GET /hello` against the
-  pinned device before opening the RAW OTA connection. A `401`/`403` must repair
-  pairing and repeat identity validation before any firmware body is sent.
+- On WiFi, validate the selected token with an authenticated `GET /hello`
+  against the pinned device before opening the multipart upload. A `401`/`403`
+  must repair pairing and repeat identity validation before any firmware body is
+  sent. On Cable, validate the same `deviceId` in the serial hello before the
+  authenticated transfer starts.
 - Validate the selected manifest artifact and SHA-256 before opening the OTA
   connection.
 - Pause the display stream for the complete upload. The Control Center uses its
@@ -33,8 +35,8 @@ handlers.
   display-stream launch service.
 - Do not run discovery, health polling, frame writes, theme installs, or asset
   uploads while firmware bytes are being sent.
-- A failed upload is never followed by a different transport or a second upload
-  in the same device boot once firmware bytes may have been sent.
+- A failed upload is never retried or moved to a different transport in the
+  same device boot once firmware bytes may have been sent.
 - A successful update is complete only after the same `deviceId` returns with
   the target firmware and healthy rendering.
 
@@ -54,10 +56,23 @@ device. Manifest SHA-256 validation therefore remains a sender-side release
 check, while the current pairing token is the mandatory receiver-side upload
 authorization. Open pairing never authorizes a firmware upload directly.
 
-## Firmware 1.0.36 compatibility transport
+## Current transports
+
+- **WiFi:** authenticated multipart `POST /update/firmware` is the current
+  firmware receiver path.
+- **Cable:** the newline-delimited serial bulk-transfer protocol in
+  `protocol/PROTOCOL.md` is the current Cable path. It is stop-and-wait, uses a
+  128-byte candidate chunk, validates a per-chunk MD5 prefix and a complete MD5,
+  and commits firmware only after `transfer-finish` verifies the full payload.
+- **Installed firmware 1.0.36 only:** the Mac keeps the legacy RAW sender below
+  as a bridge to a receiver that predates the current multipart path. Current
+  firmware no longer starts a duplicate RAW receiver on TCP port `8081`.
+
+## Legacy 1.0.36 RAW compatibility sender
 
 Firmware `1.0.36` has a fragile ESP8266 receive path. The supported bridge to
-`1.0.37` is the RAW HTTP endpoint on TCP port `8081`:
+`1.0.37` remains the Mac's RAW HTTP sender to the old device receiver on TCP
+port `8081`:
 
 - request: `POST /update/firmware.raw`
 - body: exact firmware binary with an explicit `Content-Length`
@@ -70,12 +85,13 @@ Firmware `1.0.36` has a fragile ESP8266 receive path. The supported bridge to
 - acknowledgment timeout: `30 s`
 - total connection deadline: `5 min`
 
-These values are a compatibility requirement, not a performance preference.
-Do not increase them without repeating the `1.0.36 -> 1.0.37` hardware gate.
+These historical values are a legacy-device compatibility requirement, not a
+preference for current firmware. Do not increase them without repeating the
+`1.0.36 -> 1.0.37` hardware gate.
 
-The `10 ms` body-write pacing applies to every firmware version, not only to
-`1.0.36`. The sender briefly had an unpaced fast path for released firmware
-`>= 1.0.37`; it was removed after hardware measurement (2026-08-07,
+The sender's `10 ms` body-write pacing applies when the legacy RAW bridge is
+used. The sender briefly had an unpaced fast path for released firmware
+`>= 1.0.37`; it was removed after historical hardware measurement (2026-08-07,
 esp8266-smalltv-st7789, firmware 1.0.39):
 
 | RAW upload mode | Concurrent device traffic | Installed |
@@ -84,44 +100,50 @@ esp8266-smalltv-st7789, firmware 1.0.39):
 | paced (10 ms) | none | 2/2 |
 | paced (10 ms) | Mac App runtime polling port 80 | 0/1 |
 
-Rule: `10 ms` pacing for all firmware versions, fast path removed. Pacing is
-necessary but only sufficient when no other client is talking to the device,
-which is why every writer must be quiesced before the upload starts.
+Rule for the legacy bridge: `10 ms` pacing, no fast path. Pacing is necessary
+but only sufficient when no other client is talking to the device, which is why
+every writer must be quiesced before the upload starts.
 
-Multipart is allowed only when the RAW endpoint is provably unavailable before
-an upload starts, for example `connection refused`, `no route to host`, or an
-HTTP `404`. A timeout is not proof that no firmware bytes reached the device.
+RAW is not a current-firmware fallback. The updater selects it only for the
+known installed `1.0.36` compatibility case; otherwise WiFi uses multipart and
+Cable uses the serial bulk transfer.
 
 ## Failure and retry state machine
 
-1. A connection refusal before RAW is available may fall back to multipart.
-2. An authentication rejection during the mandatory preflight repairs pairing
-   and repeats authenticated identity validation before opening RAW OTA.
-3. A broken pipe, reset, EOF, or other interrupted RAW upload first waits for
+1. An authentication rejection during the mandatory preflight repairs pairing
+   and repeats authenticated identity validation before opening the selected
+   upload path.
+2. A broken pipe, reset, EOF, or other interrupted legacy RAW upload first waits for
    the target version to return. This covers a successful flash whose response
    was lost.
-4. If the same device returns on the old version, stop. Ask the customer to
+3. If the same device returns on the old version, stop. Ask the customer to
    disconnect power for 10 seconds and retry only after the picture returns.
-5. Never switch to multipart or automatically resend in the same boot after an
-   interrupted RAW upload.
+4. Never automatically resend or switch transports in the same boot after an
+   interrupted upload.
 
 The firmware validates OTA authentication immediately after reading the request
 headers and closes the connection before `Update.begin()` when the token is
 wrong. A sender that reads the HTTP response only after writing the complete
 body can therefore surface the early `401` merely as `EPIPE`/`broken pipe`.
-This is why authenticated `/hello` is a required preflight rather than an
-upload-error recovery optimization.
+This is why authenticated identity validation is a required preflight rather
+than an upload-error recovery optimization.
 
-## Firmware receiver requirements from 1.0.37 onward
+## Current firmware receiver requirements
 
 - Release renderer, filesystem, UDP, and unrelated TCP resources before
-  `Update.begin()` while preserving the active OTA socket.
-- Reject an empty or oversized RAW body before entering update mode.
-- Use the exact RAW `Content-Length` as the update size.
+  `Update.begin()` while preserving the active multipart HTTP request or Cable
+  transfer state.
+- Reject an empty or oversized multipart body or Cable `transfer-start` byte
+  count before entering update mode.
+- For WiFi, begin with the board's bounded maximum update size and let the
+  multipart upload's actual firmware bytes determine the final image length.
+  For Cable, use the declared transfer byte count and do not call `Update.end()`
+  until the complete MD5 matches at `transfer-finish`.
 - Read only bytes currently available from the socket, in buffers no larger
   than `512` bytes. Do not block waiting to fill a larger buffer.
 - Reset the ESP8266 `Update` object on every failed begin, write, timeout,
-  disconnect, abort, or final validation.
+  disconnect, abort, or final validation. A Cable transfer inactivity timeout
+  is 15 seconds and must discard the inactive update.
 - After a failure that entered update mode, return the error and perform a
   controlled restart. Do not accept another OTA attempt in that boot.
 - Firmware `1.0.39` has no physical pairing recovery counter. Its legacy EEPROM
@@ -141,3 +163,12 @@ available production-representative device:
 5. Confirm health, rendering, WiFi credentials, and theme assets remain intact.
 
 Any unexplained failure resets the consecutive-run count.
+
+## #302 hardware gate
+
+The Cable bulk-transfer implementation is not release-proven yet. The current
+development ESP8266 build uses 46,832 bytes RAM, 476,023 bytes flash, and a
+480,176-byte `firmware.bin` (below the 482,000-byte image limit); it has not
+been flashed. #302 remains open until direct-Mac and dock measurements cover
+maximum theme, screensaver, and firmware transfers, unplug/timeout recovery,
+and timing for the final production chunk size.

--- a/docs/hardware-contract.md
+++ b/docs/hardware-contract.md
@@ -119,6 +119,13 @@ release-gated ESP8266 build and native suites, but was not flashed to hardware;
 real-screen rehearsal still requires a separate current hardware-write
 approval.
 
+The local #302 Cable-transfer development build uses 476,023 bytes flash and
+46,832 bytes RAM; its 480,176-byte `firmware.bin` is below the 482,000-byte
+image limit. It has not been flashed. The 128-byte Cable chunk is a candidate,
+not a hardware-proven production limit: direct-Mac and dock measurements still
+must cover maximum theme, screensaver, and firmware transfers, unplug/timeout
+recovery, and transfer timing before #302 can close.
+
 ## Cutover Migration Contract
 
 The connection-mode byte is appended to the existing `/s` record. Shorter
@@ -151,9 +158,10 @@ own bounded chunks, acknowledgements, retry boundary, and whole-payload hash.
 
 The ESP8266 UART has no flow control. Six back-to-back frames overflowed the
 current receive path while six frames spaced by 100 ms passed. Normal runtime
-frames therefore remain paced; #302's bulk protocol must use bounded
-stop-and-wait chunks and acknowledgements rather than copying an HTTP chunk
-size onto serial.
+frames therefore remain paced. #302 now uses one 128-byte candidate chunk at a
+time, with a device acknowledgement after its MD5 prefix is verified and the
+chunk is written; the final full-payload MD5 gates commit. That implementation
+still needs the direct-Mac and dock measurement gate above.
 
 The full Cable hello on the branch firmware is 1,161 bytes including newline.
 After opening the CH340 behind the D6000 dock, the first requested hello took
@@ -193,20 +201,24 @@ black hole. Support guidance for a stalling first update: power-cycle the
 VibeTV immediately before retrying (a fresh association starts without
 aggregation state).
 
-Forcing 11g removes the A-MSDU black hole, but it is not the only OTA stall
-mechanism. A rarer RAW-OTA acknowledgement stall still occurs intermittently
-even on 11g with healthy heap (roughly one leg in 5–10; the receive window
-closes at a 1024-byte block boundary, most likely while the ESP8266 erases a
-flash sector). This is the case the paced RAW upload and the "restart before
-another firmware upload" recovery below exist for: power-cycle and retry once.
+Forcing 11g removes the A-MSDU black hole, but it is not the only historical
+OTA stall mechanism. A rarer legacy RAW-OTA acknowledgement stall occurred
+intermittently even on 11g with healthy heap (roughly one leg in 5–10; the
+receive window closed at a 1024-byte block boundary, most likely while the
+ESP8266 erased a flash sector). The paced RAW bridge and the "restart before
+another firmware upload" recovery below apply only while upgrading installed
+1.0.36 devices.
 `scripts/vibetv-hw-selftest.sh` performs that recovery after the operator
 approves it on the terminal (a failed hardware write is never retried
 unattended).
 
-### RAW OTA sender pacing: always paced, and never concurrent
+### Legacy RAW OTA sender pacing: compatibility evidence
 
-The RAW OTA sender keeps a 10 ms pause between 64-byte chunks for **every**
-firmware version, and waits for a block acknowledgement every 1024 bytes.
+The Mac keeps the RAW sender only to bridge installed 1.0.36 devices. That
+legacy sender keeps a 10 ms pause between 64-byte chunks and waits for a block
+acknowledgement every 1024 bytes. Current firmware no longer runs the duplicate
+RAW receiver on TCP port 8081: WiFi receives multipart updates, Cable receives
+the serial bulk protocol.
 
 The pause used to be skipped for released firmware >= 1.0.37, on the assumption
 that the receiver fix in that version made it unnecessary. Measured on
@@ -227,9 +239,9 @@ runtime was still polling: 0/1.
 
 Two independent requirements follow, and both are needed:
 
-1. **Pace every upload.** No firmware version is exempt. Locked by
+1. **Pace every legacy RAW upload.** No compatibility upload is exempt. Locked by
    `TestFirmwareRawWritePauseIsConservativeForEveryFirmware`, `DO NOT weaken`.
-2. **Quiesce every other writer first.** A paced upload still stalls if anything
+2. **Quiesce every other writer first.** A paced legacy upload still stalls if anything
    else is holding a connection to the device. Nothing may talk to port 80 while
    firmware bytes are on port 8081 -- not health polls, not display frames.
 
@@ -313,7 +325,7 @@ unexplained transport error instead of an authentication failure.
 - Connected devices expose their current IP in `/hello` discovery, show `WiFi connected!` plus `app.vibetv.shop`, serve the local setup hub on that IP, and wait for the Mac App.
 - Connected devices expose read-only status on their current IP. Customer-facing writes are performed by the authenticated Control Center.
 - `POST /api/settings` accepts form field `b` as a brightness percentage and updates supported settings without reflashing firmware. Include `api=1` for a JSON/CORS response; omit it for the built-in IP-based form redirect. `GET /health` is the readback and support-diagnostics path.
-- Starting with firmware `1.0.39`, connected devices accept an explicit local-WiFi `POST /api/pair` without the previous token; the latest Mac wins. Other write APIs require `X-VibeTV-Token` or the native-tool/raw-OTA query fallback. Read-only diagnostics (`/hello`, `/health`, `GET /assets`) remain open.
+- Starting with firmware `1.0.39`, connected devices accept an explicit local-WiFi `POST /api/pair` without the previous token; the latest Mac wins. Other WiFi write APIs require `X-VibeTV-Token`. Read-only diagnostics (`/hello`, `/health`, `GET /assets`) remain open.
 - Firmware and filesystem uploads always require the current pairing token,
   including on fresh devices and while `VibeTV-Setup` is active. The public
   `/update` page never embeds that token or exposes a direct upload form.

--- a/firmware_esp8266/src/cable_transfer_core.h
+++ b/firmware_esp8266/src/cable_transfer_core.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace codexbar_display::esp8266::cable_transfer {
+
+struct State {
+  bool active = false;
+  size_t expectedBytes = 0;
+  size_t receivedBytes = 0;
+  int nextSequence = 0;
+  uint32_t lastChecksum = 0;
+  unsigned long lastActivityAtMs = 0;
+};
+
+enum class ChunkDecision : uint8_t {
+  kReject = 0,
+  kDuplicate = 1,
+  kAccept = 2,
+};
+
+inline void Begin(State& state, size_t expectedBytes, unsigned long nowMs) {
+  state = State{};
+  state.active = expectedBytes > 0;
+  state.expectedBytes = expectedBytes;
+  state.lastActivityAtMs = nowMs;
+}
+
+inline ChunkDecision CheckChunk(
+    const State& state,
+    int sequence,
+    size_t bytes,
+    uint32_t expectedChecksum,
+    uint32_t actualChecksum) {
+  if (!state.active) {
+    return ChunkDecision::kReject;
+  }
+  if (sequence + 1 == state.nextSequence &&
+      expectedChecksum == state.lastChecksum) {
+    return ChunkDecision::kDuplicate;
+  }
+  if (sequence != state.nextSequence || bytes == 0 ||
+      state.receivedBytes + bytes > state.expectedBytes ||
+      expectedChecksum != actualChecksum) {
+    return ChunkDecision::kReject;
+  }
+  return ChunkDecision::kAccept;
+}
+
+inline void AcceptChunk(
+    State& state,
+    size_t bytes,
+    uint32_t checksum,
+    unsigned long nowMs) {
+  state.receivedBytes += bytes;
+  state.nextSequence++;
+  state.lastChecksum = checksum;
+  state.lastActivityAtMs = nowMs;
+}
+
+inline bool CanFinish(const State& state, bool hashMatches) {
+  return state.active && state.receivedBytes == state.expectedBytes &&
+         hashMatches;
+}
+
+inline bool Expired(
+    const State& state,
+    unsigned long nowMs,
+    unsigned long timeoutMs) {
+  return state.active && nowMs - state.lastActivityAtMs > timeoutMs;
+}
+
+}  // namespace codexbar_display::esp8266::cable_transfer

--- a/firmware_esp8266/src/main.cpp
+++ b/firmware_esp8266/src/main.cpp
@@ -5,13 +5,16 @@
 #include <ESP8266WiFi.h>
 #include <WiFiUdp.h>
 #include <LittleFS.h>
+#include <MD5Builder.h>
 #include <Updater.h>
+#include <coredecls.h>
 #include <time.h>
 
 #include "../../firmware_shared/app_runtime.h"
 #include "../../firmware_shared/app_transport.h"
 #include "../../firmware_shared/theme_spec_renderer_core.h"
 #include "asset_path_policy.h"
+#include "cable_transfer_core.h"
 #include "connected_setup_policy.h"
 #include "device_settings.h"
 #include "standby_settings.h"
@@ -32,7 +35,7 @@
 #endif
 
 #if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
-const char kThemeFeatureJSON[] = "[\"theme-spec-v1\",\"provider-slots-v1\"]";
+const char kThemeFeatureJSON[] = "[\"theme-spec-v1\",\"provider-slots-v1\",\"cable-transfer-v1\"]";
 #else
 const char kThemeFeatureJSON[] = "[]";
 #endif
@@ -42,7 +45,6 @@ namespace {
 codexbar_display::app::RuntimeContext runtimeCtx;
 codexbar_display::esp8266::RendererESP8266 renderer;
 ESP8266WebServer webServer(80);
-WiFiServer rawOtaServer(8081);
 DNSServer dnsServer;
 
 constexpr int kMaxFrameBytes = 2048;
@@ -73,8 +75,8 @@ constexpr unsigned long kFrameStaleWarningMs = 150000UL;
 // interval, not a retry loop.
 constexpr unsigned long kDeviceClockPollMs = 2000UL;
 constexpr unsigned long kFirmwareUpdateNoticeToggleMs = 1500UL;
-constexpr unsigned long kRawOtaProgressTimeoutMs = 30000UL;
-constexpr size_t kRawOtaReadBufferBytes = 512;
+constexpr unsigned long kCableTransferTimeoutMs = 15000UL;
+constexpr size_t kCableTransferChunkBytes = 128;
 constexpr size_t kMaxStoredThemeSpecBytes = 4096;
 constexpr size_t kMaxThemeGifAssetBytes = codexbar_display::themespec::kMaxThemeSpecGifAssetBytes;
 constexpr uint8_t kDefaultBrightnessPercent =
@@ -183,6 +185,26 @@ struct DeviceSettings {
       codexbar_display::esp8266::device_settings::ConnectionMode::kUnspecified;
 };
 
+enum class CableTransferSink : uint8_t {
+  kNone = 0,
+  kAsset = 1,
+  kFirmware = 2,
+};
+
+enum class CableTransferActivation : uint8_t {
+  kNone = 0,
+  kTheme = 1,
+  kScreensaver = 2,
+};
+
+struct CableTransferState {
+  codexbar_display::esp8266::cable_transfer::State flow;
+  CableTransferSink sink = CableTransferSink::kNone;
+  CableTransferActivation activation = CableTransferActivation::kNone;
+  MD5Builder hash;
+  uint8_t expectedHash[16] = {};
+};
+
 namespace deviceclock = codexbar_display::deviceclock;
 
 unsigned long nextDeviceClockPollAtMs = 0;
@@ -190,7 +212,6 @@ char renderedClockTime[deviceclock::kTimeTextSize] = {};
 char renderedClockDate[deviceclock::kDateTextSize] = {};
 
 bool httpServerStarted = false;
-bool rawOtaServerStarted = false;
 bool setupMode = false;
 bool waitStatusRendered = false;
 String lastConnectedSetupIp;
@@ -245,10 +266,13 @@ String deviceID;
 String bootID;
 String bootResetReasonJSON;
 uint32_t bootResetCounter = 0;
+CableTransferState cableTransfer;
 
 void addCorsHeaders();
 void resetWifiReconnectState();
 void startHttpServer();
+bool handleCableTransferRequest(JsonDocument& doc, const char* op);
+void maintainCableTransfer();
 
 #if CODEXBAR_DISPLAY_THEME_SPEC_RENDERER
 constexpr const char* kLegacyMiniThemeSpecPath = "/themes/u/mini-cl-1-410a37.json";
@@ -1426,26 +1450,6 @@ String htmlEscape(const String& raw) {
   return codexbar_display::esp8266::wifi_setup::HtmlEscape(raw);
 }
 
-String macInstallerCommand() {
-  return F("curl -fsSL https://github.com/DreamyTalesPAN/CodexBar-Display/releases/latest/download/install.sh | bash");
-}
-
-String updateTargetURL() {
-  return String("http://") + WiFi.localIP().toString();
-}
-
-String updateInstallCommand() {
-  const String target = updateTargetURL();
-  String command;
-  command.reserve(260);
-  command += macInstallerCommand();
-  command += F(" -s -- --target ");
-  command += target;
-  command += F(" && codexbar-display install-update --confirm-live-update --target ");
-  command += target;
-  return command;
-}
-
 String updateStatusHTML(bool compact) {
   String html;
   html.reserve(700);
@@ -1986,6 +1990,9 @@ bool handleSerialControlLine(const String& line) {
   }
 
   const char* op = doc["op"] | "";
+  if (strncmp(op, "transfer-", 9) == 0) {
+    return handleCableTransferRequest(doc, op);
+  }
   if (strcmp(op, "hello") == 0) {
     codexbar_display::app::EmitDeviceHello(makeTransportConfig("usb"));
   } else if (strcmp(op, "status") == 0) {
@@ -2104,6 +2111,10 @@ void handleSerialInput() {
     return;
   }
   if (handleSerialControlLine(line)) {
+    return;
+  }
+  if (cableTransfer.flow.active) {
+    emitSerialError("transfer-active");
     return;
   }
   if (!codexbar_display::esp8266::device_settings::SupportsCable(
@@ -3309,26 +3320,12 @@ void maintainStandby() {
 }
 
 
-String updatePageHTML() {
-  const String installCommand = updateInstallCommand();
-  String html;
-  html.reserve(1600);
-  html += F("<!doctype html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'>");
-  html += F("<title>VibeTV Update</title><style>");
-  html += F(":root{color-scheme:dark}body{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;margin:0;background:#0b0c0d;color:#f6f4ed}main{max-width:620px;margin:auto;padding:24px 18px}a{color:#c7ff00;font-weight:800}h1{margin:16px 0}.muted{color:#a9adb3}.update,button,pre{border-radius:8px}.update{border:1px solid #6f8f00;padding:10px}.update-link{display:none}button{width:100%;font:inherit;padding:12px;margin-top:10px;background:#c7ff00;color:#111;border:0;font-weight:900}pre{white-space:pre-wrap;word-break:break-word;background:#08090a;border:1px solid #30343a;padding:12px}</style></head><body><main>");
-  html += F("<h1>VibeTV Update</h1>");
-  html += updateStatusHTML(false);
-  html += F("<h2>Check with Mac</h2><p class='muted'>Copy this command into Terminal. It refreshes the Mac helper first, then installs firmware if needed.</p><pre id='cmd'>");
-  html += htmlEscape(installCommand);
-  html += F("</pre><textarea id='cmdFallback' readonly style='position:absolute;left:-9999px'></textarea><button type='button' onclick='copyCmd()' id='copyBtn'>Copy update command</button>");
-  html += F("<p class='muted'><a href='/'>Setup</a> | <a href='/health'>Status</a> | <a href='/assets'>Files</a></p>");
-  html += F("<script>function copied(){document.getElementById('copyBtn').textContent='Copied';}function fallbackCopy(t){var a=document.getElementById('cmdFallback');a.value=t;a.focus();a.select();try{document.execCommand('copy');copied();}catch(e){window.prompt('Copy this command',t);}}function copyCmd(){var t=document.getElementById('cmd').textContent.trim();if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(t).then(copied,function(){fallbackCopy(t);});}else{fallbackCopy(t);}}</script></main></body></html>");
-  return html;
-}
-
 void handleUpdatePage() {
   webServer.keepAlive(false);
-  webServer.send(200, "text/html; charset=utf-8", updatePageHTML());
+  webServer.send(
+      200,
+      "text/html; charset=utf-8",
+      F("<!doctype html><meta name='viewport' content='width=device-width,initial-scale=1'><title>VibeTV Update</title><h1>VibeTV Update</h1><p>Open the VibeTV App on your Mac to check and install updates.</p><p><a href='/'>Back</a></p>"));
 }
 
 void setOtaError(const String& message) {
@@ -3470,181 +3467,352 @@ void handleOtaResult(const char* target) {
   otaUploadNeedsReboot = false;
 }
 
-void sendRawOtaResponse(WiFiClient& client, int status, const char* statusText, const String& body) {
-  client.print("HTTP/1.1 ");
-  client.print(status);
-  client.print(" ");
-  client.print(statusText);
-  client.print("\r\nConnection: close\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: ");
-  client.print(body.length());
-  client.print("\r\n\r\n");
-  client.print(body);
+int hexNibble(char value) {
+  if (value >= '0' && value <= '9') {
+    return value - '0';
+  }
+  if (value >= 'a' && value <= 'f') {
+    return value - 'a' + 10;
+  }
+  if (value >= 'A' && value <= 'F') {
+    return value - 'A' + 10;
+  }
+  return -1;
 }
 
-bool rawRequestLineIsFirmwarePost(const String& line) {
-  return line.startsWith("POST /update/firmware.raw ") ||
-         line.startsWith("POST /update/firmware.raw?") ||
-         line.startsWith("PUT /update/firmware.raw ") ||
-         line.startsWith("PUT /update/firmware.raw?");
+bool decodeTransferHash(const char* encoded, uint8_t* out) {
+  constexpr size_t kHashBytes = 16;
+  if (encoded == nullptr || out == nullptr || strlen(encoded) != kHashBytes * 2) {
+    return false;
+  }
+  for (size_t i = 0; i < kHashBytes; ++i) {
+    const int high = hexNibble(encoded[i * 2]);
+    const int low = hexNibble(encoded[i * 2 + 1]);
+    if (high < 0 || low < 0) {
+      return false;
+    }
+    out[i] = static_cast<uint8_t>((high << 4) | low);
+  }
+  return true;
 }
 
-String rawRequestToken(const String& line) {
-  const int queryStart = line.indexOf("?token=");
-  if (queryStart < 0) {
-    return "";
-  }
-  int tokenStart = queryStart + 7;
-  int tokenEnd = line.indexOf(' ', tokenStart);
-  const int nextParam = line.indexOf('&', tokenStart);
-  if (nextParam >= 0 && (tokenEnd < 0 || nextParam < tokenEnd)) {
-    tokenEnd = nextParam;
-  }
-  if (tokenEnd < 0) {
-    tokenEnd = line.length();
-  }
-  String token = line.substring(tokenStart, tokenEnd);
-  token.trim();
-  return token;
+uint32_t chunkChecksum(const uint8_t* data, size_t length) {
+  MD5Builder context;
+  uint8_t digest[16];
+  context.begin();
+  context.add(data, static_cast<uint16_t>(length));
+  context.calculate();
+  context.getBytes(digest);
+  return (static_cast<uint32_t>(digest[0]) << 24) |
+         (static_cast<uint32_t>(digest[1]) << 16) |
+         (static_cast<uint32_t>(digest[2]) << 8) |
+         static_cast<uint32_t>(digest[3]);
 }
 
-void handleRawOtaClient() {
-  if (!rawOtaServerStarted || otaUploadInProgress || assetUploadInProgress || rebootPending) {
+bool parseChunkChecksum(const char* encoded, uint32_t& checksum) {
+  if (encoded == nullptr || strlen(encoded) != 8) {
+    return false;
+  }
+  checksum = 0;
+  for (size_t i = 0; i < 8; ++i) {
+    const int nibble = hexNibble(encoded[i]);
+    if (nibble < 0) {
+      return false;
+    }
+    checksum = (checksum << 4) | static_cast<uint32_t>(nibble);
+  }
+  return true;
+}
+
+void emitCableTransferReply(const char* status) {
+  String out = "{\"kind\":\"transfer\",\"status\":\"";
+	out += status;
+	out += "\",\"next\":";
+	out += String(cableTransfer.flow.nextSequence);
+  out += "}";
+  Serial.println(out);
+}
+
+void resetCableTransfer(bool discard) {
+	if (!cableTransfer.flow.active) {
     return;
   }
-
-  WiFiClient client = rawOtaServer.accept();
-  if (!client) {
-    return;
-  }
-  client.setTimeout(5000);
-
-  String requestLine = client.readStringUntil('\n');
-  requestLine.trim();
-  if (!rawRequestLineIsFirmwarePost(requestLine)) {
-    sendRawOtaResponse(client, 404, "Not Found", "not found");
-    client.stop();
-    return;
-  }
-
-  String rawToken = rawRequestToken(requestLine);
-  size_t contentLength = 0;
-  while (client.connected()) {
-    String header = client.readStringUntil('\n');
-    header.trim();
-    if (header.length() == 0) {
-      break;
+  if (cableTransfer.sink == CableTransferSink::kAsset) {
+    if (assetUploadFile) {
+      assetUploadFile.close();
     }
-    String lower = header;
-    lower.toLowerCase();
-    if (lower.startsWith("content-length:")) {
-      String value = header.substring(header.indexOf(':') + 1);
-      value.trim();
-      contentLength = static_cast<size_t>(value.toInt());
-    } else if (lower.startsWith("x-vibetv-token:")) {
-      rawToken = header.substring(header.indexOf(':') + 1);
-      rawToken.trim();
+    if (discard) {
+      discardPartialAssetUpload();
     }
-  }
-
-  if (!codexbar_display::esp8266::WifiSecurityPolicy::AllowsFirmwareUpload(
-          deviceAuthConfigured(),
-          rawToken == deviceAuthToken)) {
-    sendRawOtaResponse(client, 401, "Unauthorized", "pairing token required");
-    client.stop();
-    return;
-  }
-
-  if (contentLength == 0) {
-    sendRawOtaResponse(client, 411, "Length Required", "content-length required");
-    client.stop();
-    return;
-  }
-
-  const size_t maxSize = otaMaxSizeForCommand(U_FLASH);
-  if (contentLength > maxSize) {
-    sendRawOtaResponse(client, 413, "Payload Too Large", "firmware image is too large");
-    client.stop();
-    return;
-  }
-
-  otaUploadSucceeded = false;
-  otaUploadInProgress = true;
-  otaUploadNeedsReboot = false;
-  otaUploadError = "";
-
-  enterOtaSafeMode(U_FLASH, &client);
-  otaUploadNeedsReboot = true;
-  drawUpdateStatus("Loading firmware");
-  waitStatusRendered = true;
-
-  if (!Update.begin(contentLength, U_FLASH)) {
-    setOtaError(Update.getErrorString());
-    resetOtaUpdaterAfterFailure();
-  }
-
-  uint8_t buffer[kRawOtaReadBufferBytes];
-  size_t remaining = contentLength;
-  unsigned long lastProgressMs = millis();
-  while (remaining > 0 && otaUploadError.length() == 0) {
-    const int available = client.available();
-    if (available <= 0) {
-      if (!client.connected()) {
-        setOtaError("raw upload disconnected");
-        resetOtaUpdaterAfterFailure();
-        break;
-      }
-      if (millis() - lastProgressMs > kRawOtaProgressTimeoutMs) {
-        setOtaError("raw upload timeout");
-        resetOtaUpdaterAfterFailure();
-        break;
-      }
-      delay(1);
-      continue;
-    }
-    size_t want = static_cast<size_t>(available);
-    if (want > remaining) {
-      want = remaining;
-    }
-    if (want > sizeof(buffer)) {
-      want = sizeof(buffer);
-    }
-    const int readCount = client.read(buffer, want);
-    if (readCount <= 0) {
-      delay(1);
-      continue;
-    }
-    const size_t got = static_cast<size_t>(readCount);
-    lastProgressMs = millis();
-    remaining -= got;
-    if (Update.write(buffer, got) != got) {
-      setOtaError(Update.getErrorString());
+    finishAssetUploadRequest();
+    assetUploadSucceeded = false;
+  } else if (cableTransfer.sink == CableTransferSink::kFirmware) {
+    if (discard) {
       resetOtaUpdaterAfterFailure();
-      break;
     }
-    ESP.wdtFeed();
-    delay(0);
+    otaUploadInProgress = false;
+    otaUploadNeedsReboot = false;
+    otaUploadSucceeded = false;
+  }
+  cableTransfer = CableTransferState{};
+}
+
+bool startCableTransfer(JsonDocument& doc) {
+  const char* expectedDeviceID = doc["deviceId"] | "";
+  const char* token = doc["token"] | "";
+  const char* sink = doc["sink"] | "";
+  const char* activation = doc["activate"] | "";
+  const char* expectedHash = doc["hash"] | "";
+	const int expectedBytesValue = doc["bytes"] | 0;
+	const size_t expectedBytes = expectedBytesValue > 0
+	    ? static_cast<size_t>(expectedBytesValue)
+	    : 0;
+  String destination = String(doc["path"] | "");
+  destination.trim();
+	if (cableTransfer.flow.active || otaUploadInProgress || assetUploadInProgress ||
+      rebootPending || strcmp(expectedDeviceID, deviceID.c_str()) != 0 ||
+      !deviceAuthConfigured() || strcmp(token, deviceAuthToken.c_str()) != 0 ||
+      expectedBytes == 0) {
+    emitSerialError("transfer-rejected");
+    return true;
   }
 
-  if (otaUploadError.length() == 0 && remaining == 0 && Update.end(false)) {
-    otaUploadSucceeded = true;
-    sendRawOtaResponse(client, 200, "OK", "ok");
-    drawUpdateStatus("Restarting");
-    waitStatusRendered = true;
-    scheduleReboot("firmware_raw");
-    otaUploadNeedsReboot = false;
+  CableTransferSink target = CableTransferSink::kNone;
+  CableTransferActivation targetActivation = CableTransferActivation::kNone;
+  if (strcmp(sink, "asset") == 0 && isMutableThemeAssetPath(destination)) {
+    target = CableTransferSink::kAsset;
+    if (activation[0] == '\0') {
+      targetActivation = CableTransferActivation::kNone;
+    } else if (strcmp(activation, "theme") == 0) {
+      targetActivation = CableTransferActivation::kTheme;
+    } else if (strcmp(activation, "screensaver") == 0) {
+      targetActivation = CableTransferActivation::kScreensaver;
+    } else {
+      target = CableTransferSink::kNone;
+    }
+  } else if (strcmp(sink, "firmware") == 0 &&
+             activation[0] == '\0' &&
+             expectedBytes <= otaMaxSizeForCommand(U_FLASH)) {
+    target = CableTransferSink::kFirmware;
+  }
+  uint8_t expectedDigest[16];
+  if (target == CableTransferSink::kNone ||
+      !decodeTransferHash(expectedHash, expectedDigest)) {
+    emitSerialError("transfer-rejected");
+    return true;
+  }
+
+  codexbar_display::esp8266::cable_transfer::Begin(
+      cableTransfer.flow, expectedBytes, millis());
+  cableTransfer.sink = target;
+  cableTransfer.activation = targetActivation;
+  memcpy(cableTransfer.expectedHash, expectedDigest, sizeof(expectedDigest));
+  cableTransfer.hash.begin();
+
+  if (target == CableTransferSink::kAsset) {
+    assetUploadSucceeded = false;
+    assetUploadInProgress = true;
+    assetUploadError = "";
+    assetUploadPath = destination;
+    assetUploadBytesSeen = 0;
+    enterAssetUploadSafeMode();
+    if ((assetPathLooksGif(assetUploadPath) &&
+         expectedBytes > kMaxThemeGifAssetBytes) ||
+        !LittleFS.begin() ||
+        !ensureAssetParentDirs(assetUploadPath) ||
+        (LittleFS.exists(kAssetUploadTemporaryPath) &&
+         !LittleFS.remove(kAssetUploadTemporaryPath))) {
+      resetCableTransfer(true);
+      emitSerialError("transfer-rejected");
+      return true;
+    }
+    assetUploadFile = LittleFS.open(kAssetUploadTemporaryPath, "w");
+    if (!assetUploadFile) {
+      resetCableTransfer(true);
+      emitSerialError("transfer-rejected");
+      return true;
+    }
   } else {
-    if (otaUploadError.length() == 0) {
-      setOtaError(Update.getErrorString());
-      resetOtaUpdaterAfterFailure();
+    otaUploadSucceeded = false;
+    otaUploadInProgress = true;
+    otaUploadNeedsReboot = true;
+    otaUploadError = "";
+    enterOtaSafeMode(U_FLASH, nullptr);
+    drawUpdateStatus("Loading firmware");
+    waitStatusRendered = true;
+    if (!Update.begin(expectedBytes, U_FLASH)) {
+      resetCableTransfer(true);
+      emitSerialError("transfer-rejected");
+      return true;
     }
-    sendRawOtaResponse(client, 500, "Internal Server Error", "Update failed: " + otaUploadError);
-    if (otaUploadNeedsReboot) {
-      scheduleReboot("firmware_raw_failure");
-    }
-    otaUploadNeedsReboot = false;
   }
-  otaUploadInProgress = false;
-  client.stop();
+  emitCableTransferReply("ready");
+  return true;
+}
+
+bool writeCableTransferChunk(JsonDocument& doc) {
+  const int sequence = doc["seq"] | -1;
+  const char* encoded = doc["data"] | "";
+  const char* encodedChecksum = doc["checksum"] | "";
+  uint32_t expectedChecksum = 0;
+  if (!cableTransfer.flow.active ||
+      !parseChunkChecksum(encodedChecksum, expectedChecksum)) {
+    emitSerialError("transfer-rejected");
+    return true;
+  }
+  const size_t encodedBytes = strlen(encoded);
+  if (encodedBytes == 0 || encodedBytes > kCableTransferChunkBytes * 2 ||
+      encodedBytes % 2 != 0) {
+    emitSerialError("transfer-rejected");
+    return true;
+  }
+
+  uint8_t decoded[kCableTransferChunkBytes];
+  const size_t decodedBytes = encodedBytes / 2;
+  for (size_t i = 0; i < decodedBytes; ++i) {
+    const int high = hexNibble(encoded[i * 2]);
+    const int low = hexNibble(encoded[i * 2 + 1]);
+    if (high < 0 || low < 0) {
+      emitSerialError("transfer-rejected");
+      return true;
+    }
+    decoded[i] = static_cast<uint8_t>((high << 4) | low);
+  }
+  const auto decision = codexbar_display::esp8266::cable_transfer::CheckChunk(
+      cableTransfer.flow,
+      sequence,
+      decodedBytes,
+      expectedChecksum,
+      chunkChecksum(decoded, decodedBytes));
+  if (decision == codexbar_display::esp8266::cable_transfer::ChunkDecision::kDuplicate) {
+    emitCableTransferReply("chunk");
+    return true;
+  }
+  if (decision != codexbar_display::esp8266::cable_transfer::ChunkDecision::kAccept) {
+    emitSerialError("transfer-rejected");
+    return true;
+  }
+
+  const size_t bytes = decodedBytes;
+  bool wrote = false;
+  if (cableTransfer.sink == CableTransferSink::kAsset) {
+    wrote = assetUploadFile && assetUploadFile.write(decoded, bytes) == bytes;
+    assetUploadBytesSeen += wrote ? bytes : 0;
+  } else if (cableTransfer.sink == CableTransferSink::kFirmware) {
+    wrote = Update.write(decoded, bytes) == bytes;
+  }
+  if (!wrote) {
+    resetCableTransfer(true);
+    emitSerialError("transfer-rejected");
+    return true;
+  }
+
+  cableTransfer.hash.add(decoded, static_cast<uint16_t>(bytes));
+  codexbar_display::esp8266::cable_transfer::AcceptChunk(
+      cableTransfer.flow, bytes, expectedChecksum, millis());
+  ESP.wdtFeed();
+  emitCableTransferReply("chunk");
+  return true;
+}
+
+bool finishCableTransfer(JsonDocument& doc) {
+  if (!cableTransfer.flow.active) {
+    emitSerialError("transfer-rejected");
+    return true;
+  }
+  uint8_t actualDigest[16];
+  cableTransfer.hash.calculate();
+  cableTransfer.hash.getBytes(actualDigest);
+  if (!codexbar_display::esp8266::cable_transfer::CanFinish(
+          cableTransfer.flow,
+          memcmp(actualDigest, cableTransfer.expectedHash, sizeof(actualDigest)) == 0)) {
+    resetCableTransfer(true);
+    emitSerialError("transfer-rejected");
+    return true;
+  }
+
+  bool committed = false;
+  if (cableTransfer.sink == CableTransferSink::kAsset) {
+    assetUploadFile.flush();
+    assetUploadFile.close();
+    committed = validateCompletedAssetUpload() && promoteCompletedAssetUpload();
+    if (committed && cableTransfer.activation == CableTransferActivation::kTheme) {
+      String themeID;
+      String error;
+      int themeRevision = 0;
+      committed = activateStoredThemePath(
+          assetUploadPath, true, themeID, themeRevision, error);
+      if (committed) {
+        screensaver_preview::Cancel(screensaverPreviewState);
+        screensaverPreviewLivePath = "";
+        standbyLiveThemePath = "";
+        standbyState.active = false;
+        standby::NoteUsageActivity(standbyState, millis());
+        applyDeviceSettings();
+      }
+    } else if (committed &&
+               cableTransfer.activation == CableTransferActivation::kScreensaver) {
+      DeviceSettings next = deviceSettings;
+      String error;
+      committed = setStandbyScreensaverPath(next.standby, assetUploadPath, error) &&
+                  persistDeviceSettings(next);
+      if (committed) {
+        screensaver_preview::NoteSelection(screensaverPreviewState);
+      }
+    }
+    assetUploadSucceeded = committed;
+  } else if (cableTransfer.sink == CableTransferSink::kFirmware) {
+    committed = Update.end(false);
+    otaUploadSucceeded = committed;
+  }
+  if (!committed) {
+    resetCableTransfer(true);
+    emitSerialError("transfer-rejected");
+    return true;
+  }
+
+  const CableTransferSink completedSink = cableTransfer.sink;
+  emitCableTransferReply("complete");
+  if (completedSink == CableTransferSink::kAsset) {
+    finishAssetUploadRequest();
+  } else {
+    otaUploadInProgress = false;
+    otaUploadNeedsReboot = false;
+    scheduleReboot("firmware_cable");
+  }
+  cableTransfer = CableTransferState{};
+  return true;
+}
+
+bool handleCableTransferRequest(JsonDocument& doc, const char* op) {
+  if (strcmp(op, "transfer-start") == 0) {
+    return startCableTransfer(doc);
+  }
+  if (strcmp(op, "transfer-chunk") == 0) {
+    return writeCableTransferChunk(doc);
+  }
+  if (strcmp(op, "transfer-finish") == 0) {
+    return finishCableTransfer(doc);
+  }
+  if (strcmp(op, "transfer-abort") == 0) {
+    if (cableTransfer.flow.active) {
+      resetCableTransfer(true);
+      emitCableTransferReply("aborted");
+      cableTransfer = CableTransferState{};
+    } else {
+      emitSerialError("transfer-rejected");
+    }
+    return true;
+  }
+  emitSerialError("unsupported-request");
+  return true;
+}
+
+void maintainCableTransfer() {
+  if (codexbar_display::esp8266::cable_transfer::Expired(
+          cableTransfer.flow, millis(), kCableTransferTimeoutMs)) {
+    resetCableTransfer(true);
+  }
 }
 
 void handleFrame() {
@@ -3757,11 +3925,7 @@ void startHttpServer() {
   webServer.collectHeaders(kDeviceAuthHeader);
   webServer.begin();
   httpServerStarted = true;
-  rawOtaServer.begin();
-  rawOtaServer.setNoDelay(true);
-  rawOtaServerStarted = true;
   Serial.println("http_server_started port=80");
-  Serial.println("raw_ota_server_started port=8081 path=/update/firmware.raw");
 }
 
 void startSetupAccessPoint() {
@@ -4005,11 +4169,11 @@ void loop() {
   }
 
   handleSerialInput();
+  maintainCableTransfer();
 
   if (httpServerStarted) {
     webServer.handleClient();
   }
-  handleRawOtaClient();
   maintainConnectionTransition();
   maintainWifiConnection();
   if (!otaUploadInProgress && !assetUploadInProgress) {

--- a/firmware_esp8266/tests/cable_transfer_core_test.cpp
+++ b/firmware_esp8266/tests/cable_transfer_core_test.cpp
@@ -1,0 +1,52 @@
+#include <cstdio>
+#include <cstdlib>
+
+#include "../src/cable_transfer_core.h"
+
+namespace transfer = codexbar_display::esp8266::cable_transfer;
+
+void require(bool condition, const char* message) {
+  if (!condition) {
+    std::fprintf(stderr, "FAIL: %s\n", message);
+    std::exit(1);
+  }
+}
+
+int main() {
+  transfer::State state;
+  transfer::Begin(state, 8, 100);
+
+  int sinkWrites = 0;
+  const auto corrupted = transfer::CheckChunk(state, 0, 4, 0x11111111, 0x22222222);
+  if (corrupted == transfer::ChunkDecision::kAccept) {
+    sinkWrites++;
+  }
+  require(corrupted == transfer::ChunkDecision::kReject, "bad checksum must be rejected");
+  require(sinkWrites == 0 && state.receivedBytes == 0, "bad checksum must write zero bytes");
+
+  const auto first = transfer::CheckChunk(state, 0, 4, 0x11111111, 0x11111111);
+  require(first == transfer::ChunkDecision::kAccept, "valid first chunk must be accepted");
+  sinkWrites++;
+  transfer::AcceptChunk(state, 4, 0x11111111, 110);
+  require(!transfer::CanFinish(state, true), "truncated transfer must not commit");
+
+  const auto duplicate = transfer::CheckChunk(state, 0, 4, 0x11111111, 0x11111111);
+  require(duplicate == transfer::ChunkDecision::kDuplicate, "last acknowledged chunk must be idempotent");
+  require(sinkWrites == 1, "duplicate chunk must not write twice");
+
+  const auto second = transfer::CheckChunk(state, 1, 4, 0x33333333, 0x33333333);
+  require(second == transfer::ChunkDecision::kAccept, "valid final chunk must be accepted");
+  sinkWrites++;
+  transfer::AcceptChunk(state, 4, 0x33333333, 120);
+  require(!transfer::CanFinish(state, false), "whole-payload hash mismatch must not commit");
+  require(transfer::CanFinish(state, true), "complete matching payload must commit");
+  require(!transfer::Expired(state, 15119, 15000), "active transfer must stay alive through timeout boundary");
+  require(transfer::Expired(state, 15121, 15000), "expired transfer must abort its sink");
+
+  transfer::State idle;
+  require(!transfer::CanFinish(idle, true), "aborted transfer must keep old sink active");
+  require(!transfer::Expired(idle, 99999, 1), "idle transfer must not abort again");
+
+  std::printf("ok: cable_transfer_core_test\n");
+  return 0;
+}

--- a/firmware_esp8266/tests/frame_render_policy_test.cpp
+++ b/firmware_esp8266/tests/frame_render_policy_test.cpp
@@ -216,7 +216,7 @@ bool testAssetDeleteProtectsStandbyLiveTheme(const std::string& source) {
 
 bool testStandbyExitLeavesErrorFrameVisible(const std::string& source) {
   const std::size_t standbyStart = source.find("void maintainStandby()");
-  const std::size_t standbyEnd = source.find("\nString updatePageHTML()", standbyStart);
+  const std::size_t standbyEnd = source.find("\nvoid handleUpdatePage()", standbyStart);
   if (!expect(
           standbyStart != std::string::npos && standbyEnd != std::string::npos,
           "standby state machine must remain discoverable")) {
@@ -237,7 +237,7 @@ bool testStandbyExitLeavesErrorFrameVisible(const std::string& source) {
 
 bool testUsageWakeRestoresLiveThemeBeforeDroppingPath(const std::string& source) {
   const std::size_t standbyStart = source.find("void maintainStandby()");
-  const std::size_t standbyEnd = source.find("\nString updatePageHTML()", standbyStart);
+  const std::size_t standbyEnd = source.find("\nvoid handleUpdatePage()", standbyStart);
   if (!expect(
           standbyStart != std::string::npos && standbyEnd != std::string::npos,
           "standby state machine must remain discoverable")) {

--- a/firmware_esp8266/tests/gif_core_policy_test.cpp
+++ b/firmware_esp8266/tests/gif_core_policy_test.cpp
@@ -316,13 +316,31 @@ bool testNetworkWorkPrecedesWifiRecovery(const char* mainPath) {
   }
   const std::string loop = mainSource.substr(loopStart);
   const std::size_t http = loop.find("webServer.handleClient();");
-  const std::size_t rawOta = loop.find("handleRawOtaClient();");
   const std::size_t recovery = loop.find("maintainWifiConnection();");
   return expect(
-      http != std::string::npos && rawOta != std::string::npos && recovery != std::string::npos &&
-          http < recovery && rawOta < recovery && countOccurrences(loop, "webServer.handleClient();") == 1 &&
-          countOccurrences(loop, "handleRawOtaClient();") == 1,
-      "setup HTTP and raw OTA work must run once before WiFi recovery decides busy state");
+      http != std::string::npos && recovery != std::string::npos &&
+          http < recovery && countOccurrences(loop, "webServer.handleClient();") == 1 &&
+          loop.find("handleRawOtaClient();") == std::string::npos,
+      "setup HTTP work must run once before WiFi recovery and duplicate raw OTA must stay removed");
+}
+
+bool testCableTransferOwnsSerialParserUntilCompletion(const char* mainPath) {
+  const std::string mainSource = readFile(mainPath);
+  const std::size_t start = mainSource.find("void handleSerialInput()");
+  const std::size_t end = mainSource.find("bool isSafeAssetPath", start);
+  if (!expect(
+          start != std::string::npos && end != std::string::npos,
+          "serial input handler must remain discoverable")) {
+    return false;
+  }
+  const std::string body = mainSource.substr(start, end - start);
+  const std::size_t control = body.find("handleSerialControlLine(line)");
+  const std::size_t active = body.find("cableTransfer.flow.active");
+  const std::size_t frame = body.find("ConsumeFrameLine(");
+  return expect(
+      control != std::string::npos && active != std::string::npos &&
+          frame != std::string::npos && control < active && active < frame,
+      "transfer control must be consumed before normal frames and an active transfer must block the frame parser");
 }
 
 bool testWifiRecoveryFirmwareWiring(const char* mainPath) {
@@ -372,20 +390,20 @@ bool testWifiRecoveryFirmwareWiring(const char* mainPath) {
 
 bool testUploadMutualExclusionPolicy(const char* mainPath) {
   const std::string mainSource = readFile(mainPath);
-  const std::size_t rawStart = mainSource.find("void handleRawOtaClient()");
-  const std::size_t rawAccept = mainSource.find("WiFiClient client = rawOtaServer.accept();", rawStart);
+  const std::size_t cableStart = mainSource.find("bool startCableTransfer(");
+  const std::size_t cableEnd = mainSource.find("bool writeCableTransferChunk(", cableStart);
   const std::size_t assetStart = mainSource.find("void handleAssetUpload()");
   const std::size_t assetEnd = mainSource.find("void handleAssetUploadResult()", assetStart);
   const std::size_t otaStart = mainSource.find("void handleOtaUpload(int command, const char* target)");
   const std::size_t otaEnd = mainSource.find("void scheduleReboot(", otaStart);
   if (!expect(
-          rawStart != std::string::npos && rawAccept != std::string::npos && assetStart != std::string::npos &&
+          cableStart != std::string::npos && cableEnd != std::string::npos && assetStart != std::string::npos &&
               assetEnd != std::string::npos && otaStart != std::string::npos && otaEnd != std::string::npos,
           "all upload handlers must remain discoverable")) {
     return false;
   }
 
-  const std::string rawGuard = mainSource.substr(rawStart, rawAccept - rawStart);
+  const std::string cableHandler = mainSource.substr(cableStart, cableEnd - cableStart);
   const std::string assetHandler = mainSource.substr(assetStart, assetEnd - assetStart);
   const std::string otaHandler = mainSource.substr(otaStart, otaEnd - otaStart);
   const std::size_t assetStartEvent = assetHandler.find("if (upload.status == UPLOAD_FILE_START)");
@@ -397,13 +415,13 @@ bool testUploadMutualExclusionPolicy(const char* mainPath) {
       otaHandler.find("if (assetUploadInProgress || otaUploadInProgress || rebootPending)", otaStartEvent);
   const std::size_t otaSafeMode = otaHandler.find("enterOtaSafeMode(", otaStartEvent);
   return expect(
-      rawGuard.find("assetUploadInProgress") != std::string::npos &&
-          rawGuard.find("otaUploadInProgress") != std::string::npos &&
-          rawGuard.find("rebootPending") != std::string::npos && assetStartEvent != std::string::npos &&
+      cableHandler.find("assetUploadInProgress") != std::string::npos &&
+          cableHandler.find("otaUploadInProgress") != std::string::npos &&
+          cableHandler.find("rebootPending") != std::string::npos && assetStartEvent != std::string::npos &&
           assetBusy != std::string::npos && assetSafeMode != std::string::npos && assetBusy < assetSafeMode &&
           otaStartEvent != std::string::npos && otaBusy != std::string::npos && otaSafeMode != std::string::npos &&
           otaBusy < otaSafeMode,
-      "raw OTA and HTTP asset/filesystem/firmware uploads must exclude each other before safe mode");
+      "Cable and HTTP asset/filesystem/firmware uploads must exclude each other before safe mode");
 }
 
 bool testCaptiveFirstResponseNeverBlocksOnWifiScan(const char* mainPath) {
@@ -514,33 +532,34 @@ bool testWifiSavePreservesDeviceStateAndRetiresStaleSdkCredentials(const char* m
 
 bool testRegisteredOtaEndpointsMatchAuthenticatedPolicy(const char* mainPath) {
   const std::string mainSource = readFile(mainPath);
-  const std::size_t pageStart = mainSource.find("String updatePageHTML()");
-  const std::size_t pageEnd = mainSource.find("void handleUpdatePage()", pageStart);
+  const std::size_t pageStart = mainSource.find("void handleUpdatePage()");
+  const std::size_t pageEnd = mainSource.find("void setOtaError(", pageStart);
   const std::size_t multipart = mainSource.find("void handleOtaUpload(");
   const std::size_t multipartEnd = mainSource.find("void scheduleReboot(", multipart);
   const std::size_t multipartAuth = mainSource.find("requestHasValidOtaAuth()", multipart);
   const std::size_t multipartBegin = mainSource.find("Update.begin(", multipart);
-  const std::size_t raw = mainSource.find("void handleRawOtaClient()");
-  const std::size_t rawEnd = mainSource.find("void handleFrame()", raw);
-  const std::size_t rawAuth = mainSource.find("WifiSecurityPolicy::AllowsFirmwareUpload", raw);
-  const std::size_t rawBegin = mainSource.find("Update.begin(", raw);
+  const std::size_t cable = mainSource.find("bool startCableTransfer(");
+  const std::size_t cableEnd = mainSource.find("bool writeCableTransferChunk(", cable);
+  const std::size_t cableAuth = mainSource.find("deviceAuthConfigured()", cable);
+  const std::size_t cableBegin = mainSource.find("Update.begin(", cable);
   const std::size_t server = mainSource.find("void startHttpServer()");
   if (pageStart == std::string::npos || pageEnd == std::string::npos ||
       multipart == std::string::npos || multipartEnd == std::string::npos ||
-      raw == std::string::npos || rawEnd == std::string::npos || server == std::string::npos) {
+      cable == std::string::npos || cableEnd == std::string::npos || server == std::string::npos) {
     return false;
   }
   const std::string page = mainSource.substr(pageStart, pageEnd - pageStart);
   const std::string registrations = mainSource.substr(server);
   return expect(
       multipartAuth > multipart && multipartAuth < multipartBegin && multipartBegin < multipartEnd &&
-          rawAuth > raw && rawAuth < rawBegin && rawBegin < rawEnd &&
+          cableAuth > cable && cableAuth < cableBegin && cableBegin < cableEnd &&
           registrations.find("webServer.on(\"/update\", HTTP_GET, handleUpdatePage)") != std::string::npos &&
           registrations.find("\"/update/firmware\"") != std::string::npos &&
           registrations.find("handleOtaUpload(U_FLASH, \"firmware\")") != std::string::npos &&
           registrations.find("\"/update/filesystem\"") != std::string::npos &&
           registrations.find("handleOtaUpload(U_FS, \"filesystem\")") != std::string::npos &&
-          registrations.find("raw_ota_server_started port=8081 path=/update/firmware.raw") != std::string::npos &&
+          mainSource.find("raw_ota_server_started") == std::string::npos &&
+          mainSource.find("handleRawOtaClient") == std::string::npos &&
           page.find("deviceAuthToken") == std::string::npos &&
           page.find("tokenQuery") == std::string::npos &&
           page.find("Manual upload") == std::string::npos &&
@@ -1020,6 +1039,9 @@ int main(int argc, char** argv) {
     return 1;
   }
   if (!testNetworkWorkPrecedesWifiRecovery(argv[3])) {
+    return 1;
+  }
+  if (!testCableTransferOwnsSerialParserUntilCompletion(argv[3])) {
     return 1;
   }
   if (!testWifiRecoveryFirmwareWiring(argv[3])) {

--- a/protocol/PROTOCOL.md
+++ b/protocol/PROTOCOL.md
@@ -38,6 +38,35 @@ the frame parser.
 - `set-connection-mode` and `confirm-connection-mode` start and confirm the
   bounded mode transactions defined in the hardware contract.
 
+### Cable bulk transfer v1
+
+Assets, stored ThemeSpecs, screensavers and firmware use one stop-and-wait
+transfer on the same newline-delimited control stream. Only one transfer and
+one 128-byte candidate chunk may be in flight. The final chunk may be shorter.
+The exact production chunk size remains gated on the direct-Mac and dock-path
+hardware measurements required by #302.
+
+1. `transfer-start` carries the expected `deviceId`, pairing `token`, sink
+   (`asset` or `firmware`), byte count, whole-payload MD5 hash and, for assets,
+   the destination path plus optional `activate` value (`theme` or
+   `screensaver`). The device answers `status:"ready",next:0` only after the
+   inactive sink is open.
+2. Each `transfer-chunk` carries its zero-based `seq`, lowercase hex payload
+   and the first eight hex characters of that chunk's MD5. The device validates
+   the checksum before writing, then answers `status:"chunk",next:N` only after
+   the sink write returns. A duplicate of the last acknowledged sequence and
+   checksum is acknowledged without a second write.
+3. `transfer-finish` succeeds only when the byte count and complete MD5 match.
+   Assets are atomically promoted before optional activation; firmware calls
+   `Update.end()` only after the match. `transfer-abort`, a write error or the
+   15-second inactivity bound discards the temporary asset or ends the inactive
+   firmware update without changing the bootable image.
+
+Transfer JSON is consumed before the normal frame parser. Firmware never logs
+the pairing token or payload bytes, and transfer replies are JSON objects with
+`kind:"transfer"`; ordinary debug lines remain non-JSON and are ignored by the
+Mac transfer reader.
+
 ## Host -> Device Frame
 
 Usage frame (v1 or v2, negotiated):
@@ -242,7 +271,9 @@ Standby behavior:
 Pairing/auth:
 - Firmware `1.0.39` accepts every local-WiFi `/api/pair` request and immediately replaces the previous token. It has no physical pairing gesture or pairing window.
 - Firmware `1.0.38` remains compatible with its legacy first-pair and three-power-cycle 30-minute recovery window.
-- Protected write APIs require `X-VibeTV-Token: <token>` or the documented query fallback used by native tooling and raw OTA.
+- Protected WiFi write APIs require `X-VibeTV-Token: <token>`. The legacy RAW
+  compatibility sender is not a current WiFi API fallback; see
+  `docs/firmware-ota-contract.md`.
 - Protected write APIs include `POST /frame`, `POST /api/settings`, WiFi credential writes, `POST /assets`, `DELETE /assets`, `POST /theme/active`, `POST /screensaver/active`, and firmware/filesystem OTA upload paths. OTA upload always requires a configured device and its current token.
 - Read APIs such as `GET /hello`, `GET /health`, and `GET /assets` stay open for diagnostics.
 - The unauthenticated device page never renders the pairing token. Firmware `1.0.39` WiFi `/hello` reports `capabilities.auth.paired` and `tokenHeader`; legacy firmware may additionally report pairing-window fields. No firmware reports the token value.

--- a/scripts/check-gif-core-policy-tests.sh
+++ b/scripts/check-gif-core-policy-tests.sh
@@ -10,6 +10,8 @@ PROFILE_SRC="${ROOT_DIR}/firmware_esp8266/tests/animated_gif_profile_test.cpp"
 PROFILE_OUT="${ROOT_DIR}/tmp/animated_gif_profile_test"
 PARITY_SRC="${ROOT_DIR}/firmware_esp8266/tests/animated_gif_parity_test.cpp"
 PARITY_OUT="${ROOT_DIR}/tmp/animated_gif_parity_test"
+TRANSFER_SRC="${ROOT_DIR}/firmware_esp8266/tests/cable_transfer_core_test.cpp"
+TRANSFER_OUT="${ROOT_DIR}/tmp/cable_transfer_core_test"
 CXX_BIN="${CXX:-c++}"
 
 bundled_theme=""
@@ -30,6 +32,9 @@ mkdir -p "${ROOT_DIR}/tmp"
   "${ROOT_DIR}/firmware_esp8266/src/renderer_esp8266.cpp" \
   "${ROOT_DIR}/firmware_esp8266/platformio.ini" \
   "${ROOT_DIR}/firmware_shared/theme_spec_renderer_core.h"
+
+"${CXX_BIN}" -std=c++17 -Wall -Wextra -pedantic "${TRANSFER_SRC}" -o "${TRANSFER_OUT}"
+"${TRANSFER_OUT}"
 
 "${CXX_BIN}" -std=c++17 -Wall -Wextra -pedantic \
   "${VALIDATOR_SRC}" \

--- a/scripts/test-vibetv-hosted-gates.sh
+++ b/scripts/test-vibetv-hosted-gates.sh
@@ -420,8 +420,8 @@ main() {
     'the runtime must own the paired device before the API firmware update starts'
   assert_contains "$GUEST_TEST" 'api_firmware_update "$OUTPUT/candidate-already-current.json" already_current' \
     'public guest states must prove already_current through the runtime API as well'
-  assert_contains "$GUEST_TEST" 'if expected_uploads and not any(event.get("path") == "/update/firmware.raw"' \
-    'the Raw OTA assertion must be conditional: a candidate whose firmware matches the baseline uploads nothing, and demanding a Raw OTA regardless fails every release that ships no new firmware'
+  assert_contains "$GUEST_TEST" 'if expected_uploads and not any(event.get("path") == "/update/firmware"' \
+    'the multipart OTA assertion must be conditional: a candidate whose firmware matches the baseline uploads nothing, and demanding an upload regardless fails every release that ships no new firmware'
   assert_contains "$GUEST_TEST" 'expected_uploads = int(sys.argv[2])' \
     'guest test must read the expected upload count once and reuse it for both state assertions'
   assert_contains "$GUEST_TEST" 'listenerOwner' \

--- a/scripts/test-vibetv-hosted-guest.sh
+++ b/scripts/test-vibetv-hosted-guest.sh
@@ -312,12 +312,12 @@ import json, sys
 state = json.load(open(sys.argv[1], encoding="utf-8"))
 expected_uploads = int(sys.argv[2])
 if state.get("updateUploads") != expected_uploads or state.get("violations") or state.get("framesAccepted", 0) < 1:
-    raise SystemExit("candidate companion did not complete raw OTA/render/no-op sequence")
+    raise SystemExit("candidate companion did not complete multipart OTA/render/no-op sequence")
 # A candidate whose firmware matches the baseline uploads nothing -- the outcome
-# asserted above is already_current -- so there is no Raw OTA to find. Demanding
+# asserted above is already_current -- so there is no multipart OTA to find. Demanding
 # one regardless fails every release that ships no new firmware.
-if expected_uploads and not any(event.get("path") == "/update/firmware.raw" for event in state.get("events", [])):
-    raise SystemExit("candidate companion did not use Raw OTA port 8081")
+if expected_uploads and not any(event.get("path") == "/update/firmware" for event in state.get("events", [])):
+    raise SystemExit("candidate companion did not use multipart OTA")
 PY
 
 if [[ "$STATE" == clean_os ]]; then
@@ -327,5 +327,5 @@ fi
 screencapture -x "$OUTPUT/guest-${STATE}.png"
 python3 - "$OUTPUT/result.json" "$STATE" "$VERSION" <<'PY'
 import json, sys
-json.dump({"schemaVersion": 1, "state": sys.argv[2], "version": sys.argv[3], "status": "passed", "checks": ["signed-dmg", "installed-baseline-to-sparkle-update", "candidate-companion-raw-ota-rediscovery-no-op", "candidate-daemon-render", "installed-runtime-port-47832"]}, open(sys.argv[1], "w", encoding="utf-8"), indent=2)
+json.dump({"schemaVersion": 1, "state": sys.argv[2], "version": sys.argv[3], "status": "passed", "checks": ["signed-dmg", "installed-baseline-to-sparkle-update", "candidate-companion-multipart-ota-rediscovery-no-op", "candidate-daemon-render", "installed-runtime-port-47832"]}, open(sys.argv[1], "w", encoding="utf-8"), indent=2)
 PY


### PR DESCRIPTION
## Summary

- add one paired, stop-and-wait Cable transfer protocol for theme assets, ThemeSpecs, screensavers, and firmware
- validate every 128-byte candidate chunk before writing and validate the complete MD5 before activation or firmware commit
- add explicit start, finish, abort, timeout, context cancellation, duplicate-ACK handling, and clean reconnect behavior
- route Cable theme and firmware installs through the existing customer flows without WiFi device calls
- report interrupted Cable firmware updates with a manual `Try again` action after the customer reconnects the data Cable
- remove the duplicate RAW OTA receiver from current firmware while retaining the Mac sender only for the installed 1.0.36 compatibility bridge

## Safety

- pairing token and exact device identity are required before a transfer starts
- assets stay temporary and firmware stays inactive until byte count and whole hash match
- firmware updates exclude other Cable control traffic and release the parent serial handle before the updater opens it
- no automatic firmware retry occurs after an interrupted Cable transfer
- no hardware was flashed by this PR

## Verification

- `./scripts/check-before-push.sh codex/issue-395-cable-customer-flow`
- all Go tests, `go vet`, and `staticcheck`
- 321 Control Center unit tests, customer browser flows, Theme Studio safety flow, TypeScript, production build, and UI approval gate
- ESP8266 policy/native/soak gates and release contracts
- ESP8266 build: RAM 46,832 bytes; flash 476,023 bytes; `firmware.bin` 480,176 / 482,000 bytes

## Remaining hardware gate

This is intentionally a draft and does not close #302. Direct-Mac and dock measurements are still required for the final chunk size, maximum theme and screensaver packs, firmware install/reboot/version proof, transfer timing, and unplug bootability.

Stacked on #409. Part of #302 and #390.